### PR TITLE
refactor(picohost)!: drop RFSwitchProxy, use generic PicoProxy only

### DIFF
--- a/picohost/src/picohost/__init__.py
+++ b/picohost/src/picohost/__init__.py
@@ -16,7 +16,7 @@ from .base import (
 )
 from .motor import PicoMotor
 from .manager import PicoManager
-from .proxy import PicoProxy, RFSwitchProxy
+from .proxy import PicoProxy
 from . import testing
 from . import emulators
 
@@ -30,7 +30,6 @@ __all__ = [
     "PicoPotentiometer",
     "PicoManager",
     "PicoProxy",
-    "RFSwitchProxy",
     "testing",
     "emulators",
 ]

--- a/picohost/src/picohost/proxy.py
+++ b/picohost/src/picohost/proxy.py
@@ -1,19 +1,23 @@
 """
-Redis-backed proxies for pico devices managed by PicoManager.
+Redis-backed proxy for pico devices managed by PicoManager.
 
-A proxy has the same command interface as the real device class but
-routes calls through Redis instead of serial. Construction always
-succeeds — no hardware check. At command time the proxy checks
-whether PicoManager has the device registered; if not, the command
-is a no-op that returns ``None``.
+A proxy routes device method calls through Redis instead of serial.
+Construction always succeeds — no hardware check. At command time the
+proxy checks whether PicoManager has the device registered; if not, the
+command is a no-op that returns ``None``. Every device method is invoked
+by name via :meth:`PicoProxy.send_command`; there is intentionally no
+per-device subclass.
 
 Usage::
 
-    from picohost.proxy import RFSwitchProxy
+    from picohost.proxy import PicoProxy
 
-    sw = RFSwitchProxy("rfswitch", redis_client)
-    sw.switch("RFANT")       # routed via PicoManager
-    sw.is_available           # True if PicoManager has registered it
+    sw = PicoProxy("rfswitch", redis_client)
+    sw.send_command("switch", state="RFANT")   # routed via PicoManager
+    sw.is_available                             # True if registered
+
+    peltier = PicoProxy("tempctrl", redis_client)
+    peltier.send_command("set_temperature", T_LNA=25, T_LOAD=25)
 """
 
 import json
@@ -21,7 +25,6 @@ import logging
 import time
 import uuid
 
-from .base import PicoRFSwitch
 from .manager import CMD_STREAM, HEALTH_HASH, PICOS_SET, RESP_STREAM
 
 logger = logging.getLogger(__name__)
@@ -164,45 +167,3 @@ class PicoProxy:
                             f"{data.get('error', data)}"
                         )
                     return data
-
-
-class RFSwitchProxy(PicoProxy):
-    """
-    Redis-backed proxy for an RF switch managed by PicoManager.
-
-    Drop-in replacement for :class:`PicoRFSwitch` — exposes the same
-    ``.switch()`` method and ``.path_str`` / ``.paths`` attributes so
-    that ``cmt_vna.VNA`` can use it without modification.
-    """
-
-    path_str = PicoRFSwitch.path_str
-
-    @staticmethod
-    def rbin(s):
-        return int(s[::-1], 2)
-
-    @property
-    def paths(self):
-        return {k: self.rbin(v) for k, v in self.path_str.items()}
-
-    def switch(self, state: str) -> bool:
-        """
-        Set RF switch state via PicoManager.
-
-        Returns ``True`` on success, ``False`` if the device is
-        unavailable (no-op).
-
-        Raises
-        ------
-        ValueError
-            If *state* is not a valid switch path.
-        """
-        if state not in self.path_str:
-            raise ValueError(
-                f"Invalid switch state '{state}'. "
-                f"Valid states: {list(self.path_str.keys())}"
-            )
-        result = self.send_command("switch", state=state)
-        if result is None:
-            return False
-        return True

--- a/picohost/tests/test_proxy.py
+++ b/picohost/tests/test_proxy.py
@@ -17,7 +17,7 @@ from picohost.manager import (
     RESP_STREAM,
     PicoManager,
 )
-from picohost.proxy import PicoProxy, RFSwitchProxy
+from picohost.proxy import PicoProxy
 from picohost.testing import DummyPicoRFSwitch
 
 
@@ -193,65 +193,30 @@ def mgr(redis):
 
 @pytest.fixture
 def sw(redis, mgr):
-    """RFSwitchProxy wired to the running manager."""
-    return RFSwitchProxy("rfswitch", redis, source="test", timeout=5.0)
+    """PicoProxy for the rfswitch device wired to the running manager."""
+    return PicoProxy("rfswitch", redis, source="test", timeout=5.0)
 
 
-# --- RFSwitchProxy ---------------------------------------------------------
-
-
-class TestRFSwitchProxy:
-
-    def test_switch_round_trip(self, sw):
-        """switch() routes through PicoManager and returns True."""
-        assert sw.switch("RFANT") is True
-
-    def test_switch_invalid_state_raises(self, sw):
-        with pytest.raises(ValueError, match="Invalid switch state"):
-            sw.switch("BOGUS")
-
-    def test_is_available(self, sw):
-        assert sw.is_available is True
-
-    def test_unavailable_returns_false(self, redis):
-        proxy = RFSwitchProxy("ghost", redis, timeout=1.0)
-        assert proxy.is_available is False
-        assert proxy.switch("RFANT") is False
-
-    def test_path_str_matches_real(self):
-        from picohost.base import PicoRFSwitch
-        assert RFSwitchProxy.path_str == PicoRFSwitch.path_str
-
-    def test_paths_computation(self, sw):
-        # RFANT = "00000000" → 0
-        assert sw.paths["RFANT"] == 0
-        # VNAO = "10000000" → 1 (LSB first)
-        assert sw.paths["VNAO"] == 1
-
-    def test_health_available(self, sw, redis):
-        # PicoManager writes health in _check_health, but we can also
-        # manually set it to verify the proxy reads it.
-        redis.hset(
-            "pico_health", "rfswitch",
-            json.dumps({"connected": True, "last_seen": 1.0, "app_id": 5}),
-        )
-        h = sw.health
-        assert h["connected"] is True
-        assert h["app_id"] == 5
-
-    def test_health_missing(self, redis):
-        proxy = RFSwitchProxy("ghost", redis)
-        assert proxy.health is None
-
-
-# --- PicoProxy base --------------------------------------------------------
+# --- PicoProxy -------------------------------------------------------------
 
 
 class TestPicoProxy:
 
+    def test_send_command_round_trip(self, sw):
+        """send_command routes through PicoManager and returns device result."""
+        result = sw.send_command("switch", state="RFANT")
+        assert result is not None
+        # Manager wraps the device return as {"action": ..., "result": ...}
+        assert result["action"] == "switch"
+
     def test_send_command_unavailable_returns_none(self, redis):
         proxy = PicoProxy("nonexistent", redis, timeout=1.0)
         assert proxy.send_command("switch", state="RFANT") is None
+
+    def test_send_command_invalid_state_raises(self, sw):
+        """Device-side validation surfaces as RuntimeError from the proxy."""
+        with pytest.raises(RuntimeError, match="Invalid switch state"):
+            sw.send_command("switch", state="BOGUS")
 
     def test_send_command_timeout(self, redis):
         """If manager never responds, proxy raises TimeoutError."""
@@ -266,6 +231,28 @@ class TestPicoProxy:
         with pytest.raises(RuntimeError, match="not allowed"):
             proxy.send_command("disconnect")
 
+    def test_is_available_true(self, sw):
+        assert sw.is_available is True
+
+    def test_is_available_false(self, redis):
+        proxy = PicoProxy("ghost", redis, timeout=1.0)
+        assert proxy.is_available is False
+
+    def test_health_available(self, sw, redis):
+        # PicoManager writes health in _check_health, but we can also
+        # manually set it to verify the proxy reads it.
+        redis.hset(
+            "pico_health", "rfswitch",
+            json.dumps({"connected": True, "last_seen": 1.0, "app_id": 5}),
+        )
+        h = sw.health
+        assert h["connected"] is True
+        assert h["app_id"] == 5
+
+    def test_health_missing(self, redis):
+        proxy = PicoProxy("ghost", redis)
+        assert proxy.health is None
+
 
 # --- request_id echo -------------------------------------------------------
 
@@ -274,7 +261,7 @@ class TestRequestId:
 
     def test_response_contains_request_id(self, sw, redis):
         """The manager echoes request_id in the response."""
-        sw.switch("RFANT")
+        sw.send_command("switch", state="RFANT")
         # Check that RESP_STREAM has at least one message with request_id
         msgs = redis._streams.get(RESP_STREAM, [])
         assert len(msgs) > 0
@@ -283,8 +270,8 @@ class TestRequestId:
         assert fields["request_id"] != ""
 
     def test_request_id_unique_per_call(self, sw, redis):
-        sw.switch("RFANT")
-        sw.switch("RFNON")
+        sw.send_command("switch", state="RFANT")
+        sw.send_command("switch", state="RFNON")
         msgs = redis._streams.get(RESP_STREAM, [])
         ids = [f["request_id"] for _, f in msgs]
         assert len(set(ids)) == len(ids)


### PR DESCRIPTION
## Summary

- Remove `RFSwitchProxy` class and export. The generic `PicoProxy` (with `send_command(action, **kwargs)`) is sufficient for all device commands.
- `TestRFSwitchProxy` collapses into `TestPicoProxy`: round-trip via `send_command`, invalid-state surfaces as `RuntimeError` from the remote device's own validation, availability / health checks.
- `TestRequestId` uses `send_command` instead of `.switch()`.
- Module docstring updated to show `PicoProxy` examples for both rfswitch and tempctrl.

## Motivation

`RFSwitchProxy` existed solely to duck-type `PicoRFSwitch` for cmt_vna's `switch_network` object parameter. With [CMT-VNA#31](https://github.com/EIGSEP/CMT-VNA/pull/31) making cmt_vna take a `switch_fn` callable, the subclass no longer earns its keep — every consumer can call `PicoProxy("rfswitch", r).send_command("switch", state=...)` directly.

Same pattern works uniformly for every future device command (peltier `set_temperature`, motor `az_target_deg`, etc.) without per-device proxy subclasses.

## BREAKING CHANGE

`picohost.RFSwitchProxy` and `picohost.proxy.RFSwitchProxy` are removed. Migration:

```python
# before
from picohost import RFSwitchProxy
sw = RFSwitchProxy("rfswitch", r)
sw.switch("RFANT")          # True/False

# after
from picohost import PicoProxy
sw = PicoProxy("rfswitch", r)
sw.send_command("switch", state="RFANT")  # dict or None (if unavailable)
```

Pre-validation of state names (the old ``ValueError`` from `switch()`) now comes from the device side as a ``RuntimeError`` via the manager — the `PicoRFSwitch.switch` method raises `ValueError` for unknown states, which the manager wraps and the proxy re-raises as `RuntimeError`. Callers that need local validation should import `PicoRFSwitch.path_str` directly.

## Test plan

- [x] `pytest` — 276/276 pass
- [x] `ruff check picohost/` — clean on my changes (there is a pre-existing F841 in `scripts/motor_control.py` unrelated to this PR)
- [x] `rg RFSwitchProxy picohost/src picohost/tests` — zero hits post-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)