### PR TITLE
refactor(picohost)!: simplify PicoDevice lifecycle API

### DIFF
--- a/picohost/scripts/motor_control.py
+++ b/picohost/scripts/motor_control.py
@@ -75,18 +75,18 @@ def main():
         el_up_delay_us=2400,
         el_dn_delay_us=600,
     )
-    c.stop()
+    c.halt()
     # try:
     #    #c.el_move_deg(30, wait_for_stop=True)
     #    c.az_move_deg(100, wait_for_stop=True)
     ##    c.az_target_deg(180, wait_for_stop=True)
     ##    c.az_target_deg(-180, wait_for_stop=True)
     # except(KeyboardInterrupt):
-    #    c.stop()
+    #    c.halt()
     # finally:
-    #    c.stop()
+    #    c.halt()
     try:
-        c.stop()
+        c.halt()
         c.scan(
             az_range_deg=np.linspace(-180.0, 180.0, 10),
             el_range_deg=np.linspace(-180.0, 180.0, 10),
@@ -96,9 +96,9 @@ def main():
             sleep_between=args.sleep_s,
         )
     except KeyboardInterrupt:
-        c.stop()
+        c.halt()
     finally:
-        c.stop()
+        c.halt()
 
 
 if __name__ == "__main__":

--- a/picohost/scripts/motor_manual.py
+++ b/picohost/scripts/motor_manual.py
@@ -75,9 +75,9 @@ def main(screen):
     #    c.az_target_deg(180, wait_for_stop=True)
     #    c.az_target_deg(-180, wait_for_stop=True)
     except KeyboardInterrupt:
-        c.stop()
+        c.halt()
     finally:
-        c.stop()
+        c.halt()
 
 
 if __name__ == "__main__":

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -119,8 +119,6 @@ class PicoDevice:
         if response_handler is not None:
             self.set_response_handler(response_handler)
 
-        self.start()
-
     @staticmethod
     def find_pico_ports() -> list[str]:
         """
@@ -145,13 +143,8 @@ class PicoDevice:
         """
         return self.ser is not None and self.ser.is_open
 
-    def connect(self) -> bool:
-        """
-        Connect to the Pico device.
-
-        Returns:
-            True if connection successful, False otherwise
-        """
+    def _open_serial(self) -> bool:
+        """Open the serial port without starting the reader thread."""
         try:
             self.ser = Serial(self.port, self.baudrate, timeout=self.timeout)
             self.ser.reset_input_buffer()
@@ -161,9 +154,26 @@ class PicoDevice:
             self.logger.error(f"Failed to connect to {self.port}: {e}")
             return False
 
+    def _close_serial(self):
+        """Close the serial port if open."""
+        if self.ser is not None and self.ser.is_open:
+            self.ser.close()
+
+    def connect(self) -> bool:
+        """
+        Open the serial connection and start the background reader thread.
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        if not self._open_serial():
+            return False
+        self._start_reader()
+        return True
+
     def disconnect(self):
-        """Disconnect from the device and clean up resources."""
-        self.stop()
+        """Stop the reader thread, close the serial port, and clean up."""
+        self._stop_reader()
         self.ser = None
 
     def reconnect(self) -> bool:
@@ -186,7 +196,6 @@ class PicoDevice:
         if self.usb_serial:
             self._rediscover_port()
         if self.connect():
-            self.start()
             self.on_reconnect()
             return True
         return False
@@ -285,9 +294,10 @@ class PicoDevice:
         """Background thread function for reading serial data."""
         while self._running:
             if not self.is_connected:
-                # Try to reconnect
+                # Try to reopen the serial port (don't call connect() which
+                # would spawn a second reader thread).
                 self.logger.info(f"Attempting to reconnect to {self.port}...")
-                if self.connect():
+                if self._open_serial():
                     self.logger.info(f"Reconnected to {self.port}")
                 else:
                     time.sleep(self._RECONNECT_INTERVAL)
@@ -331,7 +341,7 @@ class PicoDevice:
         """
         self._raw_handler = handler
 
-    def start(self):
+    def _start_reader(self):
         """Start the background reader thread."""
         if not self._running:
             self._running = True
@@ -340,13 +350,12 @@ class PicoDevice:
             )
             self._reader_thread.start()
 
-    def stop(self):
-        """Stop the background reader thread."""
+    def _stop_reader(self):
+        """Stop the background reader thread and close the serial port."""
         self._running = False
         # Close the serial port first so that readline() unblocks
         # immediately, rather than waiting for the serial timeout.
-        if self.ser is not None and self.ser.is_open:
-            self.ser.close()
+        self._close_serial()
         if self._reader_thread:
             self._reader_thread.join(timeout=2.0)
             self._reader_thread = None
@@ -386,10 +395,10 @@ class PicoDevice:
 
     def __enter__(self):
         """Context manager entry."""
-        if self.connect():
-            self.start()
-            return self
-        raise RuntimeError(f"Failed to connect to {self.port}")
+        if not self.is_connected:
+            if not self.connect():
+                raise RuntimeError(f"Failed to connect to {self.port}")
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
@@ -557,13 +566,13 @@ class PicoPeltier(PicoDevice):
                     break
                 time.sleep(0.1)
 
-    def stop(self):
-        """Stop keepalive and reader threads."""
+    def disconnect(self):
+        """Stop keepalive thread, then reader thread and serial port."""
         self._keepalive_running = False
         if self._keepalive_thread:
             self._keepalive_thread.join(timeout=2.0)
             self._keepalive_thread = None
-        super().stop()
+        super().disconnect()
 
     @property
     def watchdog_tripped(self):

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -166,6 +166,8 @@ class PicoDevice:
         Returns:
             True if connection successful, False otherwise
         """
+        if self.is_connected:
+            return True
         if not self._open_serial():
             return False
         self._start_reader()
@@ -573,6 +575,10 @@ class PicoPeltier(PicoDevice):
             self._keepalive_thread.join(timeout=2.0)
             self._keepalive_thread = None
         super().disconnect()
+
+    def on_reconnect(self):
+        """Restart the keepalive thread after a reconnect."""
+        self._start_keepalive()
 
     @property
     def watchdog_tripped(self):

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -79,8 +79,6 @@ _BLOCKED_ACTIONS = frozenset(
         "connect",
         "disconnect",
         "reconnect",
-        "start",
-        "stop",
         "set_response_handler",
         "set_raw_handler",
         "wait_for_response",

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -125,7 +125,7 @@ class PicoMotor(PicoDevice):
         }
         self.motor_command(**self._delay_kwargs)
 
-    def stop(self, az=True, el=True):
+    def halt(self, az=True, el=True):
         """Hard stop on motors. Default: both."""
         cmd = {"halt": 0}
         self.motor_command(**cmd)
@@ -293,4 +293,4 @@ class PicoMotor(PicoDevice):
                         print(f"Sleeping for {sleep_between} s)")
                     time.sleep(sleep_between)
         finally:
-            self.stop()
+            self.halt()

--- a/picohost/src/picohost/testing.py
+++ b/picohost/src/picohost/testing.py
@@ -43,17 +43,14 @@ class DummyPicoDevice(PicoDevice):
             )
             self._emulator.attach(self._peer)
             self._emulator.start()
+        self._start_reader()
         return True
 
     def disconnect(self):
         if hasattr(self, "_emulator") and self._emulator:
             self._emulator.stop()
             self._emulator = None
-        # Stop the reader thread explicitly via PicoDevice.stop() to avoid
-        # PicoMotor.stop() (which sends a halt command instead of stopping
-        # the thread).
-        PicoDevice.stop(self)
-        self.ser = None
+        super().disconnect()
 
 
 class DummyPicoMotor(DummyPicoDevice, PicoMotor):
@@ -69,11 +66,6 @@ class DummyPicoRFSwitch(DummyPicoDevice, PicoRFSwitch):
 class DummyPicoPeltier(DummyPicoDevice, PicoPeltier):
     EMULATOR_CLASS = TempCtrlEmulator
     EMULATOR_CADENCE_MS = 50.0
-
-    def disconnect(self):
-        # PicoPeltier.stop() handles keepalive + reader thread cleanup
-        PicoPeltier.stop(self)
-        super().disconnect()
 
 
 class DummyPicoIMU(DummyPicoDevice, PicoIMU):

--- a/picohost/tests/test_dummy_devices.py
+++ b/picohost/tests/test_dummy_devices.py
@@ -143,7 +143,7 @@ class TestDummyPicoMotor:
             lambda: motor.status.get("az_target_pos") == 1000,
             cadence_ms=cadence,
         )
-        motor.stop()
+        motor.halt()
         wait_for_condition(
             lambda: (
                 motor.status.get("az_target_pos") == motor.status.get("az_pos")

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -709,7 +709,7 @@ class TestTimeoutError:
 
 
 def test_blocked_actions_includes_lifecycle():
-    for action in ("connect", "disconnect", "reconnect", "start", "stop"):
+    for action in ("connect", "disconnect", "reconnect"):
         assert action in _BLOCKED_ACTIONS
 
 

--- a/picohost/tests/test_streaming.py
+++ b/picohost/tests/test_streaming.py
@@ -54,7 +54,7 @@ class TestStreamingData:
     def test_read_line_returns_none_on_empty_buffer(self):
         """read_line() returns None when no data is available (timeout)."""
         device = DummyPicoDevice("/dev/dummy")
-        device.stop()
+        device._stop_reader()
         result = device.read_line()
         assert result is None
         device.disconnect()


### PR DESCRIPTION
## Summary

- Collapse `start()`/`stop()` into `connect()`/`disconnect()` by making them internal (`_start_reader`/`_stop_reader`). `connect()` now opens serial + starts reader; `disconnect()` tears down both.
- Rename `PicoMotor.stop()` to `halt()` — resolves the name collision where it shadowed `PicoDevice.stop()` with completely different semantics (halt motors vs stop reader thread).
- Simplify `testing.py`: remove the `PicoDevice.stop(self)` workaround in `DummyPicoDevice` and the `DummyPicoPeltier.disconnect()` override (MRO handles it).

Closes #38

**BREAKING CHANGE:** `PicoDevice.start()`/`stop()` removed from public API. `PicoMotor.stop()` renamed to `PicoMotor.halt()`.

## Test plan

- [x] All 263 tests pass (`pytest picohost/tests/`)
- [x] `ruff check` clean on all changed files
- [x] Verified no stray `.start()`/`.stop()` calls remain on PicoDevice instances
- [x] MRO for `DummyPicoPeltier` verified: keepalive thread stopped during disconnect via cooperative `super()` chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)