### PR TITLE
fix(picohost): PicoMotor bug fixes and scan homing workflow

### DIFF
--- a/picohost/scripts/motor_control.py
+++ b/picohost/scripts/motor_control.py
@@ -64,11 +64,6 @@ def main():
     except KeyError:
         last_status = None
     c = PicoMotor(port, verbose=True)
-    # zeroed = c.status['az_pos'] == 0 and c.status['el_pos'] == 0
-    # if zeroed and (last_status is not None):
-    #    print('Resetting to last known position.')
-    #    c.reset_step_position(az_step=last_status['az_pos'], el_step=last_status['el_pos'])
-    c.reset_step_position(az_step=0, el_step=0)
     c.set_delay(
         az_up_delay_us=2400,
         az_dn_delay_us=300,

--- a/picohost/scripts/motor_manual.py
+++ b/picohost/scripts/motor_manual.py
@@ -15,8 +15,11 @@ Controls:
 
 import json
 import curses
+import logging
 
 from picohost import PicoMotor
+
+logger = logging.getLogger(__name__)
 
 
 def main(screen):
@@ -106,10 +109,11 @@ def main(screen):
         c.halt()
 
     if zeroed:
-        print("Step counters zeroed. Motors are at home (0, 0).")
+        logger.info("Step counters zeroed. Motors are at home (0, 0).")
     else:
-        print("Exited without zeroing.")
+        logger.info("Exited without zeroing.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     curses.wrapper(main)

--- a/picohost/scripts/motor_manual.py
+++ b/picohost/scripts/motor_manual.py
@@ -1,21 +1,31 @@
 """
-Motor control script for PicoMotor
-Allows manual control of azimuth and elevation motors with degree inputs
-and an infinite scanning mode.
+Interactive motor zeroing script.
+
+Use arrow keys (u/d/l/r) to jog the motors into the desired home
+position, then press Enter to zero the step counters.  After zeroing,
+scan() will treat the current physical position as (0, 0).
+
+Controls:
+    u / d  -  jog elevation up / down
+    l / r  -  jog azimuth left / right
+    + / -  -  increase / decrease jog step size
+    Enter  -  zero step counters and exit
+    q      -  quit without zeroing
 """
 
 import json
+import curses
 
 from picohost import PicoMotor
 
 
 def main(screen):
-    curses.noecho()  # optional: wrapper sets cbreak but not noecho
-    screen.nodelay(False)  # blocking getch
+    curses.noecho()
+    screen.nodelay(False)
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Control PicoMotor azimuth and elevation"
+        description="Jog motors to home position and zero step counters"
     )
     parser.add_argument(
         "-c",
@@ -24,18 +34,24 @@ def main(screen):
         default="pico_config.json",
         help="Output of flash_picos (pico_config.json)",
     )
+    parser.add_argument(
+        "--deg",
+        type=float,
+        default=1.0,
+        help="Initial jog step size in degrees (default: 1.0)",
+    )
 
     args = parser.parse_args()
     port = None
     with open(args.pico_config, "r", encoding="utf-8") as f:
         records = json.load(f)
         for config in records:
-            if config["app_id"] == 0:  # must match pico_multi.h
+            if config["app_id"] == 0:
                 port = config["port"]
                 break
-    assert port is not None  # didn't find app_id 0 in pico_config.json
+    assert port is not None, "didn't find app_id 0 in pico_config.json"
 
-    c = PicoMotor(port, verbose=True)
+    c = PicoMotor(port, verbose=False)
     c.set_delay(
         az_up_delay_us=2400,
         az_dn_delay_us=300,
@@ -43,44 +59,57 @@ def main(screen):
         el_dn_delay_us=600,
     )
 
-    def move_up(deg):
-        c.el_move_deg(deg, wait_for_stop=True)
+    deg = args.deg
+    zeroed = False
 
-    def move_dn(deg):
-        c.el_move_deg(-deg, wait_for_stop=True)
+    def refresh_status():
+        screen.clear()
+        screen.addstr(0, 0, "=== Motor Zeroing ===")
+        screen.addstr(2, 0, f"Jog step: {deg:.1f} deg")
+        screen.addstr(3, 0, f"AZ pos: {c.status.get('az_pos', '?')}")
+        screen.addstr(4, 0, f"EL pos: {c.status.get('el_pos', '?')}")
+        screen.addstr(6, 0, "u/d = jog EL | l/r = jog AZ")
+        screen.addstr(7, 0, "+/- = change step size")
+        screen.addstr(8, 0, "Enter = zero and exit | q = quit")
+        screen.refresh()
 
-    def move_lf(deg):
-        c.az_move_deg(deg, wait_for_stop=True)
-
-    def move_rt(deg):
-        c.az_move_deg(-deg, wait_for_stop=True)
-
-    DISPATCH = {
-        "u": move_up,
-        "d": move_dn,
-        "l": move_lf,
-        "r": move_rt,
-    }
     try:
-        deg = 1
         while True:
+            refresh_status()
             ch = screen.getch()
             if ch == -1:
                 continue
+            if ch == ord("\n"):
+                c.halt()
+                c.reset_step_position(az_step=0, el_step=0)
+                zeroed = True
+                break
             if 0 <= ch < 256:
                 key = chr(ch).lower()
-                if key in DISPATCH:
-                    DISPATCH[key](deg)
-        # c.el_move_deg(-10, wait_for_stop=True)
-    #    c.az_target_deg(180, wait_for_stop=True)
-    #    c.az_target_deg(-180, wait_for_stop=True)
+                if key == "q":
+                    break
+                elif key == "u":
+                    c.el_move_deg(deg, wait_for_stop=True)
+                elif key == "d":
+                    c.el_move_deg(-deg, wait_for_stop=True)
+                elif key == "l":
+                    c.az_move_deg(deg, wait_for_stop=True)
+                elif key == "r":
+                    c.az_move_deg(-deg, wait_for_stop=True)
+                elif key == "+":
+                    deg += 1
+                elif key == "-":
+                    deg = max(0.1, deg - 1)
     except KeyboardInterrupt:
-        c.halt()
+        pass
     finally:
         c.halt()
 
+    if zeroed:
+        print("Step counters zeroed. Motors are at home (0, 0).")
+    else:
+        print("Exited without zeroing.")
+
 
 if __name__ == "__main__":
-    import curses
-
     curses.wrapper(main)

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -80,7 +80,7 @@ class PicoMotor(PicoDevice):
         return int(s * self.microstep * self.gear_teeth)
 
     def steps_to_deg(self, steps: int) -> float:
-        """Convert degrees to motor pulses."""
+        """Convert motor pulses to degrees."""
         s = steps / self.microstep / self.gear_teeth
         deg = s * self.step_angle_deg
         return float(deg)
@@ -108,7 +108,7 @@ class PicoMotor(PicoDevice):
         """Set az and el position to specified count."""
         az_pos = None if az_deg is None else self.deg_to_steps(az_deg)
         el_pos = None if el_deg is None else self.deg_to_steps(el_deg)
-        self.reset_step_position(az_pos=az_pos, el_pos=el_pos)
+        self.reset_step_position(az_step=az_pos, el_step=el_pos)
 
     def set_delay(
         self,
@@ -125,10 +125,9 @@ class PicoMotor(PicoDevice):
         }
         self.motor_command(**self._delay_kwargs)
 
-    def halt(self, az=True, el=True):
-        """Hard stop on motors. Default: both."""
-        cmd = {"halt": 0}
-        self.motor_command(**cmd)
+    def halt(self):
+        """Hard stop on both motors."""
+        self.motor_command(halt=0)
 
     def _do_wait(self, wait_for_start, wait_for_stop):
         if wait_for_start:
@@ -219,10 +218,20 @@ class PicoMotor(PicoDevice):
         while not self.is_moving() and time.time() < t + timeout:
             time.sleep(0.1)
 
-    def wait_for_stop(self):
+    def wait_for_stop(self, stall_timeout=30):
         if self.verbose:
             print("Waiting for stop.")
+        last_pos = (self.status["az_pos"], self.status["el_pos"])
+        t = time.time()
         while self.is_moving():
+            pos = (self.status["az_pos"], self.status["el_pos"])
+            if pos != last_pos:
+                last_pos = pos
+                t = time.time()
+            elif time.time() - t >= stall_timeout:
+                raise TimeoutError(
+                    f"Motor stalled for {stall_timeout}s without progress"
+                )
             time.sleep(0.1)
 
     def scan(
@@ -294,3 +303,7 @@ class PicoMotor(PicoDevice):
                     time.sleep(sleep_between)
         finally:
             self.halt()
+
+        # home motors one at a time after normal completion
+        self.az_target_steps(0, wait_for_stop=True)
+        self.el_target_steps(0, wait_for_stop=True)

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -241,26 +241,29 @@ class PicoMotor(PicoDevice):
         el_first=False,
         repeat_count=None,
         pause_s=None,
-        reset_pos=False,
         sleep_between=None,
     ):
         """
         Perform beam scanning strategy.
 
+        Homes motors to (0, 0) before starting and after normal
+        completion.  Use ``reset_step_position`` beforehand to define
+        where home is.
+
         Parameters
         ---------
-        az_range : array_like
-        el_range : array_like
+        az_range_deg : array_like
+        el_range_deg : array_like
         el_first : bool
         repeat_count : int
         pause_s : float
             Pause time at each position.
-        reset_pos : bool
         sleep_between : float
             Sleep between every scan (if `repeat_count` is not None).
         """
-        if reset_pos:
-            self.reset_deg_position(az_deg=0.0, el_deg=0.0)
+        # home before scanning
+        self.az_target_steps(0, wait_for_stop=True)
+        self.el_target_steps(0, wait_for_stop=True)
         # set order of scanning
         if el_first:
             mv_axis1, mv_axis2 = self.az_target_deg, self.el_target_deg

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -4,9 +4,12 @@ Provides common functionality for serial communication with Pico devices.
 """
 
 import json
+import logging
 import time
 import numpy as np
 from .base import PicoDevice
+
+logger = logging.getLogger(__name__)
 
 
 class PicoMotor(PicoDevice):
@@ -60,7 +63,7 @@ class PicoMotor(PicoDevice):
     def update_status(self, data):
         """Update internal status based on unpacked json packets from picos."""
         if self.verbose:
-            print(json.dumps(data, indent=2, sort_keys=True))
+            logger.debug(json.dumps(data, indent=2, sort_keys=True))
         self.status.update(data)
 
     def wait_for_updates(self, timeout=10):
@@ -220,7 +223,7 @@ class PicoMotor(PicoDevice):
 
     def wait_for_stop(self, stall_timeout=30):
         if self.verbose:
-            print("Waiting for stop.")
+            logger.debug("Waiting for stop.")
         last_pos = (self.status["az_pos"], self.status["el_pos"])
         t = time.time()
         while self.is_moving():
@@ -279,14 +282,13 @@ class PicoMotor(PicoDevice):
                     break
                 for val1 in axis1_rng:
                     if self.verbose:
-                        print("MOVE AXIS 1 TO", val1)
+                        logger.info("MOVE AXIS 1 TO %s", val1)
                     mv_axis1(val1, wait_for_stop=True)
                     if pause_s is None:
                         if self.verbose:
-                            print(
-                                "MOVE AXIS 2 FROM",
+                            logger.info(
+                                "MOVE AXIS 2 FROM %s TO %s",
                                 axis2_rng[0],
-                                "TO",
                                 axis2_rng[-1],
                             )
                         # continuous motion
@@ -302,7 +304,7 @@ class PicoMotor(PicoDevice):
                 i += 1
                 if sleep_between is not None:
                     if self.verbose:
-                        print(f"Sleeping for {sleep_between} s)")
+                        logger.info("Sleeping for %s s", sleep_between)
                     time.sleep(sleep_between)
         finally:
             self.halt()

--- a/picohost/tests/test_dummy_devices.py
+++ b/picohost/tests/test_dummy_devices.py
@@ -188,35 +188,25 @@ class TestDummyPicoMotor:
     def test_scan_does_not_home_on_interrupt(self):
         """scan() only halts (does not home) when interrupted."""
         motor = DummyPicoMotor(port="/dev/ttyUSB0")
-        cadence = motor.EMULATOR_CADENCE_MS
-        # move to a known non-zero position first
-        motor.az_target_steps(1000, wait_for_stop=True)
-        wait_for_settle(
-            lambda: motor.status.get("az_pos"),
-            cadence_ms=cadence,
-            max_cycles=200,
-        )
-        # scan with infinite repeat; we'll interrupt it
+        # patch wait_for_stop to raise after the initial homing
+        # (2 calls for home-az + home-el, then interrupt during scan)
+        real_wait = motor.wait_for_stop
+        call_count = 0
+
+        def interrupt_after_homing(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            real_wait(*a, **kw)
+            if call_count > 2:
+                raise KeyboardInterrupt
+
+        motor.wait_for_stop = interrupt_after_homing
         with pytest.raises(KeyboardInterrupt):
-            # patch wait_for_stop to raise on second call
-            real_wait = motor.wait_for_stop
-            call_count = 0
-
-            def interrupt_on_second(*a, **kw):
-                nonlocal call_count
-                call_count += 1
-                real_wait(*a, **kw)
-                if call_count >= 2:
-                    raise KeyboardInterrupt
-
-            motor.wait_for_stop = interrupt_on_second
             motor.scan(
                 az_range_deg=np.array([-10.0, 0.0, 10.0]),
                 el_range_deg=np.array([-10.0, 0.0, 10.0]),
             )
-        # halt was called, but motors should NOT have homed to 0
-        # (az was at 1000 before scan, so it moved during scan but
-        # the key point is homing did not run)
+        # halt was called, but post-scan homing did not run
         assert motor.status["az_target_pos"] == motor.status["az_pos"]
         assert motor.status["el_target_pos"] == motor.status["el_pos"]
         motor.disconnect()

--- a/picohost/tests/test_dummy_devices.py
+++ b/picohost/tests/test_dummy_devices.py
@@ -7,6 +7,7 @@ lifecycle, command dispatch, status propagation, and MockSerial integration.
 """
 
 import json
+import numpy as np
 import pytest
 import mockserial
 
@@ -160,6 +161,64 @@ class TestDummyPicoMotor:
         assert "el_pos" in motor.status
         assert "az_target_pos" in motor.status
         assert "el_target_pos" in motor.status
+        motor.disconnect()
+
+    def test_scan_homes_after_normal_completion(self):
+        """scan() returns motors to (0, 0) one at a time after finishing."""
+        motor = DummyPicoMotor(port="/dev/ttyUSB0")
+        cadence = motor.EMULATOR_CADENCE_MS
+        motor.scan(
+            az_range_deg=np.array([-10.0, 0.0, 10.0]),
+            el_range_deg=np.array([-10.0, 0.0, 10.0]),
+            repeat_count=1,
+        )
+        # after scan completes, motors should be back at 0
+        wait_for_condition(
+            lambda: (
+                motor.status.get("az_pos") == 0
+                and motor.status.get("el_pos") == 0
+            ),
+            cadence_ms=cadence,
+            max_cycles=10,
+        )
+        assert motor.status["az_pos"] == 0
+        assert motor.status["el_pos"] == 0
+        motor.disconnect()
+
+    def test_scan_does_not_home_on_interrupt(self):
+        """scan() only halts (does not home) when interrupted."""
+        motor = DummyPicoMotor(port="/dev/ttyUSB0")
+        cadence = motor.EMULATOR_CADENCE_MS
+        # move to a known non-zero position first
+        motor.az_target_steps(1000, wait_for_stop=True)
+        wait_for_settle(
+            lambda: motor.status.get("az_pos"),
+            cadence_ms=cadence,
+            max_cycles=200,
+        )
+        # scan with infinite repeat; we'll interrupt it
+        with pytest.raises(KeyboardInterrupt):
+            # patch wait_for_stop to raise on second call
+            real_wait = motor.wait_for_stop
+            call_count = 0
+
+            def interrupt_on_second(*a, **kw):
+                nonlocal call_count
+                call_count += 1
+                real_wait(*a, **kw)
+                if call_count >= 2:
+                    raise KeyboardInterrupt
+
+            motor.wait_for_stop = interrupt_on_second
+            motor.scan(
+                az_range_deg=np.array([-10.0, 0.0, 10.0]),
+                el_range_deg=np.array([-10.0, 0.0, 10.0]),
+            )
+        # halt was called, but motors should NOT have homed to 0
+        # (az was at 1000 before scan, so it moved during scan but
+        # the key point is homing did not run)
+        assert motor.status["az_target_pos"] == motor.status["az_pos"]
+        assert motor.status["el_target_pos"] == motor.status["el_pos"]
         motor.disconnect()
 
 


### PR DESCRIPTION
## Summary

- **Fix `reset_deg_position()`** — was passing wrong kwarg names (`az_pos`/`el_pos` instead of `az_step`/`el_step`), causing `TypeError` on every call
- **Fix `halt()` signature** — remove unused `az`/`el` parameters; firmware always halts both motors
- **Add stall timeout to `wait_for_stop()`** — raises `TimeoutError` if motor position stops changing for 30s, preventing infinite blocking
- **`scan()` now homes motors** — physically moves to (0, 0) one motor at a time before scanning and after normal completion; on interrupt, only halts (no homing)
- **Remove `reset_pos` parameter from `scan()`** — zeroing is the operator's responsibility via the zeroing script
- **Rework `motor_manual.py`** into an interactive zeroing script: jog with u/d/l/r, adjust step with +/-, Enter to zero counters and exit
- **Fix `steps_to_deg` docstring** — was copy-pasted from `deg_to_steps`

## Workflow

1. Operator runs `motor_manual.py` to jog motors into desired home position, presses Enter to zero step counters
2. `scan()` homes → scans → homes. Interrupted scans can be restarted with a new `scan()` call

## Test plan

- [x] All 265 tests pass (263 existing + 2 new)
- [x] `test_scan_homes_after_normal_completion` — verifies motors return to (0, 0)
- [x] `test_scan_does_not_home_on_interrupt` — verifies interrupted scan only halts

🤖 Generated with [Claude Code](https://claude.com/claude-code)