### PR TITLE
refactor(picohost): raise on send_command failure, guard motor status reads

### DIFF
--- a/picohost/scripts/motor_control.py
+++ b/picohost/scripts/motor_control.py
@@ -5,10 +5,21 @@ and an infinite scanning mode.
 """
 
 import json
+import logging
 import numpy as np
 from eigsep_observing import EigsepRedis
 
 from picohost import PicoMotor
+
+logger = logging.getLogger(__name__)
+
+
+def _try_halt(c):
+    """Best-effort halt; log and swallow disconnect."""
+    try:
+        c.halt()
+    except ConnectionError as e:
+        logger.warning("halt skipped: %s", e)
 
 
 def main():
@@ -64,13 +75,17 @@ def main():
     except KeyError:
         last_status = None
     c = PicoMotor(port, verbose=True)
-    c.set_delay(
-        az_up_delay_us=2400,
-        az_dn_delay_us=300,
-        el_up_delay_us=2400,
-        el_dn_delay_us=600,
-    )
-    c.halt()
+    try:
+        c.set_delay(
+            az_up_delay_us=2400,
+            az_dn_delay_us=300,
+            el_up_delay_us=2400,
+            el_dn_delay_us=600,
+        )
+    except ConnectionError as e:
+        logger.error("Could not configure motor: %s", e)
+        return
+    _try_halt(c)
     # try:
     #    #c.el_move_deg(30, wait_for_stop=True)
     #    c.az_move_deg(100, wait_for_stop=True)
@@ -81,7 +96,7 @@ def main():
     # finally:
     #    c.halt()
     try:
-        c.halt()
+        _try_halt(c)
         c.scan(
             az_range_deg=np.linspace(-180.0, 180.0, 10),
             el_range_deg=np.linspace(-180.0, 180.0, 10),
@@ -91,9 +106,9 @@ def main():
             sleep_between=args.sleep_s,
         )
     except KeyboardInterrupt:
-        c.halt()
+        _try_halt(c)
     finally:
-        c.halt()
+        _try_halt(c)
 
 
 if __name__ == "__main__":

--- a/picohost/scripts/motor_control.py
+++ b/picohost/scripts/motor_control.py
@@ -106,7 +106,9 @@ def main():
             sleep_between=args.sleep_s,
         )
     except KeyboardInterrupt:
-        _try_halt(c)
+        pass
+    except (ConnectionError, RuntimeError) as e:
+        logger.error("Motor scan aborted: %s", e)
     finally:
         _try_halt(c)
 

--- a/picohost/scripts/motor_manual.py
+++ b/picohost/scripts/motor_manual.py
@@ -86,36 +86,44 @@ def main(screen):
             ch = screen.getch()
             if ch == -1:
                 continue
-            if ch == ord("\n"):
-                if not c.is_connected:
-                    continue
-                c.halt()
-                c.reset_step_position(az_step=0, el_step=0)
-                zeroed = True
-                break
-            if 0 <= ch < 256:
-                key = chr(ch).lower()
-                if key == "q":
-                    break
-                elif key == "+":
-                    deg += 1
-                elif key == "-":
-                    deg = max(0.1, deg - 1)
-                elif key in ("u", "d", "l", "r"):
+            try:
+                if ch == ord("\n"):
                     if not c.is_connected:
                         continue
-                    if key == "u":
-                        c.el_move_deg(deg, wait_for_stop=True)
-                    elif key == "d":
-                        c.el_move_deg(-deg, wait_for_stop=True)
-                    elif key == "l":
-                        c.az_move_deg(deg, wait_for_stop=True)
-                    elif key == "r":
-                        c.az_move_deg(-deg, wait_for_stop=True)
+                    c.halt()
+                    c.reset_step_position(az_step=0, el_step=0)
+                    zeroed = True
+                    break
+                if 0 <= ch < 256:
+                    key = chr(ch).lower()
+                    if key == "q":
+                        break
+                    elif key == "+":
+                        deg += 1
+                    elif key == "-":
+                        deg = max(0.1, deg - 1)
+                    elif key in ("u", "d", "l", "r"):
+                        if not c.is_connected:
+                            continue
+                        if key == "u":
+                            c.el_move_deg(deg, wait_for_stop=True)
+                        elif key == "d":
+                            c.el_move_deg(-deg, wait_for_stop=True)
+                        elif key == "l":
+                            c.az_move_deg(deg, wait_for_stop=True)
+                        elif key == "r":
+                            c.az_move_deg(-deg, wait_for_stop=True)
+            except (ConnectionError, RuntimeError):
+                # Disconnect mid-dispatch, or no firmware status yet.
+                # Next refresh_status() tick will show state; skip this key.
+                continue
     except KeyboardInterrupt:
         pass
     finally:
-        c.halt()
+        try:
+            c.halt()
+        except ConnectionError:
+            pass
 
     if zeroed:
         logger.info("Step counters zeroed. Motors are at home (0, 0).")

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -229,27 +229,28 @@ class PicoDevice:
         """
         pass
 
-    def send_command(self, cmd_dict: Dict[str, Any]) -> bool:
+    def send_command(self, cmd_dict: Dict[str, Any]) -> None:
         """
         Send a JSON command to the device.
 
         Args:
             cmd_dict: Dictionary to be JSON-encoded and sent
 
-        Returns:
-            True if command sent successfully, False otherwise
+        Raises:
+            ConnectionError: device is not connected, or the underlying
+                write failed.
         """
         if not self.is_connected:
-            return False
+            raise ConnectionError(f"{self.name} not connected")
 
         try:
             json_str = json.dumps(cmd_dict, separators=(",", ":"))
             self.ser.write((json_str + "\n").encode("utf-8"))
             self.ser.flush()
-            return True
         except Exception as e:
-            self.logger.error(f"Failed to send command: {e}")
-            return False
+            raise ConnectionError(
+                f"{self.name} write failed: {e}"
+            ) from e
 
     def read_line(self) -> Optional[str]:
         """
@@ -452,7 +453,7 @@ class PicoRFSwitch(PicoDevice):
     def paths(self):
         return {k: self.rbin(v) for k, v in self.path_str.items()}
 
-    def switch(self, state: str) -> bool:
+    def switch(self, state: str) -> None:
         """
         Set RF switch state.
 
@@ -461,15 +462,12 @@ class PicoRFSwitch(PicoDevice):
         state: str
             Switch state path, see self.PATHS for valid keys
 
-        Returns
-        -------
-        bool
-            True if command sent successfully
-
         Raises
         -------
         ValueError
             If an invalid switch state is provided
+        ConnectionError
+            If the device is not connected or the write failed.
 
         """
         try:
@@ -479,13 +477,9 @@ class PicoRFSwitch(PicoDevice):
                 f"Invalid switch state '{state}'. Valid states: "
                 f"{list(self.paths.keys())}"
             ) from e
-        c = self.send_command({"sw_state": s})
-        if c:
-            time.sleep(0.05)  # allow time for switch to settle
-            self.logger.info(f"Switched to {state}.")
-        else:
-            self.logger.error(f"Failed to switch to {state}.")
-        return c
+        self.send_command({"sw_state": s})
+        time.sleep(0.05)  # allow time for switch to settle
+        self.logger.info(f"Switched to {state}.")
 
 
 class PicoPeltier(PicoDevice):
@@ -534,19 +528,7 @@ class PicoPeltier(PicoDevice):
             usb_serial=usb_serial,
             verbose=verbose,
         )
-        self.wait_for_updates()
         self._start_keepalive()
-
-    def wait_for_updates(self, timeout=3):
-        t = time.time()
-        while True:
-            if len(self.last_status) != 0:
-                break
-            if time.time() - t >= timeout:
-                raise TimeoutError(
-                    f"No status from {self.name} within {timeout}s"
-                )
-            time.sleep(0.1)
 
     def _start_keepalive(self):
         """Start the background keepalive thread."""
@@ -560,7 +542,11 @@ class PicoPeltier(PicoDevice):
     def _keepalive_thread_func(self):
         """Send empty commands periodically to reset the firmware watchdog."""
         while self._keepalive_running:
-            self.send_command({})
+            try:
+                self.send_command({})
+            except ConnectionError:
+                # Reader thread owns reconnection; keepalive survives drops.
+                pass
             # Sleep in small increments so thread stops promptly
             for _ in range(max(1, int(self._keepalive_interval * 10))):
                 if not self._keepalive_running:
@@ -593,12 +579,12 @@ class PicoPeltier(PicoDevice):
         timeout_ms : int
             Watchdog timeout in milliseconds. 0 disables the watchdog.
 
-        Returns
-        -------
-        bool
-            True if command sent successfully.
+        Raises
+        ------
+        ConnectionError
+            If the device is not connected or the write failed.
         """
-        return self.send_command({"watchdog_timeout_ms": int(timeout_ms)})
+        self.send_command({"watchdog_timeout_ms": int(timeout_ms)})
 
     def set_temperature(
         self, T_LNA=None, LNA_hyst=0.5, T_LOAD=None, LOAD_hyst=0.5
@@ -611,11 +597,11 @@ class PicoPeltier(PicoDevice):
         if T_LOAD is not None:
             cmd["LOAD_temp_target"] = T_LOAD
             cmd["LOAD_hysteresis"] = LOAD_hyst
-        return self.send_command(cmd)
+        self.send_command(cmd)
 
     def set_enable(self, LNA=True, LOAD=True):
         """Enable temperature control."""
-        return self.send_command({"LNA_enable": LNA, "LOAD_enable": LOAD})
+        self.send_command({"LNA_enable": LNA, "LOAD_enable": LOAD})
 
     def set_clamp(self, LNA=None, LOAD=None):
         """Set maximum drive level [0.0, 1.0], 0.6 default."""
@@ -624,7 +610,7 @@ class PicoPeltier(PicoDevice):
             cmd["LNA_clamp"] = LNA
         if LOAD is not None:
             cmd["LOAD_clamp"] = LOAD
-        return self.send_command(cmd)
+        self.send_command(cmd)
 
 
 class PicoIMU(PicoDevice):

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -243,8 +243,8 @@ class PicoDevice:
         if not self.is_connected:
             raise ConnectionError(f"{self.name} not connected")
 
+        json_str = json.dumps(cmd_dict, separators=(",", ":"))
         try:
-            json_str = json.dumps(cmd_dict, separators=(",", ":"))
             self.ser.write((json_str + "\n").encode("utf-8"))
             self.ser.flush()
         except Exception as e:

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -82,7 +82,6 @@ _BLOCKED_ACTIONS = frozenset(
         "set_response_handler",
         "set_raw_handler",
         "wait_for_response",
-        "wait_for_updates",
         "wait_for_start",
         "wait_for_stop",
         "find_pico_ports",

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -50,23 +50,11 @@ class PicoMotor(PicoDevice):
             verbose=verbose,
         )
         self.set_delay()
-        self.wait_for_updates()
 
     def on_reconnect(self):
         """Re-apply delay configuration after a serial reconnect."""
         if self._delay_kwargs is not None:
             self.set_delay(**self._delay_kwargs)
-
-    def wait_for_updates(self, timeout=10):
-        t = time.time()
-        while True:
-            if len(self.last_status) != 0:
-                break
-            if time.time() - t >= timeout:
-                raise TimeoutError(
-                    f"No status from {self.name} within {timeout}s"
-                )
-            time.sleep(0.1)
 
     def deg_to_steps(self, degrees: float) -> int:
         """Convert degrees to motor pulses."""
@@ -146,10 +134,16 @@ class PicoMotor(PicoDevice):
             wait_for_stop=wait_for_stop,
         )
 
+    def _require_status(self):
+        """Raise if no firmware status has been received yet."""
+        if not self.last_status:
+            raise RuntimeError(f"No status from {self.name} yet")
+
     def az_move_steps(
         self, delta_steps, wait_for_start=True, wait_for_stop=False
     ):
         """Move az in specified number of steps from current target."""
+        self._require_status()
         new_target = self.last_status["az_target_pos"] + delta_steps
         self.az_target_steps(
             new_target,
@@ -186,6 +180,7 @@ class PicoMotor(PicoDevice):
         self, delta_steps, wait_for_start=True, wait_for_stop=False
     ):
         """Move el in specified number of steps from current target."""
+        self._require_status()
         new_target = self.last_status["el_target_pos"] + delta_steps
         self.el_target_steps(
             new_target,
@@ -202,6 +197,7 @@ class PicoMotor(PicoDevice):
         )
 
     def is_moving(self):
+        self._require_status()
         return (
             self.last_status["az_target_pos"] != self.last_status["az_pos"]
             or self.last_status["el_target_pos"] != self.last_status["el_pos"]
@@ -215,6 +211,7 @@ class PicoMotor(PicoDevice):
     def wait_for_stop(self, stall_timeout=30):
         if self.verbose:
             logger.debug("Waiting for stop.")
+        self._require_status()
         last_pos = (self.last_status["az_pos"], self.last_status["el_pos"])
         t = time.time()
         while self.is_moving():

--- a/picohost/src/picohost/testing.py
+++ b/picohost/src/picohost/testing.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 try:
     import mockserial
@@ -35,6 +36,10 @@ class DummyPicoDevice(PicoDevice):
         self.ser.add_peer(self._peer)
         self._peer.add_peer(self.ser)
         self.ser.reset_input_buffer()
+        # Mirror PicoDevice._open_serial: stamp open time so the health
+        # loop gives us a HEALTH_TIMEOUT grace window before declaring
+        # the device stale and triggering a reconnect.
+        self.last_status_time = time.time()
         # Create and start emulator if a class is configured
         self._emulator = None
         if self.EMULATOR_CLASS is not None:

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -40,18 +40,19 @@ class TestPicoDevice:
         """send_command() serializes a dict as compact JSON + newline."""
         device = DummyPicoDevice("/dev/dummy")
         cmd = {"cmd": "test", "value": 42}
-        assert device.send_command(cmd) is True
+        device.send_command(cmd)
 
         # No emulator on base DummyPicoDevice, so bytes stay in peer buffer
         expected_data = json.dumps(cmd, separators=(",", ":")) + "\n"
         assert device.ser.peer._read_buffer == expected_data.encode("utf-8")
         device.disconnect()
 
-    def test_send_command_returns_false_when_disconnected(self):
-        """send_command() returns False when the serial port is closed."""
+    def test_send_command_raises_when_disconnected(self):
+        """send_command() raises ConnectionError when the port is closed."""
         device = DummyPicoDevice("/dev/dummy")
         device.disconnect()
-        assert device.send_command({"cmd": "test"}) is False
+        with pytest.raises(ConnectionError):
+            device.send_command({"cmd": "test"})
 
     def test_parse_response_valid_json(self):
         """parse_response() returns a dict for valid JSON."""
@@ -156,7 +157,10 @@ class TestPicoMotor:
     def test_status_has_motor_fields(self):
         """Motor status should contain all expected fields from the emulator."""
         motor = DummyPicoMotor("/dev/dummy")
-        assert motor.last_status.get("sensor_name") == "motor"
+        wait_for_condition(
+            lambda: motor.last_status.get("sensor_name") == "motor",
+            cadence_ms=motor.EMULATOR_CADENCE_MS,
+        )
         for key in ("az_pos", "az_target_pos", "el_pos", "el_target_pos"):
             assert key in motor.last_status, f"Missing key: {key}"
         motor.disconnect()
@@ -170,7 +174,7 @@ class TestPicoRFSwitch:
         switch = DummyPicoRFSwitch("/dev/dummy")
         cadence = switch.EMULATOR_CADENCE_MS
         expected_state = switch.rbin(switch.path_str["VNAO"])
-        assert switch.switch("VNAO") is True
+        switch.switch("VNAO")
         wait_for_condition(
             lambda: switch.last_status.get("sw_state") == expected_state,
             cadence_ms=cadence,
@@ -182,7 +186,7 @@ class TestPicoRFSwitch:
         """Every defined path string can be switched without error."""
         switch = DummyPicoRFSwitch("/dev/dummy")
         for state in switch.paths:
-            assert switch.switch(state) is True
+            switch.switch(state)
         switch.disconnect()
 
     def test_switch_invalid_state_raises(self):
@@ -216,7 +220,7 @@ class TestPicoPeltier:
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
         before = peltier.last_status.get("LNA_T_target")
-        assert peltier.set_temperature(T_LNA=25.5, LNA_hyst=0.5) is True
+        peltier.set_temperature(T_LNA=25.5, LNA_hyst=0.5)
         assert wait_for_settle(
             lambda: peltier.last_status.get("LNA_T_target"),
             initial=before,
@@ -231,7 +235,7 @@ class TestPicoPeltier:
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
         before = peltier.last_status.get("LOAD_hysteresis")
-        assert peltier.set_temperature(T_LOAD=30.0, LOAD_hyst=1.0) is True
+        peltier.set_temperature(T_LOAD=30.0, LOAD_hyst=1.0)
         assert wait_for_settle(
             lambda: peltier.last_status.get("LOAD_hysteresis"),
             initial=before,
@@ -246,11 +250,8 @@ class TestPicoPeltier:
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
         before = peltier.last_status.get("LNA_T_target")
-        assert (
-            peltier.set_temperature(
-                T_LNA=28.0, LNA_hyst=0.3, T_LOAD=32.0, LOAD_hyst=0.8
-            )
-            is True
+        peltier.set_temperature(
+            T_LNA=28.0, LNA_hyst=0.3, T_LOAD=32.0, LOAD_hyst=0.8
         )
         assert wait_for_settle(
             lambda: peltier.last_status.get("LNA_T_target"),
@@ -265,7 +266,7 @@ class TestPicoPeltier:
         """set_enable() updates the enabled flags in emulator status."""
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
-        assert peltier.set_enable(LNA=True, LOAD=True) is True
+        peltier.set_enable(LNA=True, LOAD=True)
         wait_for_condition(
             lambda: peltier.last_status.get("LNA_enabled") is True,
             cadence_ms=cadence,
@@ -277,7 +278,7 @@ class TestPicoPeltier:
         """Disabling channels is reflected in emulator status."""
         peltier = DummyPicoPeltier("/dev/dummy")
         cadence = peltier.EMULATOR_CADENCE_MS
-        assert peltier.set_enable(LNA=False, LOAD=False) is True
+        peltier.set_enable(LNA=False, LOAD=False)
         wait_for_condition(
             lambda: peltier.last_status.get("LNA_enabled") is False,
             cadence_ms=cadence,
@@ -288,7 +289,10 @@ class TestPicoPeltier:
     def test_status_has_tempctrl_fields(self):
         """Peltier status should contain all tempctrl fields from the emulator."""
         peltier = DummyPicoPeltier("/dev/dummy")
-        assert peltier.last_status.get("sensor_name") == "tempctrl"
+        wait_for_condition(
+            lambda: peltier.last_status.get("sensor_name") == "tempctrl",
+            cadence_ms=peltier.EMULATOR_CADENCE_MS,
+        )
         for key in (
             "LNA_T_now",
             "LOAD_T_now",

--- a/picohost/tests/test_dummy_devices.py
+++ b/picohost/tests/test_dummy_devices.py
@@ -51,17 +51,18 @@ class TestDummyPicoDevice:
         """send_command() writes compact JSON + newline to the peer's read buffer."""
         device = DummyPicoDevice(port="/dev/ttyUSB0")
         cmd = {"cmd": "test", "value": 123}
-        assert device.send_command(cmd) is True
+        device.send_command(cmd)
 
         expected = json.dumps(cmd, separators=(",", ":")) + "\n"
         assert device.ser.peer.read(len(expected)) == expected.encode()
         device.disconnect()
 
-    def test_send_command_returns_false_when_disconnected(self):
-        """send_command() returns False when there is no active connection."""
+    def test_send_command_raises_when_disconnected(self):
+        """send_command() raises ConnectionError when no active connection."""
         device = DummyPicoDevice(port="/dev/ttyUSB0")
         device.disconnect()
-        assert device.send_command({"cmd": "test"}) is False
+        with pytest.raises(ConnectionError):
+            device.send_command({"cmd": "test"})
 
     def test_reader_thread_populates_last_status(self):
         """JSON written by the peer is parsed by the reader thread into last_status."""
@@ -153,10 +154,13 @@ class TestDummyPicoMotor:
         )
         motor.disconnect()
 
-    def test_status_populated_on_init(self):
-        """wait_for_updates() in __init__ ensures status is populated immediately."""
+    def test_status_populated_after_first_cycle(self):
+        """First emulator status cycle populates the required motor keys."""
         motor = DummyPicoMotor(port="/dev/ttyUSB0")
-        assert motor.last_status["sensor_name"] == "motor"
+        wait_for_condition(
+            lambda: motor.last_status.get("sensor_name") == "motor",
+            cadence_ms=motor.EMULATOR_CADENCE_MS,
+        )
         assert "az_pos" in motor.last_status
         assert "el_pos" in motor.last_status
         assert "az_target_pos" in motor.last_status
@@ -167,6 +171,9 @@ class TestDummyPicoMotor:
         """scan() returns motors to (0, 0) one at a time after finishing."""
         motor = DummyPicoMotor(port="/dev/ttyUSB0")
         cadence = motor.EMULATOR_CADENCE_MS
+        wait_for_condition(
+            lambda: "az_target_pos" in motor.last_status, cadence_ms=cadence
+        )
         motor.scan(
             az_range_deg=np.array([-10.0, 0.0, 10.0]),
             el_range_deg=np.array([-10.0, 0.0, 10.0]),
@@ -188,6 +195,10 @@ class TestDummyPicoMotor:
     def test_scan_does_not_home_on_interrupt(self):
         """scan() only halts (does not home) when interrupted."""
         motor = DummyPicoMotor(port="/dev/ttyUSB0")
+        wait_for_condition(
+            lambda: "az_target_pos" in motor.last_status,
+            cadence_ms=motor.EMULATOR_CADENCE_MS,
+        )
         # patch wait_for_stop to raise after the initial homing
         # (2 calls for home-az + home-el, then interrupt during scan)
         real_wait = motor.wait_for_stop
@@ -241,9 +252,7 @@ class TestDummyPicoRFSwitch:
         switch = DummyPicoRFSwitch(port="/dev/ttyUSB0")
         cadence = switch.EMULATOR_CADENCE_MS
         for state in switch.paths:
-            assert switch.switch(state) is True, (
-                f"switch('{state}') returned False"
-            )
+            switch.switch(state)
 
         # Verify the last state is reflected
         last_state = list(switch.paths.keys())[-1]
@@ -281,7 +290,7 @@ class TestDummyPicoPeltier:
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
         before = peltier.last_status.get("LNA_T_target")
-        assert peltier.set_temperature(T_LNA=25.5, LNA_hyst=0.5) is True
+        peltier.set_temperature(T_LNA=25.5, LNA_hyst=0.5)
         assert wait_for_settle(
             lambda: peltier.last_status.get("LNA_T_target"),
             initial=before,
@@ -296,11 +305,8 @@ class TestDummyPicoPeltier:
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
         before = peltier.last_status.get("LOAD_T_target")
-        assert (
-            peltier.set_temperature(
-                T_LNA=30.0, LNA_hyst=1.0, T_LOAD=25.0, LOAD_hyst=0.5
-            )
-            is True
+        peltier.set_temperature(
+            T_LNA=30.0, LNA_hyst=1.0, T_LOAD=25.0, LOAD_hyst=0.5
         )
         assert wait_for_settle(
             lambda: peltier.last_status.get("LOAD_T_target"),
@@ -315,7 +321,7 @@ class TestDummyPicoPeltier:
         """Enabling LNA and disabling LOAD is reflected in emulator status."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
-        assert peltier.set_enable(LNA=True, LOAD=False) is True
+        peltier.set_enable(LNA=True, LOAD=False)
         wait_for_condition(
             lambda: peltier.last_status.get("LNA_enabled") is True,
             cadence_ms=cadence,
@@ -327,7 +333,7 @@ class TestDummyPicoPeltier:
         """Enabling both channels is reflected in emulator status."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
-        assert peltier.set_enable(LNA=True, LOAD=True) is True
+        peltier.set_enable(LNA=True, LOAD=True)
         wait_for_condition(
             lambda: peltier.last_status.get("LNA_enabled") is True,
             cadence_ms=cadence,
@@ -339,7 +345,7 @@ class TestDummyPicoPeltier:
         """Disabling both channels is reflected in emulator status."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
         cadence = peltier.EMULATOR_CADENCE_MS
-        assert peltier.set_enable(LNA=False, LOAD=False) is True
+        peltier.set_enable(LNA=False, LOAD=False)
         wait_for_condition(
             lambda: peltier.last_status.get("LNA_enabled") is False,
             cadence_ms=cadence,
@@ -347,10 +353,13 @@ class TestDummyPicoPeltier:
         assert peltier.last_status["LOAD_enabled"] is False
         peltier.disconnect()
 
-    def test_status_populated_on_init(self):
-        """wait_for_updates() in PicoStatus.__init__ populates status immediately."""
+    def test_status_populated_after_first_cycle(self):
+        """First emulator status cycle populates the required peltier keys."""
         peltier = DummyPicoPeltier(port="/dev/ttyUSB0")
-        assert peltier.last_status["sensor_name"] == "tempctrl"
+        wait_for_condition(
+            lambda: peltier.last_status.get("sensor_name") == "tempctrl",
+            cadence_ms=peltier.EMULATOR_CADENCE_MS,
+        )
         assert "LNA_T_now" in peltier.last_status
         assert "LOAD_T_now" in peltier.last_status
         assert "LNA_drive_level" in peltier.last_status

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -90,9 +90,18 @@ RFSWITCH_FIELDS = {"sensor_name", "status", "app_id", "sw_state"}
 # --- Fixtures ---
 
 
+def _wait_for_first_status(device):
+    """Block until emulator has sent its first status packet."""
+    wait_for_condition(
+        lambda: bool(device.last_status),
+        cadence_ms=device.EMULATOR_CADENCE_MS,
+    )
+
+
 @pytest.fixture
 def motor():
     m = DummyPicoMotor("/dev/dummy")
+    _wait_for_first_status(m)
     yield m
     m.disconnect()
 
@@ -100,6 +109,7 @@ def motor():
 @pytest.fixture
 def rfswitch():
     s = DummyPicoRFSwitch("/dev/dummy")
+    _wait_for_first_status(s)
     yield s
     s.disconnect()
 
@@ -107,6 +117,7 @@ def rfswitch():
 @pytest.fixture
 def peltier():
     p = DummyPicoPeltier("/dev/dummy")
+    _wait_for_first_status(p)
     yield p
     p.disconnect()
 
@@ -114,6 +125,7 @@ def peltier():
 @pytest.fixture
 def imu():
     i = DummyPicoIMU("/dev/dummy")
+    _wait_for_first_status(i)
     yield i
     i.disconnect()
 
@@ -121,6 +133,7 @@ def imu():
 @pytest.fixture
 def tempmon():
     m = DummyPicoTempMon("/dev/dummy")
+    _wait_for_first_status(m)
     yield m
     m.disconnect()
 
@@ -128,6 +141,7 @@ def tempmon():
 @pytest.fixture
 def lidar():
     d = DummyPicoLidar("/dev/dummy")
+    _wait_for_first_status(d)
     yield d
     d.disconnect()
 

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -172,7 +172,7 @@ class TestRouteCommand:
             pico, "rfswitch", {"action": "switch", "state": "RFANT"}
         )
         assert result["action"] == "switch"
-        assert result["result"] is True
+        assert result["result"] is None
 
     @pytest.mark.parametrize("action", sorted(_BLOCKED_ACTIONS))
     def test_blocked_actions_rejected(self, mgr, action):
@@ -202,7 +202,7 @@ class TestRouteCommand:
             {"action": "set_temperature", "T_LNA": 25.0, "LNA_hyst": 0.5},
         )
         assert result["action"] == "set_temperature"
-        assert result["result"] is True
+        assert result["result"] is None
 
 
 # --- _process_command -----------------------------------------------------
@@ -675,34 +675,6 @@ class TestReconnectHook:
         switch.usb_serial = ""
         switch._rediscover_port()
         assert switch.port == original_port
-
-
-class _StubDevice:
-    """Bare attribute holder for testing wait_for_updates in isolation."""
-
-    def __init__(self):
-        self.last_status = {}
-        self.name = "stub"
-
-
-class TestTimeoutError:
-    """
-    Both wait_for_updates methods used to use ``assert``, which gets
-    stripped under ``python -O``. They now raise TimeoutError; verify
-    that explicitly.
-    """
-
-    def test_peltier_wait_for_updates_raises_timeout(self):
-        from picohost.base import PicoPeltier
-
-        with pytest.raises(TimeoutError, match="No status"):
-            PicoPeltier.wait_for_updates(_StubDevice(), timeout=0.05)
-
-    def test_motor_wait_for_updates_raises_timeout(self):
-        from picohost.motor import PicoMotor
-
-        with pytest.raises(TimeoutError, match="No status"):
-            PicoMotor.wait_for_updates(_StubDevice(), timeout=0.05)
 
 
 # --- module-level constants -----------------------------------------------

--- a/picohost/tests/test_manager_integration.py
+++ b/picohost/tests/test_manager_integration.py
@@ -534,10 +534,9 @@ class TestDiscoverIntegration:
         pico = mgr.picos["rfswitch"]
         assert pico.is_connected
         wait_for_condition(
-            lambda: pico.last_status_time is not None,
+            lambda: pico.last_status.get("sensor_name") == "rfswitch",
             cadence_ms=CADENCE_MS,
         )
-        assert pico.last_status["sensor_name"] == "rfswitch"
         # Status should also flow to add_metadata.
         mock = mgr.eig_redis
         wait_for_condition(

--- a/picohost/tests/test_motor_commands.py
+++ b/picohost/tests/test_motor_commands.py
@@ -2,13 +2,22 @@
 Tests for motor control commands.
 """
 
+from conftest import wait_for_condition
 from picohost.testing import DummyPicoMotor
+
+
+def _wait_for_status(motor):
+    wait_for_condition(
+        lambda: "az_target_pos" in motor.last_status,
+        cadence_ms=motor.EMULATOR_CADENCE_MS,
+    )
 
 
 class TestDummyPicoMotor:
     def test_motor_move_command(self):
         """Test motor move command generation."""
         motor = DummyPicoMotor("/dev/ttyACM0")
+        _wait_for_status(motor)
 
         deg_az = 5.0
         deg_el = 10.0
@@ -26,6 +35,7 @@ class TestDummyPicoMotor:
     def test_motor_move_defaults(self):
         """Test motor move with default delay values."""
         motor = DummyPicoMotor("/dev/ttyACM0")
+        _wait_for_status(motor)
 
         deg_az = 3.0
         deg_el = 4.0


### PR DESCRIPTION
## Summary

Follow-up to #50 (merged). Hardens `PicoMotor` / `PicoDevice` so firmware-silent-but-serial-open no longer presents as silent success + eventual `KeyError`.

- **TX:** `PicoDevice.send_command` now raises `ConnectionError` on disconnect or write failure instead of returning a discarded `bool`. `PicoRFSwitch.switch` and `PicoPeltier.set_temperature`/`set_enable`/`set_clamp`/`set_watchdog_timeout` drop their bool return (success = didn't raise). `PicoPeltier` keepalive thread swallows `ConnectionError` so it survives brief disconnects.
- **RX:** `PicoMotor._require_status()` guards `az_move_steps`, `el_move_steps`, `is_moving`, `wait_for_stop` with a clear `RuntimeError("No status from ... yet")` instead of `KeyError` from bare subscripts.
- **Constructor handshake:** `PicoMotor.wait_for_updates` and `PicoPeltier.wait_for_updates` removed (they were masking the RX issue above). `"wait_for_updates"` dropped from `manager._BLOCKED_ACTIONS`.
- **Latent race fix:** `DummyPicoDevice.connect` now stamps `last_status_time` on open, mirroring real `_open_serial`. Closes a race in `test_proxy.py` where the manager health loop fired a reconnect before the emulator's first status arrived — previously hidden by the old silent-False `send_command`.
- **Scripts:** `motor_manual.py` catches `ConnectionError`/`RuntimeError` around key dispatch and shutdown `halt()`. `motor_control.py` uses a `_try_halt` helper; `set_delay` failure exits cleanly.

## Test plan

- [x] `pytest` — 274 passed
- [ ] Manual smoke on hardware:
  - [ ] `PicoMotor(...)` no longer blocks 10s on missing status
  - [ ] `m.az_move_steps(100)` on fresh instance raises `RuntimeError("No status from ... yet")` before first status
  - [ ] `m.halt()` with USB unplugged raises `ConnectionError`
  - [ ] `motor_manual.py`: unplug mid-session → `DISCONNECTED` banner; replug → live status resumes; Ctrl-C during disconnect exits cleanly
  - [ ] `PicoPeltier` watchdog does not trip under normal operation (keepalive still fires every ~10s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)