### PR TITLE
refactor(picohost): consolidate device status into last_status

### DIFF
--- a/picohost/scripts/motor_manual.py
+++ b/picohost/scripts/motor_manual.py
@@ -69,8 +69,12 @@ def main(screen):
         screen.clear()
         screen.addstr(0, 0, "=== Motor Zeroing ===")
         screen.addstr(2, 0, f"Jog step: {deg:.1f} deg")
-        screen.addstr(3, 0, f"AZ pos: {c.status.get('az_pos', '?')}")
-        screen.addstr(4, 0, f"EL pos: {c.status.get('el_pos', '?')}")
+        if c.is_connected:
+            screen.addstr(3, 0, f"AZ pos: {c.last_status.get('az_pos', '?')}")
+            screen.addstr(4, 0, f"EL pos: {c.last_status.get('el_pos', '?')}")
+        else:
+            screen.addstr(3, 0, "AZ pos: DISCONNECTED (waiting for reconnect)")
+            screen.addstr(4, 0, "EL pos: ---")
         screen.addstr(6, 0, "u/d = jog EL | l/r = jog AZ")
         screen.addstr(7, 0, "+/- = change step size")
         screen.addstr(8, 0, "Enter = zero and exit | q = quit")
@@ -83,6 +87,8 @@ def main(screen):
             if ch == -1:
                 continue
             if ch == ord("\n"):
+                if not c.is_connected:
+                    continue
                 c.halt()
                 c.reset_step_position(az_step=0, el_step=0)
                 zeroed = True
@@ -91,18 +97,21 @@ def main(screen):
                 key = chr(ch).lower()
                 if key == "q":
                     break
-                elif key == "u":
-                    c.el_move_deg(deg, wait_for_stop=True)
-                elif key == "d":
-                    c.el_move_deg(-deg, wait_for_stop=True)
-                elif key == "l":
-                    c.az_move_deg(deg, wait_for_stop=True)
-                elif key == "r":
-                    c.az_move_deg(-deg, wait_for_stop=True)
                 elif key == "+":
                     deg += 1
                 elif key == "-":
                     deg = max(0.1, deg - 1)
+                elif key in ("u", "d", "l", "r"):
+                    if not c.is_connected:
+                        continue
+                    if key == "u":
+                        c.el_move_deg(deg, wait_for_stop=True)
+                    elif key == "d":
+                        c.el_move_deg(-deg, wait_for_stop=True)
+                    elif key == "l":
+                        c.az_move_deg(deg, wait_for_stop=True)
+                    elif key == "r":
+                        c.az_move_deg(-deg, wait_for_stop=True)
     except KeyboardInterrupt:
         pass
     finally:

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -81,6 +81,7 @@ class PicoDevice:
         eig_redis=None,
         response_handler=None,
         usb_serial: str = "",
+        verbose: bool = False,
     ):
         """
         Initialize a Pico device connection.
@@ -88,16 +89,18 @@ class PicoDevice:
         Args:
             port: Serial port device (e.g., '/dev/ttyACM0' or 'COM3')
             baudrate: Serial baud rate (default: 115200)
-            timeout: Serial read timeout in seconds (default: 1.0)
+            timeout: Serial read timeout in seconds (default: 5.0)
             name: str
             eig_redis: EigsepRedis instance
             usb_serial: USB serial number for port re-discovery
+            verbose: log each received status packet at DEBUG level
         """
         self.logger = logger
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
         self.usb_serial = usb_serial
+        self.verbose = verbose
         self.ser = None
         self._running = False
         self._reader_thread = None
@@ -312,6 +315,10 @@ class PicoDevice:
                 if data:  # is json
                     self.last_status = data
                     self.last_status_time = time.time()
+                    if self.verbose:
+                        self.logger.debug(
+                            json.dumps(data, sort_keys=True)
+                        )
                     # upload to redis
                     if self.redis_handler:
                         try:
@@ -519,29 +526,21 @@ class PicoPeltier(PicoDevice):
         self._keepalive_running = False
         self._keepalive_thread = None
         self._keepalive_interval = keepalive_interval
-        self.verbose = verbose
-        self.status = {}
         super().__init__(
             port,
             timeout=timeout,
             name=name,
             eig_redis=eig_redis,
             usb_serial=usb_serial,
+            verbose=verbose,
         )
-        self.set_response_handler(self.update_status)
         self.wait_for_updates()
         self._start_keepalive()
-
-    def update_status(self, data):
-        """Update internal status based on unpacked json packets from picos."""
-        if self.verbose:
-            print(json.dumps(data, indent=2, sort_keys=True))
-        self.status.update(data)
 
     def wait_for_updates(self, timeout=3):
         t = time.time()
         while True:
-            if len(self.status) != 0:
+            if len(self.last_status) != 0:
                 break
             if time.time() - t >= timeout:
                 raise TimeoutError(
@@ -583,7 +582,7 @@ class PicoPeltier(PicoDevice):
     @property
     def watchdog_tripped(self):
         """Whether the firmware watchdog has tripped and disabled the peltiers."""
-        return self.status.get("watchdog_tripped", False)
+        return self.last_status.get("watchdog_tripped", False)
 
     def set_watchdog_timeout(self, timeout_ms):
         """

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -88,7 +88,6 @@ _BLOCKED_ACTIONS = frozenset(
         "find_pico_ports",
         "read_line",
         "parse_response",
-        "update_status",
     }
 )
 

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -3,7 +3,6 @@ Base class for Pico device communication.
 Provides common functionality for serial communication with Pico devices.
 """
 
-import json
 import logging
 import time
 import numpy as np
@@ -27,7 +26,6 @@ class PicoMotor(PicoDevice):
         eig_redis=None,
         usb_serial="",
     ):
-        self.verbose = verbose
         self.step_angle_deg = step_angle_deg
         self.gear_teeth = gear_teeth
         self.microstep = microstep
@@ -42,7 +40,6 @@ class PicoMotor(PicoDevice):
             "el_up_delay_us": int,
             "el_dn_delay_us": int,
         }
-        self.status = {}
         self._delay_kwargs = None
         super().__init__(
             port,
@@ -50,8 +47,8 @@ class PicoMotor(PicoDevice):
             name=name,
             eig_redis=eig_redis,
             usb_serial=usb_serial,
+            verbose=verbose,
         )
-        self.set_response_handler(self.update_status)
         self.set_delay()
         self.wait_for_updates()
 
@@ -60,16 +57,10 @@ class PicoMotor(PicoDevice):
         if self._delay_kwargs is not None:
             self.set_delay(**self._delay_kwargs)
 
-    def update_status(self, data):
-        """Update internal status based on unpacked json packets from picos."""
-        if self.verbose:
-            logger.debug(json.dumps(data, indent=2, sort_keys=True))
-        self.status.update(data)
-
     def wait_for_updates(self, timeout=10):
         t = time.time()
         while True:
-            if len(self.status) != 0:
+            if len(self.last_status) != 0:
                 break
             if time.time() - t >= timeout:
                 raise TimeoutError(
@@ -159,7 +150,7 @@ class PicoMotor(PicoDevice):
         self, delta_steps, wait_for_start=True, wait_for_stop=False
     ):
         """Move az in specified number of steps from current target."""
-        new_target = self.status["az_target_pos"] + delta_steps
+        new_target = self.last_status["az_target_pos"] + delta_steps
         self.az_target_steps(
             new_target,
             wait_for_start=wait_for_start,
@@ -195,7 +186,7 @@ class PicoMotor(PicoDevice):
         self, delta_steps, wait_for_start=True, wait_for_stop=False
     ):
         """Move el in specified number of steps from current target."""
-        new_target = self.status["el_target_pos"] + delta_steps
+        new_target = self.last_status["el_target_pos"] + delta_steps
         self.el_target_steps(
             new_target,
             wait_for_start=wait_for_start,
@@ -212,8 +203,8 @@ class PicoMotor(PicoDevice):
 
     def is_moving(self):
         return (
-            self.status["az_target_pos"] != self.status["az_pos"]
-            or self.status["el_target_pos"] != self.status["el_pos"]
+            self.last_status["az_target_pos"] != self.last_status["az_pos"]
+            or self.last_status["el_target_pos"] != self.last_status["el_pos"]
         )
 
     def wait_for_start(self, timeout=0.3):
@@ -224,10 +215,10 @@ class PicoMotor(PicoDevice):
     def wait_for_stop(self, stall_timeout=30):
         if self.verbose:
             logger.debug("Waiting for stop.")
-        last_pos = (self.status["az_pos"], self.status["el_pos"])
+        last_pos = (self.last_status["az_pos"], self.last_status["el_pos"])
         t = time.time()
         while self.is_moving():
-            pos = (self.status["az_pos"], self.status["el_pos"])
+            pos = (self.last_status["az_pos"], self.last_status["el_pos"])
             if pos != last_pos:
                 last_pos = pos
                 t = time.time()

--- a/picohost/tests/conftest.py
+++ b/picohost/tests/conftest.py
@@ -19,7 +19,7 @@ def wait_for_settle(
 
     Returns the settled value so callers can assert on it directly::
 
-        assert wait_for_settle(lambda: motor.status.get("az_pos")) == 500
+        assert wait_for_settle(lambda: motor.last_status.get("az_pos")) == 500
 
     When *cadence_ms* is provided, *timeout* and *poll_interval* are derived
     from the emulator cadence unless explicitly overridden::

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -112,11 +112,11 @@ class TestPicoMotor:
         cadence = motor.EMULATOR_CADENCE_MS
         az_deg = 10.0
         expected_steps = motor.deg_to_steps(az_deg)
-        before = motor.status.get("az_target_pos")
+        before = motor.last_status.get("az_target_pos")
         motor.az_target_deg(az_deg, wait_for_start=False, wait_for_stop=False)
         assert (
             wait_for_settle(
-                lambda: motor.status.get("az_target_pos"),
+                lambda: motor.last_status.get("az_target_pos"),
                 initial=before,
                 cadence_ms=cadence,
                 max_cycles=20,
@@ -128,9 +128,9 @@ class TestPicoMotor:
     def test_status_has_motor_fields(self):
         """Motor status should contain all expected fields from the emulator."""
         motor = DummyPicoMotor("/dev/dummy")
-        assert motor.status.get("sensor_name") == "motor"
+        assert motor.last_status.get("sensor_name") == "motor"
         for key in ("az_pos", "az_target_pos", "el_pos", "el_target_pos"):
-            assert key in motor.status, f"Missing key: {key}"
+            assert key in motor.last_status, f"Missing key: {key}"
         motor.disconnect()
 
 
@@ -187,37 +187,37 @@ class TestPicoPeltier:
         """Setting LNA channel target updates emulator status."""
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
-        before = peltier.status.get("LNA_T_target")
+        before = peltier.last_status.get("LNA_T_target")
         assert peltier.set_temperature(T_LNA=25.5, LNA_hyst=0.5) is True
         assert wait_for_settle(
-            lambda: peltier.status.get("LNA_T_target"),
+            lambda: peltier.last_status.get("LNA_T_target"),
             initial=before,
             cadence_ms=cadence,
             max_cycles=10,
         ) == pytest.approx(25.5)
-        assert peltier.status.get("LNA_hysteresis") == pytest.approx(0.5)
+        assert peltier.last_status.get("LNA_hysteresis") == pytest.approx(0.5)
         peltier.disconnect()
 
     def test_set_temperature_channel_load(self):
         """Setting LOAD channel target updates emulator status."""
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
-        before = peltier.status.get("LOAD_hysteresis")
+        before = peltier.last_status.get("LOAD_hysteresis")
         assert peltier.set_temperature(T_LOAD=30.0, LOAD_hyst=1.0) is True
         assert wait_for_settle(
-            lambda: peltier.status.get("LOAD_hysteresis"),
+            lambda: peltier.last_status.get("LOAD_hysteresis"),
             initial=before,
             cadence_ms=cadence,
             max_cycles=10,
         ) == pytest.approx(1.0)
-        assert peltier.status.get("LOAD_T_target") == pytest.approx(30.0)
+        assert peltier.last_status.get("LOAD_T_target") == pytest.approx(30.0)
         peltier.disconnect()
 
     def test_set_temperature_both_channels(self):
         """Setting both channels in one call updates both in emulator."""
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
-        before = peltier.status.get("LNA_T_target")
+        before = peltier.last_status.get("LNA_T_target")
         assert (
             peltier.set_temperature(
                 T_LNA=28.0, LNA_hyst=0.3, T_LOAD=32.0, LOAD_hyst=0.8
@@ -225,12 +225,12 @@ class TestPicoPeltier:
             is True
         )
         assert wait_for_settle(
-            lambda: peltier.status.get("LNA_T_target"),
+            lambda: peltier.last_status.get("LNA_T_target"),
             initial=before,
             cadence_ms=cadence,
             max_cycles=10,
         ) == pytest.approx(28.0)
-        assert peltier.status.get("LOAD_T_target") == pytest.approx(32.0)
+        assert peltier.last_status.get("LOAD_T_target") == pytest.approx(32.0)
         peltier.disconnect()
 
     def test_enable_channels(self):
@@ -239,10 +239,10 @@ class TestPicoPeltier:
         cadence = peltier.EMULATOR_CADENCE_MS
         assert peltier.set_enable(LNA=True, LOAD=True) is True
         wait_for_condition(
-            lambda: peltier.status.get("LNA_enabled") is True,
+            lambda: peltier.last_status.get("LNA_enabled") is True,
             cadence_ms=cadence,
         )
-        assert peltier.status.get("LOAD_enabled") is True
+        assert peltier.last_status.get("LOAD_enabled") is True
         peltier.disconnect()
 
     def test_disable_channels(self):
@@ -251,21 +251,21 @@ class TestPicoPeltier:
         cadence = peltier.EMULATOR_CADENCE_MS
         assert peltier.set_enable(LNA=False, LOAD=False) is True
         wait_for_condition(
-            lambda: peltier.status.get("LNA_enabled") is False,
+            lambda: peltier.last_status.get("LNA_enabled") is False,
             cadence_ms=cadence,
         )
-        assert peltier.status.get("LOAD_enabled") is False
+        assert peltier.last_status.get("LOAD_enabled") is False
         peltier.disconnect()
 
     def test_status_has_tempctrl_fields(self):
         """Peltier status should contain all tempctrl fields from the emulator."""
         peltier = DummyPicoPeltier("/dev/dummy")
-        assert peltier.status.get("sensor_name") == "tempctrl"
+        assert peltier.last_status.get("sensor_name") == "tempctrl"
         for key in (
             "LNA_T_now",
             "LOAD_T_now",
             "LNA_drive_level",
             "LOAD_drive_level",
         ):
-            assert key in peltier.status, f"Missing key: {key}"
+            assert key in peltier.last_status, f"Missing key: {key}"
         peltier.disconnect()

--- a/picohost/tests/test_dummy_devices.py
+++ b/picohost/tests/test_dummy_devices.py
@@ -106,7 +106,7 @@ class TestDummyPicoMotor:
 
     Commands sent through the PicoMotor API are dispatched to the emulator,
     which updates its state and sends periodic status JSON that the reader
-    thread picks up into motor.status.
+    thread picks up into motor.last_status.
     """
 
     def test_deg_to_steps_known_values(self):
@@ -121,18 +121,18 @@ class TestDummyPicoMotor:
         """motor_command() is dispatched to the emulator and reflected in status."""
         motor = DummyPicoMotor(port="/dev/ttyUSB0")
         cadence = motor.EMULATOR_CADENCE_MS
-        before = motor.status.get("az_target_pos")
+        before = motor.last_status.get("az_target_pos")
         motor.motor_command(az_set_target_pos=1000, el_set_target_pos=500)
         assert (
             wait_for_settle(
-                lambda: motor.status.get("az_target_pos"),
+                lambda: motor.last_status.get("az_target_pos"),
                 initial=before,
                 cadence_ms=cadence,
                 max_cycles=10,
             )
             == 1000
         )
-        assert motor.status["el_target_pos"] == 500
+        assert motor.last_status["el_target_pos"] == 500
         motor.disconnect()
 
     def test_halt_sets_target_to_current(self):
@@ -141,13 +141,13 @@ class TestDummyPicoMotor:
         cadence = motor.EMULATOR_CADENCE_MS
         motor.motor_command(az_set_target_pos=1000)
         wait_for_condition(
-            lambda: motor.status.get("az_target_pos") == 1000,
+            lambda: motor.last_status.get("az_target_pos") == 1000,
             cadence_ms=cadence,
         )
         motor.halt()
         wait_for_condition(
             lambda: (
-                motor.status.get("az_target_pos") == motor.status.get("az_pos")
+                motor.last_status.get("az_target_pos") == motor.last_status.get("az_pos")
             ),
             cadence_ms=cadence,
         )
@@ -156,11 +156,11 @@ class TestDummyPicoMotor:
     def test_status_populated_on_init(self):
         """wait_for_updates() in __init__ ensures status is populated immediately."""
         motor = DummyPicoMotor(port="/dev/ttyUSB0")
-        assert motor.status["sensor_name"] == "motor"
-        assert "az_pos" in motor.status
-        assert "el_pos" in motor.status
-        assert "az_target_pos" in motor.status
-        assert "el_target_pos" in motor.status
+        assert motor.last_status["sensor_name"] == "motor"
+        assert "az_pos" in motor.last_status
+        assert "el_pos" in motor.last_status
+        assert "az_target_pos" in motor.last_status
+        assert "el_target_pos" in motor.last_status
         motor.disconnect()
 
     def test_scan_homes_after_normal_completion(self):
@@ -175,14 +175,14 @@ class TestDummyPicoMotor:
         # after scan completes, motors should be back at 0
         wait_for_condition(
             lambda: (
-                motor.status.get("az_pos") == 0
-                and motor.status.get("el_pos") == 0
+                motor.last_status.get("az_pos") == 0
+                and motor.last_status.get("el_pos") == 0
             ),
             cadence_ms=cadence,
             max_cycles=10,
         )
-        assert motor.status["az_pos"] == 0
-        assert motor.status["el_pos"] == 0
+        assert motor.last_status["az_pos"] == 0
+        assert motor.last_status["el_pos"] == 0
         motor.disconnect()
 
     def test_scan_does_not_home_on_interrupt(self):
@@ -207,8 +207,8 @@ class TestDummyPicoMotor:
                 el_range_deg=np.array([-10.0, 0.0, 10.0]),
             )
         # halt was called, but post-scan homing did not run
-        assert motor.status["az_target_pos"] == motor.status["az_pos"]
-        assert motor.status["el_target_pos"] == motor.status["el_pos"]
+        assert motor.last_status["az_target_pos"] == motor.last_status["az_pos"]
+        assert motor.last_status["el_target_pos"] == motor.last_status["el_pos"]
         motor.disconnect()
 
 
@@ -280,22 +280,22 @@ class TestDummyPicoPeltier:
         """Setting LNA channel target and hysteresis updates emulator status."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
-        before = peltier.status.get("LNA_T_target")
+        before = peltier.last_status.get("LNA_T_target")
         assert peltier.set_temperature(T_LNA=25.5, LNA_hyst=0.5) is True
         assert wait_for_settle(
-            lambda: peltier.status.get("LNA_T_target"),
+            lambda: peltier.last_status.get("LNA_T_target"),
             initial=before,
             cadence_ms=cadence,
             max_cycles=10,
         ) == pytest.approx(25.5)
-        assert peltier.status["LNA_hysteresis"] == pytest.approx(0.5)
+        assert peltier.last_status["LNA_hysteresis"] == pytest.approx(0.5)
         peltier.disconnect()
 
     def test_set_temperature_both_channels(self):
         """Setting both channels in one call updates both in emulator."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
-        before = peltier.status.get("LOAD_T_target")
+        before = peltier.last_status.get("LOAD_T_target")
         assert (
             peltier.set_temperature(
                 T_LNA=30.0, LNA_hyst=1.0, T_LOAD=25.0, LOAD_hyst=0.5
@@ -303,12 +303,12 @@ class TestDummyPicoPeltier:
             is True
         )
         assert wait_for_settle(
-            lambda: peltier.status.get("LOAD_T_target"),
+            lambda: peltier.last_status.get("LOAD_T_target"),
             initial=before,
             cadence_ms=cadence,
             max_cycles=10,
         ) == pytest.approx(25.0)
-        assert peltier.status["LNA_T_target"] == pytest.approx(30.0)
+        assert peltier.last_status["LNA_T_target"] == pytest.approx(30.0)
         peltier.disconnect()
 
     def test_set_enable_mixed(self):
@@ -317,10 +317,10 @@ class TestDummyPicoPeltier:
         cadence = peltier.EMULATOR_CADENCE_MS
         assert peltier.set_enable(LNA=True, LOAD=False) is True
         wait_for_condition(
-            lambda: peltier.status.get("LNA_enabled") is True,
+            lambda: peltier.last_status.get("LNA_enabled") is True,
             cadence_ms=cadence,
         )
-        assert peltier.status["LOAD_enabled"] is False
+        assert peltier.last_status["LOAD_enabled"] is False
         peltier.disconnect()
 
     def test_enable_both_channels(self):
@@ -329,10 +329,10 @@ class TestDummyPicoPeltier:
         cadence = peltier.EMULATOR_CADENCE_MS
         assert peltier.set_enable(LNA=True, LOAD=True) is True
         wait_for_condition(
-            lambda: peltier.status.get("LNA_enabled") is True,
+            lambda: peltier.last_status.get("LNA_enabled") is True,
             cadence_ms=cadence,
         )
-        assert peltier.status["LOAD_enabled"] is True
+        assert peltier.last_status["LOAD_enabled"] is True
         peltier.disconnect()
 
     def test_disable_both_channels(self):
@@ -341,19 +341,19 @@ class TestDummyPicoPeltier:
         cadence = peltier.EMULATOR_CADENCE_MS
         assert peltier.set_enable(LNA=False, LOAD=False) is True
         wait_for_condition(
-            lambda: peltier.status.get("LNA_enabled") is False,
+            lambda: peltier.last_status.get("LNA_enabled") is False,
             cadence_ms=cadence,
         )
-        assert peltier.status["LOAD_enabled"] is False
+        assert peltier.last_status["LOAD_enabled"] is False
         peltier.disconnect()
 
     def test_status_populated_on_init(self):
         """wait_for_updates() in PicoStatus.__init__ populates status immediately."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
-        assert peltier.status["sensor_name"] == "tempctrl"
-        assert "LNA_T_now" in peltier.status
-        assert "LOAD_T_now" in peltier.status
-        assert "LNA_drive_level" in peltier.status
+        assert peltier.last_status["sensor_name"] == "tempctrl"
+        assert "LNA_T_now" in peltier.last_status
+        assert "LOAD_T_now" in peltier.last_status
+        assert "LNA_drive_level" in peltier.last_status
         peltier.disconnect()
 
 

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -138,17 +138,17 @@ def lidar():
 class TestMotorIntegration:
     def test_status_fields(self, motor):
         """Motor emulator populates all status fields via reader thread."""
-        assert set(motor.status.keys()) == MOTOR_FIELDS
-        assert motor.status["sensor_name"] == "motor"
+        assert set(motor.last_status.keys()) == MOTOR_FIELDS
+        assert motor.last_status["sensor_name"] == "motor"
 
     def test_command_round_trip(self, motor):
         """Command sent through serial is processed by emulator."""
         cadence = motor.EMULATOR_CADENCE_MS
-        before = motor.status.get("az_target_pos")
+        before = motor.last_status.get("az_target_pos")
         motor.motor_command(az_set_target_pos=500)
         assert (
             wait_for_settle(
-                lambda: motor.status.get("az_target_pos"),
+                lambda: motor.last_status.get("az_target_pos"),
                 initial=before,
                 cadence_ms=cadence,
                 max_cycles=10,
@@ -160,7 +160,7 @@ class TestMotorIntegration:
         expected_ops = math.ceil(500 / steps_per_op)
         assert (
             wait_for_settle(
-                lambda: motor.status.get("az_pos"),
+                lambda: motor.last_status.get("az_pos"),
                 initial=0,
                 cadence_ms=cadence,
                 max_cycles=expected_ops + 10,
@@ -204,8 +204,8 @@ class TestRFSwitchIntegration:
 class TestPeltierIntegration:
     def test_status_fields(self, peltier):
         """Peltier emulator populates all status fields via reader thread."""
-        assert set(peltier.status.keys()) == TEMPCTRL_FIELDS
-        assert peltier.status["sensor_name"] == "tempctrl"
+        assert set(peltier.last_status.keys()) == TEMPCTRL_FIELDS
+        assert peltier.last_status["sensor_name"] == "tempctrl"
 
     def test_command_round_trip(self, peltier):
         """Temperature control converges to target through serial pipeline."""
@@ -215,7 +215,7 @@ class TestPeltierIntegration:
         # 10°C delta, drive clamped at 0.6, drift 0.05/op -> ~0.03°C/op
         # ~333 ops to converge + margin for hysteresis settling
         settled = wait_for_settle(
-            lambda: round(peltier.status.get("LNA_T_now", 0), 1),
+            lambda: round(peltier.last_status.get("LNA_T_now", 0), 1),
             cadence_ms=cadence,
             max_cycles=500,
             stable_count=5,
@@ -263,7 +263,7 @@ class TestIMUIntegration:
 class TestMotorIntegrationTypes:
     def test_status_types(self, motor):
         """Verify motor status value types through serial pipeline."""
-        s = motor.status
+        s = motor.last_status
         assert isinstance(s["sensor_name"], str)
         assert isinstance(s["status"], str)
         assert isinstance(s["app_id"], int)
@@ -279,7 +279,7 @@ class TestMotorIntegrationTypes:
 class TestPeltierIntegrationTypes:
     def test_status_types(self, peltier):
         """Verify peltier status value types through serial pipeline."""
-        s = peltier.status
+        s = peltier.last_status
         assert isinstance(s["sensor_name"], str)
         assert isinstance(s["app_id"], int)
         # Booleans
@@ -404,7 +404,7 @@ class TestPeltierWatchdog:
         try:
             p.set_watchdog_timeout(500)
             time.sleep(1.0)
-            assert p.status.get("watchdog_tripped") is False
+            assert p.last_status.get("watchdog_tripped") is False
         finally:
             p.disconnect()
 
@@ -416,7 +416,7 @@ class TestPeltierWatchdog:
             p.set_watchdog_timeout(200)
             # 200ms watchdog / 50ms cadence = 4 ops + margin
             wait_for_condition(
-                lambda: p.status.get("watchdog_tripped") is True,
+                lambda: p.last_status.get("watchdog_tripped") is True,
                 cadence_ms=cadence,
                 max_cycles=20,
             )
@@ -469,7 +469,7 @@ class TestConvergenceTiming:
         margin = 10
         motor.motor_command(az_set_target_pos=target)
         settled = wait_for_settle(
-            lambda: motor.status.get("az_pos"),
+            lambda: motor.last_status.get("az_pos"),
             initial=0,
             cadence_ms=cadence,
             max_cycles=expected_ops + margin,
@@ -485,7 +485,7 @@ class TestConvergenceTiming:
         margin = 10
         motor.motor_command(az_set_target_pos=target)
         settled = wait_for_settle(
-            lambda: motor.status.get("az_pos"),
+            lambda: motor.last_status.get("az_pos"),
             initial=0,
             cadence_ms=cadence,
             max_cycles=expected_ops + margin,
@@ -507,13 +507,13 @@ class TestConvergenceTiming:
             el_set_target_pos=el_target,
         )
         az = wait_for_settle(
-            lambda: motor.status.get("az_pos"),
+            lambda: motor.last_status.get("az_pos"),
             initial=0,
             cadence_ms=cadence,
             max_cycles=slowest_ops + margin,
         )
         el = wait_for_settle(
-            lambda: motor.status.get("el_pos"),
+            lambda: motor.last_status.get("el_pos"),
             initial=0,
             cadence_ms=cadence,
             max_cycles=slowest_ops + margin,
@@ -524,11 +524,11 @@ class TestConvergenceTiming:
     def test_command_ack_within_few_cycles(self, motor):
         """Target-position update is visible in status within a few cycles."""
         cadence = motor.EMULATOR_CADENCE_MS
-        before = motor.status.get("az_target_pos")
+        before = motor.last_status.get("az_target_pos")
         motor.motor_command(az_set_target_pos=999)
         # Should appear within ~2-3 status cycles (command + next status send)
         settled = wait_for_settle(
-            lambda: motor.status.get("az_target_pos"),
+            lambda: motor.last_status.get("az_target_pos"),
             initial=before,
             cadence_ms=cadence,
             max_cycles=6,
@@ -548,7 +548,7 @@ class TestConvergenceTiming:
             p.set_temperature(T_LNA=35.0)
             p.set_enable(LNA=True)
             settled = wait_for_settle(
-                lambda: round(p.status.get("LNA_T_now", 0), 1),
+                lambda: round(p.last_status.get("LNA_T_now", 0), 1),
                 cadence_ms=cadence,
                 max_cycles=500,
                 stable_count=5,
@@ -571,7 +571,7 @@ class TestConvergenceTiming:
             # Allow generous margin for thread scheduling, but still
             # much tighter than the old hardcoded 2s timeout.
             wait_for_condition(
-                lambda: p.status.get("watchdog_tripped") is True,
+                lambda: p.last_status.get("watchdog_tripped") is True,
                 cadence_ms=cadence,
                 max_cycles=watchdog_cycles + 15,
             )

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -681,7 +681,7 @@ class _StubDevice:
     """Bare attribute holder for testing wait_for_updates in isolation."""
 
     def __init__(self):
-        self.status = {}
+        self.last_status = {}
         self.name = "stub"
 
 

--- a/picohost/tests/test_manager_integration.py
+++ b/picohost/tests/test_manager_integration.py
@@ -331,7 +331,7 @@ class TestCommandRelay:
         )
         # 300 steps / 60 steps_per_op = 5 ops + margin
         settled = wait_for_settle(
-            lambda: pico.status.get("az_pos"),
+            lambda: pico.last_status.get("az_pos"),
             initial=0,
             cadence_ms=CADENCE_MS,
             max_cycles=20,
@@ -362,7 +362,7 @@ class TestCommandRelay:
         )
         # Only verify the target was set, not convergence.
         wait_for_condition(
-            lambda: pico.status.get("LNA_T_target") == 30.0,
+            lambda: pico.last_status.get("LNA_T_target") == 30.0,
             cadence_ms=CADENCE_MS,
             max_cycles=10,
         )


### PR DESCRIPTION
## Summary

- `PicoMotor` and `PicoPeltier` no longer keep a parallel `self.status` dict alongside the base-class `self.last_status`. The reader thread's full-replacement writes are equivalent to the old merge-update semantics because the firmware contract (see `test_no_command_acknowledgment`) only emits full `get_status()` payloads — no partial responses, no ACKs.
- `verbose` + per-packet DEBUG logging moved into `PicoDevice` so it's uniform across device classes.
- Also closes the disconnect-handling audit for `motor_manual.py`: the TUI now shows `DISCONNECTED` instead of stale positions, and jog/zero keys skip when `not c.is_connected` so the script can't silently claim `zeroed = True` or hang 30s inside `wait_for_stop` after a disconnect.

## Notable non-change

Motor methods (`motor_command`, `halt`, `reset_step_position`, `set_delay`, etc.) still discard `send_command`'s bool return — callers have no way to detect silent disconnect failures at the library layer. The `motor_manual.py` guard works around this in the script, but a proper fix (thread the bool up, or raise `ConnectionError` from `send_command`) is deferred to a follow-up PR since it needs a caller audit across scripts + manager forwarders.

## Test plan

- [x] `pytest` — 275 passed
- [ ] Manual smoke on hardware: start `motor_manual.py`, verify positions update; unplug Pico mid-session, verify `DISCONNECTED` banner and that `u/d/l/r` and Enter are ignored; replug, verify live status resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)