### PR TITLE
feat(picohost): add PicoProxy for Redis-mediated device control

### DIFF
--- a/picohost/src/picohost/__init__.py
+++ b/picohost/src/picohost/__init__.py
@@ -16,6 +16,7 @@ from .base import (
 )
 from .motor import PicoMotor
 from .manager import PicoManager
+from .proxy import PicoProxy, RFSwitchProxy
 from . import testing
 from . import emulators
 
@@ -28,6 +29,8 @@ __all__ = [
     "PicoLidar",
     "PicoPotentiometer",
     "PicoManager",
+    "PicoProxy",
+    "RFSwitchProxy",
     "testing",
     "emulators",
 ]

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -469,7 +469,7 @@ class PicoManager:
             return
 
         if target == "manager":
-            self._handle_manager_cmd(r, source, cmd)
+            self._handle_manager_cmd(r, source, cmd, request_id)
             return
 
         pico = self.picos.get(target)
@@ -564,10 +564,10 @@ class PicoManager:
         result = method(**cmd)
         return {"action": action, "result": result}
 
-    def _handle_manager_cmd(self, r, source, cmd):
+    def _handle_manager_cmd(self, r, source, cmd, request_id=""):
         """Handle commands targeted at the manager itself."""
         action = cmd.get("action", "")
-        resp = {"target": "manager", "source": source}
+        resp = {"target": "manager", "source": source, "request_id": request_id}
 
         if action == "rediscover":
             self.logger.info(f"Rediscover requested by {source}")

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -442,35 +442,30 @@ class PicoManager:
         f = {self._decode(k): self._decode(v) for k, v in fields.items()}
         target = f.get("target", "")
         source = f.get("source", "unknown")
+        request_id = f.get("request_id", "")
         cmd_raw = f.get("cmd", "{}")
+
+        def _err(error_msg):
+            r.xadd(
+                RESP_STREAM,
+                {
+                    "target": target,
+                    "source": source,
+                    "request_id": request_id,
+                    "status": "error",
+                    "data": json.dumps({"error": error_msg}),
+                },
+            )
 
         try:
             cmd = json.loads(cmd_raw)
         except json.JSONDecodeError:
             self.logger.error(f"Invalid JSON in command: {cmd_raw}")
-            r.xadd(
-                RESP_STREAM,
-                {
-                    "target": target,
-                    "source": source,
-                    "status": "error",
-                    "data": json.dumps({"error": "invalid JSON"}),
-                },
-            )
+            _err("invalid JSON")
             return
         if not isinstance(cmd, dict):
             self.logger.error(f"Command must be a JSON object: {cmd_raw}")
-            r.xadd(
-                RESP_STREAM,
-                {
-                    "target": target,
-                    "source": source,
-                    "status": "error",
-                    "data": json.dumps(
-                        {"error": "command must be a JSON object"}
-                    ),
-                },
-            )
+            _err("command must be a JSON object")
             return
 
         if target == "manager":
@@ -480,20 +475,16 @@ class PicoManager:
         pico = self.picos.get(target)
         if pico is None:
             self.logger.error(f"Unknown target: {target}")
-            r.xadd(
-                RESP_STREAM,
-                {
-                    "target": target,
-                    "source": source,
-                    "status": "error",
-                    "data": json.dumps({"error": f"unknown target: {target}"}),
-                },
-            )
+            _err(f"unknown target: {target}")
             return
 
         # Soft claims: warn (but allow) when a non-owner sends a command
         # to a claimed device. Claims are advisory, not enforced.
-        resp = {"target": target, "source": source}
+        resp = {
+            "target": target,
+            "source": source,
+            "request_id": request_id,
+        }
         claim_key = f"pico_claim:{target}"
         current_owner = r.get(claim_key)
         if current_owner is not None:
@@ -511,15 +502,7 @@ class PicoManager:
             try:
                 ttl = int(ttl)
             except (ValueError, TypeError):
-                r.xadd(
-                    RESP_STREAM,
-                    {
-                        "target": target,
-                        "source": source,
-                        "status": "error",
-                        "data": json.dumps({"error": f"invalid ttl: {ttl!r}"}),
-                    },
-                )
+                _err(f"invalid ttl: {ttl!r}")
                 return
             r.set(claim_key, source, ex=ttl)
             resp.update(

--- a/picohost/src/picohost/proxy.py
+++ b/picohost/src/picohost/proxy.py
@@ -18,6 +18,7 @@ Usage::
 
 import json
 import logging
+import time
 import uuid
 
 from .base import PicoRFSwitch
@@ -97,6 +98,13 @@ class PicoProxy:
             return None
 
         request_id = str(uuid.uuid4())
+        # Capture current stream end so we don't miss fast responses.
+        try:
+            info = self.redis.xinfo_stream(RESP_STREAM)
+            last_id = info["last-generated-id"]
+        except Exception:
+            # Stream doesn't exist yet — read from the beginning.
+            last_id = "0-0"
         cmd = {"action": action, **kwargs}
         self.redis.xadd(
             CMD_STREAM,
@@ -107,18 +115,22 @@ class PicoProxy:
                 "cmd": json.dumps(cmd),
             },
         )
-        return self._wait_response(request_id)
+        return self._wait_response(request_id, last_id)
 
-    def _wait_response(self, request_id):
+    def _wait_response(self, request_id, last_id):
         """
         Poll ``stream:pico_resp`` for a response matching *request_id*.
         """
-        # Read only new messages from the response stream.
-        last_id = "$"
-        timeout_ms = int(self.timeout * 1000)
+        deadline = time.monotonic() + self.timeout
         while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"No response for {self.name} within {self.timeout}s"
+                )
+            block_ms = int(remaining * 1000)
             result = self.redis.xread(
-                {RESP_STREAM: last_id}, block=timeout_ms, count=10
+                {RESP_STREAM: last_id}, block=block_ms, count=10
             )
             if not result:
                 raise TimeoutError(

--- a/picohost/src/picohost/proxy.py
+++ b/picohost/src/picohost/proxy.py
@@ -1,0 +1,196 @@
+"""
+Redis-backed proxies for pico devices managed by PicoManager.
+
+A proxy has the same command interface as the real device class but
+routes calls through Redis instead of serial. Construction always
+succeeds — no hardware check. At command time the proxy checks
+whether PicoManager has the device registered; if not, the command
+is a no-op that returns ``None``.
+
+Usage::
+
+    from picohost.proxy import RFSwitchProxy
+
+    sw = RFSwitchProxy("rfswitch", redis_client)
+    sw.switch("RFANT")       # routed via PicoManager
+    sw.is_available           # True if PicoManager has registered it
+"""
+
+import json
+import logging
+import uuid
+
+from .base import PicoRFSwitch
+from .manager import CMD_STREAM, HEALTH_HASH, PICOS_SET, RESP_STREAM
+
+logger = logging.getLogger(__name__)
+
+
+class PicoProxy:
+    """
+    Redis-backed proxy for a pico device managed by PicoManager.
+
+    Parameters
+    ----------
+    name : str
+        Device name as registered by PicoManager (e.g. ``"rfswitch"``).
+    redis : redis.Redis
+        The underlying Redis client (not an ``EigsepRedis`` wrapper).
+    source : str
+        Identifier included in command stream entries for logging and
+        soft-claim tracking.
+    timeout : float
+        Default seconds to wait for a command response.
+    """
+
+    def __init__(self, name, redis, source="client", timeout=5.0):
+        self.name = name
+        self.redis = redis
+        self.source = source
+        self.timeout = timeout
+        self.logger = logger
+
+    @property
+    def is_available(self):
+        """True if PicoManager has registered this device."""
+        return self.redis.sismember(PICOS_SET, self.name)
+
+    @property
+    def health(self):
+        """Device health dict from PicoManager, or None."""
+        raw = self.redis.hget(HEALTH_HASH, self.name)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    def send_command(self, action, **kwargs):
+        """
+        Send a command to PicoManager and wait for the response.
+
+        If the device is not available, logs a warning and returns
+        ``None`` (no-op).
+
+        Parameters
+        ----------
+        action : str
+            Method name to invoke on the device (e.g. ``"switch"``).
+        **kwargs
+            Arguments forwarded to the device method.
+
+        Returns
+        -------
+        dict or None
+            Parsed response data, or ``None`` if the device is
+            unavailable.
+
+        Raises
+        ------
+        TimeoutError
+            If no response arrives within ``self.timeout`` seconds.
+        RuntimeError
+            If PicoManager returns an error status.
+        """
+        if not self.is_available:
+            self.logger.warning(
+                f"{self.name} not available, skipping command"
+            )
+            return None
+
+        request_id = str(uuid.uuid4())
+        cmd = {"action": action, **kwargs}
+        self.redis.xadd(
+            CMD_STREAM,
+            {
+                "target": self.name,
+                "source": self.source,
+                "request_id": request_id,
+                "cmd": json.dumps(cmd),
+            },
+        )
+        return self._wait_response(request_id)
+
+    def _wait_response(self, request_id):
+        """
+        Poll ``stream:pico_resp`` for a response matching *request_id*.
+        """
+        # Read only new messages from the response stream.
+        last_id = "$"
+        timeout_ms = int(self.timeout * 1000)
+        while True:
+            result = self.redis.xread(
+                {RESP_STREAM: last_id}, block=timeout_ms, count=10
+            )
+            if not result:
+                raise TimeoutError(
+                    f"No response for {self.name} within {self.timeout}s"
+                )
+            for _stream, messages in result:
+                for msg_id, fields in messages:
+                    last_id = msg_id
+                    rid = fields.get(b"request_id") or fields.get(
+                        "request_id"
+                    )
+                    if isinstance(rid, bytes):
+                        rid = rid.decode()
+                    if rid != request_id:
+                        continue
+                    # Found our response
+                    status = fields.get(b"status") or fields.get(
+                        "status"
+                    )
+                    if isinstance(status, bytes):
+                        status = status.decode()
+                    data_raw = fields.get(b"data") or fields.get(
+                        "data", b"{}"
+                    )
+                    if isinstance(data_raw, bytes):
+                        data_raw = data_raw.decode()
+                    data = json.loads(data_raw)
+                    if status == "error":
+                        raise RuntimeError(
+                            f"Command failed on {self.name}: "
+                            f"{data.get('error', data)}"
+                        )
+                    return data
+
+
+class RFSwitchProxy(PicoProxy):
+    """
+    Redis-backed proxy for an RF switch managed by PicoManager.
+
+    Drop-in replacement for :class:`PicoRFSwitch` — exposes the same
+    ``.switch()`` method and ``.path_str`` / ``.paths`` attributes so
+    that ``cmt_vna.VNA`` can use it without modification.
+    """
+
+    path_str = PicoRFSwitch.path_str
+
+    @staticmethod
+    def rbin(s):
+        return int(s[::-1], 2)
+
+    @property
+    def paths(self):
+        return {k: self.rbin(v) for k, v in self.path_str.items()}
+
+    def switch(self, state: str) -> bool:
+        """
+        Set RF switch state via PicoManager.
+
+        Returns ``True`` on success, ``False`` if the device is
+        unavailable (no-op).
+
+        Raises
+        ------
+        ValueError
+            If *state* is not a valid switch path.
+        """
+        if state not in self.path_str:
+            raise ValueError(
+                f"Invalid switch state '{state}'. "
+                f"Valid states: {list(self.path_str.keys())}"
+            )
+        result = self.send_command("switch", state=state)
+        if result is None:
+            return False
+        return True

--- a/picohost/tests/test_proxy.py
+++ b/picohost/tests/test_proxy.py
@@ -110,6 +110,13 @@ class MockRedis:
             self._cv.notify_all()
             return msg_id
 
+    def xinfo_stream(self, stream):
+        with self._cv:
+            msgs = self._streams.get(stream, [])
+            if not msgs:
+                raise Exception(f"no such key: {stream}")
+            return {"last-generated-id": msgs[-1][0]}
+
     def xread(self, streams, block=None, count=None):
         timeout_s = (block / 1000.0) if block else 0
         deadline = time.time() + timeout_s if block else 0

--- a/picohost/tests/test_proxy.py
+++ b/picohost/tests/test_proxy.py
@@ -1,0 +1,283 @@
+"""
+Tests for picohost.proxy — Redis-backed device proxies.
+
+Uses an in-test MockRedis with thread-safe stream support so that
+PicoManager's cmd_loop thread can process commands in the background
+while the proxy reads responses in the foreground.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+from picohost.manager import (
+    PICOS_SET,
+    RESP_STREAM,
+    PicoManager,
+)
+from picohost.proxy import PicoProxy, RFSwitchProxy
+from picohost.testing import DummyPicoRFSwitch
+
+
+class MockRedis:
+    """
+    Thread-safe MockRedis with blocking ``xread`` support.
+
+    Messages use integer-prefixed IDs (``"0-0"``, ``"1-0"``, ...)
+    so that ``cmd_loop`` and the proxy can interleave reads.
+    """
+
+    def __init__(self):
+        self._sets = {}
+        self._hashes = {}
+        self._keys = {}
+        self._streams = {}
+        self._counter = 0
+        self._cv = threading.Condition()
+        self.r = self
+
+    def add_metadata(self, name, data):
+        pass
+
+    # -- sets --
+
+    def sadd(self, key, *values):
+        with self._cv:
+            self._sets.setdefault(key, set()).update(
+                v if isinstance(v, str) else v.decode()
+                for v in values
+            )
+
+    def srem(self, key, *values):
+        with self._cv:
+            s = self._sets.get(key, set())
+            for v in values:
+                s.discard(v if isinstance(v, str) else v.decode())
+
+    def smembers(self, key):
+        with self._cv:
+            return set(self._sets.get(key, set()))
+
+    def sismember(self, key, member):
+        with self._cv:
+            if isinstance(member, bytes):
+                member = member.decode()
+            return member in self._sets.get(key, set())
+
+    # -- hashes --
+
+    def hset(self, name, key=None, value=None, mapping=None):
+        with self._cv:
+            self._hashes.setdefault(name, {})
+            if key is not None:
+                self._hashes[name][key] = value
+            if mapping:
+                self._hashes[name].update(mapping)
+
+    def hget(self, name, key):
+        with self._cv:
+            return self._hashes.get(name, {}).get(key)
+
+    def hgetall(self, name):
+        with self._cv:
+            return dict(self._hashes.get(name, {}))
+
+    # -- keys --
+
+    def set(self, key, value, ex=None):
+        with self._cv:
+            self._keys[key] = value
+
+    def get(self, key):
+        with self._cv:
+            return self._keys.get(key)
+
+    def delete(self, *keys):
+        with self._cv:
+            for key in keys:
+                self._keys.pop(key, None)
+
+    # -- streams (thread-safe with blocking xread) --
+
+    def xadd(self, stream, fields, maxlen=None):
+        with self._cv:
+            msgs = self._streams.setdefault(stream, [])
+            msg_id = f"{self._counter}-0"
+            self._counter += 1
+            msgs.append((msg_id, fields))
+            self._cv.notify_all()
+            return msg_id
+
+    def xread(self, streams, block=None, count=None):
+        timeout_s = (block / 1000.0) if block else 0
+        deadline = time.time() + timeout_s if block else 0
+
+        with self._cv:
+            # Resolve "$" → current stream end
+            resolved = {}
+            for stream_name, last_id in streams.items():
+                if isinstance(last_id, bytes):
+                    last_id = last_id.decode()
+                if last_id == "$":
+                    msgs = self._streams.get(stream_name, [])
+                    last_id = msgs[-1][0] if msgs else "-1-0"
+                resolved[stream_name] = last_id
+
+            while True:
+                result = self._collect(resolved, count)
+                if result:
+                    return result
+                if not block or time.time() >= deadline:
+                    return []
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return []
+                self._cv.wait(timeout=min(remaining, 0.05))
+
+    def _collect(self, resolved, count):
+        result = []
+        for stream_name, last_id in resolved.items():
+            msgs = self._streams.get(stream_name, [])
+            new = [
+                (mid, f) for mid, f in msgs
+                if self._id_gt(mid, last_id)
+            ]
+            if new:
+                key = (
+                    stream_name.encode()
+                    if isinstance(stream_name, str)
+                    else stream_name
+                )
+                result.append((key, new[:count] if count else new))
+        return result
+
+    @staticmethod
+    def _id_gt(a, b):
+        """Compare Redis stream IDs numerically."""
+        try:
+            return int(a.split("-")[0]) > int(b.split("-")[0])
+        except (ValueError, IndexError):
+            return a > b
+
+
+# --- fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def redis():
+    return MockRedis()
+
+
+@pytest.fixture
+def mgr(redis):
+    """PicoManager with a DummyPicoRFSwitch, cmd_loop running."""
+    m = PicoManager(redis)
+    pico = DummyPicoRFSwitch(
+        "/dev/dummy", eig_redis=redis, name="rfswitch"
+    )
+    m.picos["rfswitch"] = pico
+    redis.sadd(PICOS_SET, "rfswitch")
+    m.start()
+    yield m
+    m.stop()
+
+
+@pytest.fixture
+def sw(redis, mgr):
+    """RFSwitchProxy wired to the running manager."""
+    return RFSwitchProxy("rfswitch", redis, source="test", timeout=5.0)
+
+
+# --- RFSwitchProxy ---------------------------------------------------------
+
+
+class TestRFSwitchProxy:
+
+    def test_switch_round_trip(self, sw):
+        """switch() routes through PicoManager and returns True."""
+        assert sw.switch("RFANT") is True
+
+    def test_switch_invalid_state_raises(self, sw):
+        with pytest.raises(ValueError, match="Invalid switch state"):
+            sw.switch("BOGUS")
+
+    def test_is_available(self, sw):
+        assert sw.is_available is True
+
+    def test_unavailable_returns_false(self, redis):
+        proxy = RFSwitchProxy("ghost", redis, timeout=1.0)
+        assert proxy.is_available is False
+        assert proxy.switch("RFANT") is False
+
+    def test_path_str_matches_real(self):
+        from picohost.base import PicoRFSwitch
+        assert RFSwitchProxy.path_str == PicoRFSwitch.path_str
+
+    def test_paths_computation(self, sw):
+        # RFANT = "00000000" → 0
+        assert sw.paths["RFANT"] == 0
+        # VNAO = "10000000" → 1 (LSB first)
+        assert sw.paths["VNAO"] == 1
+
+    def test_health_available(self, sw, redis):
+        # PicoManager writes health in _check_health, but we can also
+        # manually set it to verify the proxy reads it.
+        redis.hset(
+            "pico_health", "rfswitch",
+            json.dumps({"connected": True, "last_seen": 1.0, "app_id": 5}),
+        )
+        h = sw.health
+        assert h["connected"] is True
+        assert h["app_id"] == 5
+
+    def test_health_missing(self, redis):
+        proxy = RFSwitchProxy("ghost", redis)
+        assert proxy.health is None
+
+
+# --- PicoProxy base --------------------------------------------------------
+
+
+class TestPicoProxy:
+
+    def test_send_command_unavailable_returns_none(self, redis):
+        proxy = PicoProxy("nonexistent", redis, timeout=1.0)
+        assert proxy.send_command("switch", state="RFANT") is None
+
+    def test_send_command_timeout(self, redis):
+        """If manager never responds, proxy raises TimeoutError."""
+        redis.sadd(PICOS_SET, "orphan")
+        proxy = PicoProxy("orphan", redis, timeout=0.2)
+        with pytest.raises(TimeoutError, match="No response"):
+            proxy.send_command("switch", state="RFANT")
+
+    def test_send_command_error_raises_runtime(self, redis, mgr):
+        """If manager returns an error, proxy raises RuntimeError."""
+        proxy = PicoProxy("rfswitch", redis, source="test", timeout=5.0)
+        with pytest.raises(RuntimeError, match="not allowed"):
+            proxy.send_command("disconnect")
+
+
+# --- request_id echo -------------------------------------------------------
+
+
+class TestRequestId:
+
+    def test_response_contains_request_id(self, sw, redis):
+        """The manager echoes request_id in the response."""
+        sw.switch("RFANT")
+        # Check that RESP_STREAM has at least one message with request_id
+        msgs = redis._streams.get(RESP_STREAM, [])
+        assert len(msgs) > 0
+        _, fields = msgs[-1]
+        assert "request_id" in fields
+        assert fields["request_id"] != ""
+
+    def test_request_id_unique_per_call(self, sw, redis):
+        sw.switch("RFANT")
+        sw.switch("RFNON")
+        msgs = redis._streams.get(RESP_STREAM, [])
+        ids = [f["request_id"] for _, f in msgs]
+        assert len(set(ids)) == len(ids)


### PR DESCRIPTION
## Summary

- Adds `picohost.proxy` module with `PicoProxy` (base) and `RFSwitchProxy` — Redis-backed proxies that route commands through PicoManager's `stream:pico_cmd` / `stream:pico_resp` instead of serial
- Proxies are always constructible (no hardware check); commands no-op gracefully when the device is unavailable
- `RFSwitchProxy` is a drop-in for `PicoRFSwitch` (same `.switch()` / `.path_str` interface), so `cmt_vna.VNA` accepts either interchangeably
- Adds `request_id` echo to PicoManager for reliable request/response correlation

This enables eigsep_observing to interface with picos exclusively through Redis while preserving the standalone serial workflow for lab scripts.

## Test plan

- [x] 13 new tests in `test_proxy.py` (round-trip, unavailable device, invalid state, timeout, error handling, request_id correlation)
- [x] Full suite: 278 passed
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)