### PR TITLE
feat(picohost)!: depend on eigsep_redis directly, not eigsep_observing

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
   "numpy",
   "pyserial",
+  "eigsep_redis>=0.1.0",
 ]
 
 [project.scripts]

--- a/picohost/scripts/motor_control.py
+++ b/picohost/scripts/motor_control.py
@@ -6,7 +6,7 @@ and an infinite scanning mode.
 
 import json
 import numpy as np
-from eigsep_observing import EigsepRedis
+from eigsep_redis import EigsepRedis
 
 from picohost import PicoMotor
 

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -711,11 +711,11 @@ def main():
     )
 
     try:
-        from eigsep_observing import EigsepRedis
+        from eigsep_redis import EigsepRedis
     except ImportError:
         print(
-            "eigsep_observing is required to run PicoManager.\n"
-            "Install it with: pip install eigsep_observing",
+            "eigsep_redis is required to run PicoManager.\n"
+            "Install it with: pip install eigsep_redis",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
`eigsep_redis` is now a sibling repo:
https://github.com/EIGSEP/eigsep_redis

Previously picohost imported `EigsepRedis` from `eigsep_observing`, which forced any picohost install to pull in h5py, flask, eigsep-vna, and picohost itself just to reach the Redis handler. The new sibling package exposes the bus primitives alone.

Changes:
- pyproject.toml: add `eigsep_redis>=0.1.0` as a runtime dep (was previously undeclared — picohost imported EigsepRedis at runtime in manager.py and scripts/motor_control.py without declaring the dep).
- src/picohost/manager.py: swap the lazy import from `eigsep_observing` to `eigsep_redis`. Update the error message to match.
- scripts/motor_control.py: same import-path swap.

Behavior unchanged — `EigsepRedis` is the same shim class that hosted `add_metadata`, now served from its new home. The `add_metadata` call in `base.py:65` continues to work via the shim; migrating it to `MetadataWriter.add` will retire the shim in a follow-up PR.

BREAKING CHANGE: picohost now requires `eigsep_redis` in addition to (or instead of) `eigsep_observing`.