### PR TITLE
feat(picohost)!: rebuild Redis surface on eigsep_redis writer/reader classes

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "pytest-cov",
   "pytest-timeout",
   "pyserial-mock==1.0.0",
+  "fakeredis",
 ]
 
 [tool.setuptools]

--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
   "numpy",
   "pyserial",
-  "eigsep_redis>=0.1.0",
+  "eigsep_redis>=2.1.0",
 ]
 
 [project.scripts]
@@ -35,7 +35,7 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest-timeout",
-  "pyserial-mock==1.0.0",
+  "pyserial-mock>=1.0.0",
   "fakeredis",
 ]
 

--- a/picohost/scripts/flash-picos
+++ b/picohost/scripts/flash-picos
@@ -1,8 +1,0 @@
-#!/usr/bin/python3
-# -*- coding: utf-8 -*-
-import re
-import sys
-from picohost.flash_picos import main
-if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
-    sys.exit(main())

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -21,19 +21,23 @@ PICO_PID_CDC = 0x0009  # CDC mode (serial)
 PICO_PID_BOOTSEL = 0x0003  # BOOTSEL mode
 
 
-def redis_handler(redis):
+def redis_handler(writer):
     """
-    Create a handler function to upload data to Redis.
+    Create a handler function that publishes a status dict via a
+    :class:`eigsep_redis.MetadataWriter`.
 
     Parameters
     ----------
-    redis : EigsepRedis
-        Custom EIGSEP Redis client instance.
+    writer : eigsep_redis.MetadataWriter
+        The metadata bus writer to publish through. The ``sensor_name``
+        field on each data dict is used as the metadata key (so
+        ``stream:{sensor_name}`` carries the per-sensor history and
+        ``metadata[sensor_name]`` holds the live snapshot).
 
     Returns
     -------
     handler : callable
-        Function that takes a data dictionary and uploads it to Redis.
+        Function that takes a data dictionary and publishes it.
 
     Notes
     -----
@@ -62,7 +66,7 @@ def redis_handler(redis):
         except KeyError:
             logger.error("Data does not contain 'sensor_name' key")
             return
-        redis.add_metadata(name, data)
+        writer.add(name, data)
 
     return handler
 
@@ -78,7 +82,7 @@ class PicoDevice:
         baudrate: int = 115200,
         timeout: float = 5.0,
         name=None,
-        eig_redis=None,
+        metadata_writer=None,
         response_handler=None,
         usb_serial: str = "",
         verbose: bool = False,
@@ -91,7 +95,8 @@ class PicoDevice:
             baudrate: Serial baud rate (default: 115200)
             timeout: Serial read timeout in seconds (default: 5.0)
             name: str
-            eig_redis: EigsepRedis instance
+            metadata_writer: eigsep_redis.MetadataWriter instance, or
+                ``None`` to disable Redis publication.
             usb_serial: USB serial number for port re-discovery
             verbose: log each received status packet at DEBUG level
         """
@@ -113,8 +118,8 @@ class PicoDevice:
         else:
             self.name = name
 
-        if eig_redis is not None:
-            self.redis_handler = redis_handler(eig_redis)
+        if metadata_writer is not None:
+            self.redis_handler = redis_handler(metadata_writer)
         else:
             self.redis_handler = None
         self.connect()
@@ -495,7 +500,7 @@ class PicoPeltier(PicoDevice):
         verbose=False,
         timeout=5.0,
         name=None,
-        eig_redis=None,
+        metadata_writer=None,
         keepalive_interval=10.0,
         usb_serial="",
     ):
@@ -504,8 +509,8 @@ class PicoPeltier(PicoDevice):
         ----------
         port : str
             Serial port device.
-        eig_redis : EigsepRedis
-            Redis client instance.
+        metadata_writer : eigsep_redis.MetadataWriter, optional
+            Metadata bus writer. ``None`` disables Redis publication.
         verbose : bool, optional
             Enable verbose output.
         timeout : float, optional
@@ -524,7 +529,7 @@ class PicoPeltier(PicoDevice):
             port,
             timeout=timeout,
             name=name,
-            eig_redis=eig_redis,
+            metadata_writer=metadata_writer,
             usb_serial=usb_serial,
             verbose=verbose,
         )
@@ -634,7 +639,7 @@ class PicoPotentiometer(PicoDevice):
         calibration_file=None,
         timeout=5.0,
         name=None,
-        eig_redis=None,
+        metadata_writer=None,
         usb_serial="",
     ):
         """
@@ -648,8 +653,8 @@ class PicoPotentiometer(PicoDevice):
         timeout : float
             Serial read timeout in seconds (default: 5.0).
         name : str, optional
-        eig_redis : EigsepRedis, optional
-            EigsepRedis response handler (default: None).
+        metadata_writer : eigsep_redis.MetadataWriter, optional
+            Metadata bus writer. ``None`` disables Redis publication.
         usb_serial : str, optional
             USB serial number for port re-discovery.
         """
@@ -658,7 +663,7 @@ class PicoPotentiometer(PicoDevice):
             port,
             timeout=timeout,
             name=name,
-            eig_redis=eig_redis,
+            metadata_writer=metadata_writer,
             usb_serial=usb_serial,
         )
         if calibration_file is not None:

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -49,7 +49,7 @@ class PicoConfigStore:
     ``{"devices": [...], "upload_time": ...}`` — a *list* of device
     dicts is stored under the ``devices`` key so the canonical
     ``upload_time`` field injected by
-    :meth:`Transport._upload_dict` stays at the top level next to
+    :meth:`Transport.upload_dict` stays at the top level next to
     it.
 
     ``flash-picos`` uploads the list after every flash pass. The
@@ -71,7 +71,7 @@ class PicoConfigStore:
             Each dict must carry ``app_id``, ``port``, and
             ``usb_serial`` (extra fields are preserved verbatim).
         """
-        self.transport._upload_dict({"devices": list(devices)}, PICO_CONFIG_KEY)
+        self.transport.upload_dict({"devices": list(devices)}, PICO_CONFIG_KEY)
 
     def get(self):
         """Return the stored device list.

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -1,0 +1,233 @@
+"""
+Redis bus surfaces owned by picohost.
+
+Mirrors the ``CorrWriter`` / ``CorrReader`` / ``CorrConfigStore``
+pattern in ``eigsep_observing.corr``: each class takes an
+``eigsep_redis.Transport`` at construction, and the concerns are
+split into the smallest stable surface per bus.
+
+Four buses here:
+
+- :class:`PicoConfigStore` — persistent single-key blob holding the
+  list of picos (app id, serial port, usb serial) written once by
+  ``flash-picos`` and read on manager boot as the source of truth.
+- :class:`PicoCmdReader` — blocking reader for the pico command
+  stream. Consumed by the manager's command-relay thread.
+- :class:`PicoRespWriter` — writer for the pico response stream.
+  Every command yields exactly one response entry, correlated by
+  ``request_id``.
+- :class:`PicoClaimStore` — TTL-backed soft claims for per-device
+  ownership. Claims are advisory and the stream reader never
+  rejects a command for claim reasons; the store exists so a
+  consumer that wants to coordinate can see who currently holds
+  a device.
+
+Per-device liveness is tracked via
+``eigsep_redis.HeartbeatWriter(transport, name=pico_heartbeat_name(dev))``
+— one heartbeat key per pico. There is no picohost-owned heartbeat
+class because the eigsep_redis surface already fits.
+"""
+
+import json
+import logging
+
+from .keys import (
+    PICO_CMD_STREAM,
+    PICO_CONFIG_KEY,
+    PICO_RESP_STREAM,
+    pico_claim_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PicoConfigStore:
+    """
+    Persistent single-key store for the pico device list.
+
+    The value under :data:`PICO_CONFIG_KEY` is a JSON object
+    ``{"devices": [...], "upload_time": ...}`` — a *list* of device
+    dicts is stored under the ``devices`` key so the canonical
+    ``upload_time`` field injected by
+    :meth:`Transport._upload_dict` stays at the top level next to
+    it.
+
+    ``flash-picos`` uploads the list after every flash pass. The
+    manager reads it once at boot and treats it as the source of
+    truth; if it's missing, the manager falls back to running
+    ``flash-and-discover`` itself and writes the result back with
+    :meth:`upload`.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload(self, devices):
+        """Upload the device list.
+
+        Parameters
+        ----------
+        devices : list of dict
+            Each dict must carry ``app_id``, ``port``, and
+            ``usb_serial`` (extra fields are preserved verbatim).
+        """
+        self.transport._upload_dict({"devices": list(devices)}, PICO_CONFIG_KEY)
+
+    def get(self):
+        """Return the stored device list.
+
+        Returns
+        -------
+        list of dict or None
+            ``None`` if no config has been uploaded, or if the stored
+            JSON fails to decode — the manager then falls back to
+            flash-and-discover.
+        """
+        raw = self.transport.get_raw(PICO_CONFIG_KEY)
+        if raw is None:
+            return None
+        try:
+            blob = json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Corrupted {PICO_CONFIG_KEY} in Redis ({e}); "
+                "falling back to flash-and-discover."
+            )
+            return None
+        return blob.get("devices", [])
+
+    def clear(self):
+        """Delete the stored config. Used by ``--clear-config``."""
+        self.transport.r.delete(PICO_CONFIG_KEY)
+
+
+class PicoCmdReader:
+    """
+    Blocking reader for the pico command stream.
+
+    Mirrors :class:`eigsep_redis.StatusReader` — a single
+    hard-coded stream (:data:`PICO_CMD_STREAM`) with per-transport
+    last-read-id tracking so independent readers don't race. Only
+    the manager's command-relay thread is expected to call
+    :meth:`read`; other consumers should talk to
+    :class:`PicoRespWriter` via the response stream.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    @property
+    def stream(self):
+        """``{PICO_CMD_STREAM: last_read_id}`` — view, used for blocking reads."""
+        return {
+            PICO_CMD_STREAM: self.transport._get_last_read_id(PICO_CMD_STREAM)
+        }
+
+    def read(self, timeout=1.0, count=10):
+        """Blocking read of up to ``count`` command entries.
+
+        Parameters
+        ----------
+        timeout : float
+            Maximum seconds to block waiting for new entries. ``0``
+            returns immediately; any positive value is converted to
+            milliseconds for Redis' ``XREAD BLOCK``.
+        count : int
+            Maximum number of entries to consume in one call.
+
+        Returns
+        -------
+        list of (bytes, dict)
+            ``[(msg_id, fields), ...]``. Empty list on timeout.
+            ``fields`` keys and values are bytes exactly as returned
+            by redis-py; decoding is the caller's responsibility.
+        """
+        block_time = int(timeout * 1000) if timeout else 0
+        result = self.transport.r.xread(
+            self.stream, block=block_time, count=count
+        )
+        if not result:
+            return []
+        # Single-stream read → result has exactly one (stream, messages) tuple.
+        _stream, messages = result[0]
+        last_id = messages[-1][0]
+        self.transport._set_last_read_id(PICO_CMD_STREAM, last_id)
+        return messages
+
+
+class PicoRespWriter:
+    """Writer for the pico response stream.
+
+    Every processed command yields one entry on
+    :data:`PICO_RESP_STREAM` carrying the command's ``target``,
+    ``source``, ``request_id``, ``status`` (``"ok"``/``"error"``),
+    and JSON-encoded ``data`` payload. An optional ``warning``
+    field is included when present (used today to signal that a
+    non-owner overrode a soft claim).
+
+    The stream is intentionally not length-bounded: response
+    volume tracks command volume — bounded by the caller — and
+    a dead consumer starving its own responses is a bug, not a
+    failure mode to paper over.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def send(self, target, source, request_id, status, data, warning=None):
+        """Publish one response entry.
+
+        Parameters
+        ----------
+        target : str
+        source : str
+        request_id : str
+        status : str
+            ``"ok"`` or ``"error"``.
+        data : dict
+            JSON-serializable payload.
+        warning : str or None
+            Optional advisory message attached to an otherwise-ok
+            response (e.g. claim override).
+        """
+        entry = {
+            "target": target,
+            "source": source,
+            "request_id": request_id,
+            "status": status,
+            "data": json.dumps(data),
+        }
+        if warning is not None:
+            entry["warning"] = warning
+        self.transport.r.xadd(PICO_RESP_STREAM, entry)
+
+
+class PicoClaimStore:
+    """TTL-backed soft claim store.
+
+    Claims are advisory — a non-owner can still send commands, and
+    the response stream simply tags such overrides with a
+    ``warning`` field. The store exists so a coordinator (e.g. an
+    observing loop) can see which device is currently held and by
+    whom, and releases itself when its TTL expires.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def set(self, device, owner, ttl):
+        """Register ``owner`` as holding ``device`` for ``ttl`` seconds."""
+        self.transport.r.set(pico_claim_key(device), owner, ex=int(ttl))
+
+    def get(self, device):
+        """Return the current owner string, or ``None`` if unclaimed."""
+        raw = self.transport.r.get(pico_claim_key(device))
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            return raw.decode("utf-8")
+        return str(raw)
+
+    def delete(self, device):
+        """Drop any existing claim on ``device``."""
+        self.transport.r.delete(pico_claim_key(device))

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 import argparse
+import json
 import logging
 import subprocess
-import time
 import sys
-import json
+import time
 from pathlib import Path
+
+from eigsep_redis import Transport
 from serial import Serial
 from serial.tools import list_ports
+
+from .buses import PicoConfigStore
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +36,7 @@ def find_pico_ports():
 def flash_uf2(uf2_path, serial):
     """
     Flash the UF2 onto the Pico whose USB serial number is `serial`,
-    using picotool’s --ser selector.
+    using picotool's --ser selector.
     """
     cmd = f"picotool load -f --ser {serial} -x {uf2_path}".split()
     print(f"Flashing {uf2_path} → serial={serial}")
@@ -130,11 +134,24 @@ def flash_and_discover(
     return all_devices
 
 
+def _publish_to_redis(devices, host, port):
+    """Publish *devices* to Redis via :class:`PicoConfigStore`.
+
+    Returns the :class:`PicoConfigStore` on success. Raises on
+    connection failure so ``main`` can fall back to file output if the
+    user asked for that.
+    """
+    transport = Transport(host=host, port=port)
+    store = PicoConfigStore(transport)
+    store.upload(devices)
+    return store
+
+
 def main():
     p = argparse.ArgumentParser(
         description=(
-            "Flash all attached Picos, read JSON from each, save to single "
-            "file."
+            "Flash all attached Picos, read JSON from each, and publish "
+            "the device list to Redis (source of truth for PicoManager)."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -159,11 +176,38 @@ def main():
         help="Seconds to wait for each Pico's JSON",
     )
     p.add_argument(
-        "--output",
-        default="pico_config.json",
-        help="Output JSON file",
+        "--redis-host",
+        default="localhost",
+        help="Redis host for PicoConfigStore publication",
+    )
+    p.add_argument(
+        "--redis-port",
+        type=int,
+        default=6379,
+        help="Redis port for PicoConfigStore publication",
+    )
+    p.add_argument(
+        "--no-redis",
+        action="store_true",
+        help=(
+            "Skip Redis publication. Use with --output-file for offline "
+            "provisioning on a host without Redis."
+        ),
+    )
+    p.add_argument(
+        "--output-file",
+        default=None,
+        help=(
+            "Optional: also write the device list to this JSON file. "
+            "Not required — PicoManager reads from Redis directly."
+        ),
     )
     args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
 
     try:
         all_devices = flash_and_discover(
@@ -180,12 +224,25 @@ def main():
         print("No devices discovered.", file=sys.stderr)
         sys.exit(1)
 
-    with open(args.output, "w") as f:
-        json.dump(all_devices, f, indent=2)
-    print(
-        f"Wrote all device information to {args.output} ({len(all_devices)} "
-        "devices)."
-    )
+    if not args.no_redis:
+        try:
+            _publish_to_redis(all_devices, args.redis_host, args.redis_port)
+            print(
+                f"Published {len(all_devices)} device(s) to Redis at "
+                f"{args.redis_host}:{args.redis_port} (key: pico_config)."
+            )
+        except Exception as e:
+            print(
+                f"Redis publication failed: {e}\n"
+                "Re-run with --no-redis (and optionally --output-file) if "
+                "Redis is not available.",
+                file=sys.stderr,
+            )
+
+    if args.output_file:
+        with open(args.output_file, "w") as f:
+            json.dump(all_devices, f, indent=2)
+        print(f"Wrote {len(all_devices)} device(s) to {args.output_file}.")
 
 
 if __name__ == "__main__":

--- a/picohost/src/picohost/keys.py
+++ b/picohost/src/picohost/keys.py
@@ -1,0 +1,32 @@
+"""
+Central registry of Redis keys owned by picohost.
+
+Mirrors the layout of ``eigsep_redis.keys`` and
+``eigsep_observing.keys``: every key/stream/set/prefix touched by
+this package lives here so collisions are visible at import time
+and new names can be audited in one place. None of these overlap
+with eigsep_redis (``metadata``, ``stream:status``, ``config``, …)
+or eigsep_observing (``stream:corr``, ``corr_config``, …).
+"""
+
+PICO_CONFIG_KEY = "pico_config"
+PICO_CMD_STREAM = "stream:pico_cmd"
+PICO_RESP_STREAM = "stream:pico_resp"
+PICO_CLAIM_PREFIX = "pico_claim"
+PICO_HEARTBEAT_PREFIX = "pico"
+
+
+def pico_heartbeat_name(device):
+    """Return the name of the HeartbeatWriter for a given device.
+
+    The writer renders the key as ``heartbeat:{name}``; with the
+    ``pico:`` prefix the final key is ``heartbeat:pico:{device}`` —
+    which keeps per-device liveness out of the same namespace as the
+    panda client heartbeat (``heartbeat:client``).
+    """
+    return f"{PICO_HEARTBEAT_PREFIX}:{device}"
+
+
+def pico_claim_key(device):
+    """Return the soft-claim key for a given device."""
+    return f"{PICO_CLAIM_PREFIX}:{device}"

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -1,24 +1,48 @@
 """
 PicoManager - standalone service that owns all pico serial connections.
 
-The manager discovers devices from a ``pico_config.json`` produced by
-``flash-picos``, instantiates the matching :class:`PicoDevice` subclass
-for each one, monitors device health (reconnecting on serial drops),
-and relays commands from a Redis stream so that other processes can
-talk to picos without holding the serial port themselves.
+Redis is the source of truth. ``flash-picos`` writes the discovered
+device list into ``PicoConfigStore`` on the host side; the manager
+boots, reads that list, instantiates the matching :class:`PicoDevice`
+subclass per entry, and then exposes each device to the rest of the
+system through four bus surfaces (all from ``eigsep_redis`` /
+``picohost.buses``):
+
+- :class:`eigsep_redis.MetadataWriter` — per-sensor firmware status
+  (the 200 ms JSON packets) is republished onto ``stream:{sensor}``
+  and the ``metadata`` snapshot hash, same as every other sensor in
+  the system.
+- :class:`eigsep_redis.HeartbeatWriter` — per-device liveness under
+  ``heartbeat:pico:{name}`` with a TTL, so a consumer that loses its
+  view of a pico (or of the manager itself) detects it within the
+  TTL window via :class:`eigsep_redis.HeartbeatReader.check`.
+- :class:`eigsep_redis.StatusWriter` — manager-level log events
+  (discover, reconnect, stop) land on ``stream:status`` alongside
+  every other service's events.
+- :class:`picohost.buses.PicoCmdReader` /
+  :class:`picohost.buses.PicoRespWriter` /
+  :class:`picohost.buses.PicoClaimStore` — command/response stream
+  with soft claim ownership, the one surface that is picohost-specific
+  and has no eigsep_observing analogue.
 
 Usage:
-    python -m picohost.manager [--config pico_config.json] [--log-level INFO]
+    python -m picohost.manager [--uf2 build/pico_multi.uf2] [--log-level INFO]
 """
 
 import argparse
 import json
 import logging
 import signal
-import sys
 import threading
 import time
 from pathlib import Path
+
+from eigsep_redis import (
+    HeartbeatWriter,
+    MetadataWriter,
+    StatusWriter,
+    Transport,
+)
 
 from .base import (
     PicoDevice,
@@ -28,13 +52,20 @@ from .base import (
     PicoPotentiometer,
     PicoRFSwitch,
 )
+from .buses import (
+    PicoClaimStore,
+    PicoCmdReader,
+    PicoConfigStore,
+    PicoRespWriter,
+)
+from .keys import pico_heartbeat_name
 from .motor import PicoMotor
 
 logger = logging.getLogger(__name__)
 
 # Map firmware app_id (from src/pico_multi.h) to a logical device name.
-# Names are used as Redis keys and as the "target" field in command
-# stream entries — they must stay stable across releases.
+# Names are used as metadata/heartbeat keys and as the "target" field in
+# command stream entries — they must stay stable across releases.
 APP_NAMES = {
     0: "motor",
     1: "tempctrl",
@@ -59,16 +90,13 @@ PICO_CLASSES = {
     "rfswitch": PicoRFSwitch,
 }
 
-# Redis keys
-PICOS_SET = "picos"
-HEALTH_HASH = "pico_health"
-CONFIG_HASH = "pico_config"
-CMD_STREAM = "stream:pico_cmd"
-RESP_STREAM = "stream:pico_resp"
-
 # Timing
 HEALTH_CHECK_INTERVAL = 5.0  # seconds between health checks
 HEALTH_TIMEOUT = 10.0  # seconds without status before unhealthy
+# Heartbeat TTL is 4× the check interval so a single missed tick
+# (or a reconnection storm that blocks one pass) doesn't expire the
+# key before the next tick has a chance to re-assert liveness.
+HEARTBEAT_TTL = int(HEALTH_CHECK_INTERVAL * 4)
 CLAIM_TTL = 300  # default soft-claim TTL in seconds
 
 # Methods that must not be invoked via the command stream. These are
@@ -95,49 +123,53 @@ class PicoManager:
     """
     Standalone service that owns all pico serial connections.
 
-    Discovers devices from a config file, monitors their health, and
-    relays commands from a Redis stream to the right device.
+    Discovers devices from the Redis :class:`PicoConfigStore`,
+    monitors their health via per-device heartbeats, and relays
+    commands from :class:`PicoCmdReader` to the right
+    :class:`PicoDevice`.
     """
 
     def __init__(
         self,
-        eig_redis,
-        config_file="pico_config.json",
+        transport,
         uf2_path="build/pico_multi.uf2",
-        use_redis_config=True,
     ):
         """
         Parameters
         ----------
-        eig_redis : EigsepRedis or redis.Redis
-            Redis client used both as the source for incoming commands
-            and as the publication target for status, health, and
-            command responses. Either an :class:`EigsepRedis` (which
-            exposes the underlying client as ``.r``) or a bare
-            ``redis.Redis`` is accepted.
-        config_file : str or Path
-            Path to ``pico_config.json`` produced by ``flash-picos``.
+        transport : eigsep_redis.Transport
+            Shared transport used to construct every bus writer/reader
+            this manager needs. The same instance underpins
+            :class:`MetadataWriter` (passed to each ``PicoDevice``),
+            per-device :class:`HeartbeatWriter`,
+            :class:`StatusWriter`, :class:`PicoConfigStore`,
+            :class:`PicoCmdReader`, :class:`PicoRespWriter`, and
+            :class:`PicoClaimStore`.
         uf2_path : str or Path
-            Path to the UF2 firmware file for auto-flashing.
-        use_redis_config : bool
-            If ``True`` (default), check Redis for existing config
-            before falling back to the file/flash.
+            Path to the UF2 firmware file for auto-flashing when
+            Redis is empty at boot.
         """
-        self.eig_redis = eig_redis
-        self.config_file = Path(config_file)
+        self.transport = transport
         self.uf2_path = Path(uf2_path)
-        self.use_redis_config = use_redis_config
         self.picos = {}
+        self._heartbeats = {}
+        self._metadata_writer = MetadataWriter(transport)
+        self._config_store = PicoConfigStore(transport)
+        self._cmd_reader = PicoCmdReader(transport)
+        self._resp_writer = PicoRespWriter(transport)
+        self._claim_store = PicoClaimStore(transport)
+        self._status_writer = StatusWriter(transport)
         self._running = False
         self._health_thread = None
         self._cmd_thread = None
+        # Serializes mutations of self.picos / self._heartbeats between
+        # the health thread and the cmd thread (rediscover). Without it,
+        # a rediscover teardown can run concurrently with an in-flight
+        # reconnect on the same serial connection, and heartbeats popped
+        # by rediscover can be reasserted alive by a lingering health
+        # iteration.
+        self._lock = threading.Lock()
         self.logger = logger
-
-    def _redis(self):
-        """Return the underlying ``redis.Redis`` client."""
-        if hasattr(self.eig_redis, "r"):
-            return self.eig_redis.r
-        return self.eig_redis
 
     @staticmethod
     def _decode(value):
@@ -146,110 +178,37 @@ class PicoManager:
             return value.decode("utf-8")
         return str(value) if value is not None else ""
 
+    def _status(self, msg, level=logging.INFO):
+        """Log *msg* and mirror it onto the shared status stream."""
+        self.logger.log(level, msg)
+        try:
+            self._status_writer.send(msg, level=level)
+        except Exception as e:  # pragma: no cover - don't mask bugs behind status
+            self.logger.warning(f"Failed to publish status: {e}")
+
     # --- Discovery & Config ---
 
     def discover(self):
         """
-        Discover pico devices using a cascading config strategy:
+        Resolve the device list and instantiate devices.
 
-        1. Redis ``CONFIG_HASH`` (previous run persisted config)
-        2. JSON config file on disk
-        3. Flash-and-discover (if UF2 exists)
-
-        After any source succeeds the config is written back to both
-        Redis (via :meth:`_register_devices`) and the JSON file (via
-        :meth:`_save_config_to_file`).
+        1. Read :class:`PicoConfigStore` from Redis. If non-empty,
+           register those devices.
+        2. If empty, run :func:`flash_picos.flash_and_discover` and
+           publish the result back into the config store.
         """
-        devices = (
-            self._load_config_from_redis() if self.use_redis_config else None
-        )
+        devices = self._config_store.get()
         if devices:
-            self.logger.info(f"Loaded {len(devices)} device(s) from Redis")
+            self._status(f"Loaded {len(devices)} device(s) from Redis")
             self._register_devices(devices)
-            self._save_config_to_file(devices)
-            return
-
-        devices = self._load_config_from_file()
-        if devices:
-            self.logger.info(
-                f"Loaded {len(devices)} device(s) from config file"
-            )
-            self._register_devices(devices)
-            self._save_config_to_file(devices)
             return
 
         self._try_flash_discover()
         if self.picos:
-            devices = self._current_device_list()
-            self._save_config_to_file(devices)
-
-    def _load_config_from_redis(self):
-        """
-        Try to load device config from the Redis ``CONFIG_HASH``.
-
-        Returns
-        -------
-        list[dict] or None
-            Device config dicts if Redis has config, ``None`` otherwise.
-        """
-        r = self._redis()
-        try:
-            raw = r.hgetall(CONFIG_HASH)
-        except Exception as e:
-            self.logger.warning(f"Failed to read config from Redis: {e}")
-            return None
-
-        if not raw:
-            return None
-
-        devices = []
-        for name, blob in raw.items():
-            blob = self._decode(blob)
-            try:
-                devices.append(json.loads(blob))
-            except json.JSONDecodeError:
-                self.logger.warning(
-                    f"Invalid JSON in Redis config for {self._decode(name)}"
-                )
-        return devices if devices else None
-
-    def _load_config_from_file(self):
-        """
-        Read the device list from the JSON config file.
-
-        Returns
-        -------
-        list[dict] or None
-            Device config dicts if the file is valid, ``None`` otherwise.
-        """
-        if not self.config_file.exists():
-            self.logger.warning(f"Config file {self.config_file} not found")
-            return None
-
-        with open(self.config_file) as f:
-            try:
-                devices = json.load(f)
-            except json.JSONDecodeError as e:
-                self.logger.error(f"Invalid JSON in config file: {e}")
-                return None
-
-        return devices if devices else None
-
-    def _save_config_to_file(self, devices):
-        """Persist the device list to the JSON config file."""
-        try:
-            with open(self.config_file, "w") as f:
-                json.dump(devices, f, indent=2)
-            self.logger.debug(
-                f"Wrote {len(devices)} device(s) to {self.config_file}"
-            )
-        except OSError as e:
-            self.logger.warning(
-                f"Could not write config file {self.config_file}: {e}"
-            )
+            self._config_store.upload(self._current_device_list())
 
     def _current_device_list(self):
-        """Build a device list from currently registered picos."""
+        """Build a list of device dicts from currently registered picos."""
         devices = []
         for name, pico in self.picos.items():
             app_id = APP_IDS.get(name, -1)
@@ -263,11 +222,8 @@ class PicoManager:
         return devices
 
     def _register_devices(self, devices):
-        """
-        Instantiate the matching :class:`PicoDevice` subclass for each
-        entry in *devices* and publish to Redis.
-        """
-        r = self._redis()
+        """Instantiate each :class:`PicoDevice` and publish an initial
+        heartbeat."""
         for dev_info in devices:
             app_id = dev_info.get("app_id")
             port = dev_info.get("port")
@@ -291,39 +247,23 @@ class PicoManager:
             try:
                 pico = cls(
                     port,
-                    eig_redis=self.eig_redis,
+                    metadata_writer=self._metadata_writer,
                     name=name,
                     usb_serial=usb_serial,
                 )
                 self.picos[name] = pico
-                r.sadd(PICOS_SET, name)
-                r.hset(
-                    CONFIG_HASH,
-                    name,
-                    json.dumps(
-                        {
-                            "port": port,
-                            "app_id": app_id,
-                            "usb_serial": usb_serial,
-                        }
-                    ),
+                self._heartbeats[name] = HeartbeatWriter(
+                    self.transport, name=pico_heartbeat_name(name)
                 )
-                r.hset(
-                    HEALTH_HASH,
-                    name,
-                    json.dumps(
-                        {
-                            "connected": True,
-                            "last_seen": time.time(),
-                            "app_id": app_id,
-                        }
-                    ),
-                )
-                self.logger.info(
+                self._heartbeats[name].set(ex=HEARTBEAT_TTL, alive=True)
+                self._status(
                     f"Discovered {name} (app_id={app_id}) on {port}"
                 )
             except Exception as e:
-                self.logger.error(f"Failed to init {name} on {port}: {e}")
+                self._status(
+                    f"Failed to init {name} on {port}: {e}",
+                    level=logging.ERROR,
+                )
 
     def _try_flash_discover(self):
         """Attempt to flash attached Picos and discover devices."""
@@ -360,82 +300,59 @@ class PicoManager:
 
     def _check_health(self):
         """Run one iteration of health checks for all picos."""
-        r = self._redis()
-        for name, pico in list(self.picos.items()):
-            connected = pico.is_connected
-            last_seen = pico.last_status_time or 0
-            now = time.time()
-            stale = (now - last_seen) > HEALTH_TIMEOUT if last_seen else True
-            healthy = connected and not stale
-
-            if not healthy:
-                self.logger.warning(
-                    f"{name}: unhealthy (connected={connected}, stale={stale})"
+        with self._lock:
+            for name, pico in list(self.picos.items()):
+                connected = pico.is_connected
+                last_seen = pico.last_status_time or 0
+                now = time.time()
+                stale = (
+                    (now - last_seen) > HEALTH_TIMEOUT if last_seen else True
                 )
-                try:
-                    old_port = pico.port
-                    if pico.reconnect():
-                        self.logger.info(f"{name}: reconnected")
-                        r.sadd(PICOS_SET, name)
-                        connected = True
-                        if pico.port != old_port:
-                            app_id = APP_IDS.get(name, -1)
-                            r.hset(
-                                CONFIG_HASH,
-                                name,
-                                json.dumps(
-                                    {
-                                        "port": pico.port,
-                                        "app_id": app_id,
-                                        "usb_serial": pico.usb_serial,
-                                    }
-                                ),
-                            )
-                            self._save_config_to_file(
-                                self._current_device_list()
-                            )
-                    else:
-                        r.srem(PICOS_SET, name)
-                        connected = False
-                except Exception as e:
-                    self.logger.error(f"{name}: reconnect failed: {e}")
-                    r.srem(PICOS_SET, name)
-                    connected = False
+                healthy = connected and not stale
 
-            app_id = APP_IDS.get(name, -1)
-            r.hset(
-                HEALTH_HASH,
-                name,
-                json.dumps(
-                    {
-                        "connected": connected,
-                        "last_seen": pico.last_status_time or 0,
-                        "app_id": app_id,
-                    }
-                ),
-            )
+                if not healthy:
+                    self._status(
+                        f"{name}: unhealthy "
+                        f"(connected={connected}, stale={stale})",
+                        level=logging.WARNING,
+                    )
+                    try:
+                        old_port = pico.port
+                        if pico.reconnect():
+                            self._status(f"{name}: reconnected")
+                            connected = True
+                            if pico.port != old_port:
+                                self._config_store.upload(
+                                    self._current_device_list()
+                                )
+                        else:
+                            connected = False
+                    except Exception as e:
+                        self._status(
+                            f"{name}: reconnect failed: {e}",
+                            level=logging.ERROR,
+                        )
+                        connected = False
+
+                hb = self._heartbeats.get(name)
+                if hb is not None:
+                    hb.set(ex=HEARTBEAT_TTL, alive=connected)
 
     # --- Command Relay ---
 
     def cmd_loop(self):
         """Listen for incoming pico commands on the Redis stream."""
-        r = self._redis()
-        last_id = "$"  # only read new messages
         while self._running:
             try:
-                result = r.xread({CMD_STREAM: last_id}, block=1000, count=10)
-                if not result:
-                    continue
-                for _stream, messages in result:
-                    for msg_id, fields in messages:
-                        last_id = msg_id
-                        self._process_command(r, msg_id, fields)
+                messages = self._cmd_reader.read(timeout=1.0, count=10)
+                for msg_id, fields in messages:
+                    self._process_command(msg_id, fields)
             except Exception as e:
                 if self._running:
                     self.logger.error(f"cmd_loop error: {e}")
                     time.sleep(1)
 
-    def _process_command(self, r, msg_id, fields):
+    def _process_command(self, msg_id, fields):
         """Validate and dispatch a single command stream entry."""
         f = {self._decode(k): self._decode(v) for k, v in fields.items()}
         target = f.get("target", "")
@@ -444,15 +361,12 @@ class PicoManager:
         cmd_raw = f.get("cmd", "{}")
 
         def _err(error_msg):
-            r.xadd(
-                RESP_STREAM,
-                {
-                    "target": target,
-                    "source": source,
-                    "request_id": request_id,
-                    "status": "error",
-                    "data": json.dumps({"error": error_msg}),
-                },
+            self._resp_writer.send(
+                target=target,
+                source=source,
+                request_id=request_id,
+                status="error",
+                data={"error": error_msg},
             )
 
         try:
@@ -467,7 +381,7 @@ class PicoManager:
             return
 
         if target == "manager":
-            self._handle_manager_cmd(r, source, cmd, request_id)
+            self._handle_manager_cmd(source, cmd, request_id)
             return
 
         pico = self.picos.get(target)
@@ -478,21 +392,13 @@ class PicoManager:
 
         # Soft claims: warn (but allow) when a non-owner sends a command
         # to a claimed device. Claims are advisory, not enforced.
-        resp = {
-            "target": target,
-            "source": source,
-            "request_id": request_id,
-        }
-        claim_key = f"pico_claim:{target}"
-        current_owner = r.get(claim_key)
-        if current_owner is not None:
-            current_owner = self._decode(current_owner)
-            if current_owner != source:
-                warning = f"overriding claim by {current_owner}"
-                self.logger.warning(
-                    f"{target}: {source} overrides claim by {current_owner}"
-                )
-                resp["warning"] = warning
+        warning = None
+        current_owner = self._claim_store.get(target)
+        if current_owner is not None and current_owner != source:
+            warning = f"overriding claim by {current_owner}"
+            self.logger.warning(
+                f"{target}: {source} overrides claim by {current_owner}"
+            )
 
         action = cmd.get("action")
         if action == "claim":
@@ -502,43 +408,48 @@ class PicoManager:
             except (ValueError, TypeError):
                 _err(f"invalid ttl: {ttl!r}")
                 return
-            r.set(claim_key, source, ex=ttl)
-            resp.update(
-                {
-                    "status": "ok",
-                    "data": json.dumps({"claimed": target, "ttl": ttl}),
-                }
+            self._claim_store.set(target, source, ttl)
+            self._resp_writer.send(
+                target=target,
+                source=source,
+                request_id=request_id,
+                status="ok",
+                data={"claimed": target, "ttl": ttl},
+                warning=warning,
             )
-            r.xadd(RESP_STREAM, resp)
             return
         if action == "release":
-            r.delete(claim_key)
-            resp.update(
-                {
-                    "status": "ok",
-                    "data": json.dumps({"released": target}),
-                }
+            self._claim_store.delete(target)
+            self._resp_writer.send(
+                target=target,
+                source=source,
+                request_id=request_id,
+                status="ok",
+                data={"released": target},
+                warning=warning,
             )
-            r.xadd(RESP_STREAM, resp)
             return
 
         try:
             result = self._route_command(pico, target, cmd)
-            resp.update(
-                {
-                    "status": "ok",
-                    "data": json.dumps(result if result is not None else {}),
-                }
+            self._resp_writer.send(
+                target=target,
+                source=source,
+                request_id=request_id,
+                status="ok",
+                data=result if result is not None else {},
+                warning=warning,
             )
         except Exception as e:
             self.logger.error(f"Command failed on {target}: {e}")
-            resp.update(
-                {
-                    "status": "error",
-                    "data": json.dumps({"error": str(e)}),
-                }
+            self._resp_writer.send(
+                target=target,
+                source=source,
+                request_id=request_id,
+                status="error",
+                data={"error": str(e)},
+                warning=warning,
             )
-        r.xadd(RESP_STREAM, resp)
 
     def _route_command(self, pico, target, cmd):
         """
@@ -562,53 +473,51 @@ class PicoManager:
         result = method(**cmd)
         return {"action": action, "result": result}
 
-    def _handle_manager_cmd(self, r, source, cmd, request_id=""):
+    def _handle_manager_cmd(self, source, cmd, request_id=""):
         """Handle commands targeted at the manager itself."""
         action = cmd.get("action", "")
-        resp = {"target": "manager", "source": source, "request_id": request_id}
-
         if action == "rediscover":
-            self.logger.info(f"Rediscover requested by {source}")
+            self._status(f"Rediscover requested by {source}")
             try:
-                for name, pico in list(self.picos.items()):
-                    try:
-                        pico.disconnect()
-                    except Exception:
-                        pass
-                    r.srem(PICOS_SET, name)
-                self.picos.clear()
-                self.discover()
-                device_names = list(self.picos.keys())
-                resp.update(
-                    {
-                        "status": "ok",
-                        "data": json.dumps(
-                            {
-                                "devices": device_names,
-                                "count": len(device_names),
-                            }
-                        ),
-                    }
+                with self._lock:
+                    for name, pico in list(self.picos.items()):
+                        try:
+                            pico.disconnect()
+                        except Exception:
+                            pass
+                        hb = self._heartbeats.pop(name, None)
+                        if hb is not None:
+                            hb.set(ex=HEARTBEAT_TTL, alive=False)
+                    self.picos.clear()
+                    self.discover()
+                    device_names = list(self.picos.keys())
+                self._resp_writer.send(
+                    target="manager",
+                    source=source,
+                    request_id=request_id,
+                    status="ok",
+                    data={
+                        "devices": device_names,
+                        "count": len(device_names),
+                    },
                 )
             except Exception as e:
                 self.logger.error(f"Rediscover failed: {e}")
-                resp.update(
-                    {
-                        "status": "error",
-                        "data": json.dumps({"error": str(e)}),
-                    }
+                self._resp_writer.send(
+                    target="manager",
+                    source=source,
+                    request_id=request_id,
+                    status="error",
+                    data={"error": str(e)},
                 )
         else:
-            resp.update(
-                {
-                    "status": "error",
-                    "data": json.dumps(
-                        {"error": f"unknown manager action: {action}"}
-                    ),
-                }
+            self._resp_writer.send(
+                target="manager",
+                source=source,
+                request_id=request_id,
+                status="error",
+                data={"error": f"unknown manager action: {action}"},
             )
-
-        r.xadd(RESP_STREAM, resp)
 
     # --- Lifecycle ---
 
@@ -623,37 +532,33 @@ class PicoManager:
         )
         self._health_thread.start()
         self._cmd_thread.start()
-        self.logger.info("PicoManager started")
+        self._status("PicoManager started")
 
     def stop(self):
-        """Graceful shutdown: stop threads, disconnect picos, clear Redis."""
-        self.logger.info("PicoManager stopping...")
+        """Graceful shutdown: stop threads, disconnect picos, mark dead."""
+        self._status("PicoManager stopping...")
         self._running = False
         if self._health_thread:
             self._health_thread.join(timeout=HEALTH_CHECK_INTERVAL + 1)
         if self._cmd_thread:
             self._cmd_thread.join(timeout=2)
 
-        r = self._redis()
         for name, pico in self.picos.items():
             try:
                 pico.disconnect()
-                r.srem(PICOS_SET, name)
-                r.hset(
-                    HEALTH_HASH,
-                    name,
-                    json.dumps(
-                        {
-                            "connected": False,
-                            "last_seen": 0,
-                            "app_id": APP_IDS.get(name, -1),
-                        }
-                    ),
-                )
             except Exception as e:
                 self.logger.error(f"Error stopping {name}: {e}")
+            hb = self._heartbeats.get(name)
+            if hb is not None:
+                try:
+                    hb.set(ex=HEARTBEAT_TTL, alive=False)
+                except Exception as e:
+                    self.logger.error(
+                        f"Failed to clear heartbeat for {name}: {e}"
+                    )
         self.picos.clear()
-        self.logger.info("PicoManager stopped")
+        self._heartbeats.clear()
+        self._status("PicoManager stopped")
 
     def run(self):
         """Discover, start, and block until interrupted."""
@@ -676,25 +581,26 @@ def main():
     """Console-script and ``python -m picohost.manager`` entry point."""
     parser = argparse.ArgumentParser(description="EIGSEP Pico Manager")
     parser.add_argument(
-        "--config",
-        default="pico_config.json",
-        help="Path to pico_config.json (default: pico_config.json)",
-    )
-    parser.add_argument(
         "--uf2",
         default="build/pico_multi.uf2",
-        help="Path to pico_multi.uf2 for auto-flashing "
+        help="Path to pico_multi.uf2 for auto-flashing when Redis is empty "
         "(default: build/pico_multi.uf2)",
     )
     parser.add_argument(
-        "--no-redis-config",
-        action="store_true",
-        help="Skip Redis config lookup, re-discover from file/flash",
+        "--redis-host",
+        default="localhost",
+        help="Redis host (default: localhost)",
+    )
+    parser.add_argument(
+        "--redis-port",
+        type=int,
+        default=6379,
+        help="Redis port (default: 6379)",
     )
     parser.add_argument(
         "--clear-config",
         action="store_true",
-        help="Clear stored config from Redis before discovering",
+        help="Clear PicoConfigStore before discovering",
     )
     parser.add_argument(
         "--log-level",
@@ -709,25 +615,10 @@ def main():
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
-    try:
-        from eigsep_redis import EigsepRedis
-    except ImportError:
-        print(
-            "eigsep_redis is required to run PicoManager.\n"
-            "Install it with: pip install eigsep_redis",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    r = EigsepRedis()
+    transport = Transport(host=args.redis_host, port=args.redis_port)
+    mgr = PicoManager(transport, uf2_path=args.uf2)
     if args.clear_config:
-        r.r.delete(CONFIG_HASH)
-    mgr = PicoManager(
-        r,
-        config_file=args.config,
-        uf2_path=args.uf2,
-        use_redis_config=not args.no_redis_config,
-    )
+        mgr._config_store.clear()
     mgr.run()
 
 

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -23,7 +23,7 @@ class PicoMotor(PicoDevice):
         verbose=False,
         timeout=5.0,
         name=None,
-        eig_redis=None,
+        metadata_writer=None,
         usb_serial="",
     ):
         self.step_angle_deg = step_angle_deg
@@ -45,7 +45,7 @@ class PicoMotor(PicoDevice):
             port,
             timeout=timeout,
             name=name,
-            eig_redis=eig_redis,
+            metadata_writer=metadata_writer,
             usb_serial=usb_serial,
             verbose=verbose,
         )

--- a/picohost/src/picohost/proxy.py
+++ b/picohost/src/picohost/proxy.py
@@ -3,20 +3,22 @@ Redis-backed proxy for pico devices managed by PicoManager.
 
 A proxy routes device method calls through Redis instead of serial.
 Construction always succeeds — no hardware check. At command time the
-proxy checks whether PicoManager has the device registered; if not, the
-command is a no-op that returns ``None``. Every device method is invoked
-by name via :meth:`PicoProxy.send_command`; there is intentionally no
-per-device subclass.
+proxy checks whether the manager's per-device heartbeat is alive; if
+not, the command is a no-op that returns ``None``. Every device method
+is invoked by name via :meth:`PicoProxy.send_command`; there is
+intentionally no per-device subclass.
 
 Usage::
 
+    from eigsep_redis import Transport
     from picohost.proxy import PicoProxy
 
-    sw = PicoProxy("rfswitch", redis_client)
+    transport = Transport()
+    sw = PicoProxy("rfswitch", transport)
     sw.send_command("switch", state="RFANT")   # routed via PicoManager
-    sw.is_available                             # True if registered
+    sw.is_available                             # True if heartbeat alive
 
-    peltier = PicoProxy("tempctrl", redis_client)
+    peltier = PicoProxy("tempctrl", transport)
     peltier.send_command("set_temperature", T_LNA=25, T_LOAD=25)
 """
 
@@ -25,7 +27,13 @@ import logging
 import time
 import uuid
 
-from .manager import CMD_STREAM, HEALTH_HASH, PICOS_SET, RESP_STREAM
+from eigsep_redis import HeartbeatReader
+
+from .keys import (
+    PICO_CMD_STREAM,
+    PICO_RESP_STREAM,
+    pico_heartbeat_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +46,9 @@ class PicoProxy:
     ----------
     name : str
         Device name as registered by PicoManager (e.g. ``"rfswitch"``).
-    redis : redis.Redis
-        The underlying Redis client (not an ``EigsepRedis`` wrapper).
+    transport : eigsep_redis.Transport
+        Shared transport used for availability checks and command
+        round-trips.
     source : str
         Identifier included in command stream entries for logging and
         soft-claim tracking.
@@ -47,25 +56,25 @@ class PicoProxy:
         Default seconds to wait for a command response.
     """
 
-    def __init__(self, name, redis, source="client", timeout=5.0):
+    def __init__(self, name, transport, source="client", timeout=5.0):
         self.name = name
-        self.redis = redis
+        self.transport = transport
         self.source = source
         self.timeout = timeout
         self.logger = logger
+        self._heartbeat_reader = HeartbeatReader(
+            transport, name=pico_heartbeat_name(name)
+        )
+
+    @property
+    def r(self):
+        """Raw redis client from the underlying transport."""
+        return self.transport.r
 
     @property
     def is_available(self):
-        """True if PicoManager has registered this device."""
-        return self.redis.sismember(PICOS_SET, self.name)
-
-    @property
-    def health(self):
-        """Device health dict from PicoManager, or None."""
-        raw = self.redis.hget(HEALTH_HASH, self.name)
-        if raw is None:
-            return None
-        return json.loads(raw)
+        """True if the device's heartbeat is alive."""
+        return self._heartbeat_reader.check()
 
     def send_command(self, action, **kwargs):
         """
@@ -102,15 +111,24 @@ class PicoProxy:
 
         request_id = str(uuid.uuid4())
         # Capture current stream end so we don't miss fast responses.
+        # xinfo_stream returns bytes keys when decode_responses=False,
+        # so probe both.
         try:
-            info = self.redis.xinfo_stream(RESP_STREAM)
-            last_id = info["last-generated-id"]
+            info = self.r.xinfo_stream(PICO_RESP_STREAM)
         except Exception:
             # Stream doesn't exist yet — read from the beginning.
             last_id = "0-0"
+        else:
+            last_id = info.get("last-generated-id") or info.get(
+                b"last-generated-id"
+            )
+            if isinstance(last_id, bytes):
+                last_id = last_id.decode()
+            if last_id is None:
+                last_id = "0-0"
         cmd = {"action": action, **kwargs}
-        self.redis.xadd(
-            CMD_STREAM,
+        self.r.xadd(
+            PICO_CMD_STREAM,
             {
                 "target": self.name,
                 "source": self.source,
@@ -121,9 +139,7 @@ class PicoProxy:
         return self._wait_response(request_id, last_id)
 
     def _wait_response(self, request_id, last_id):
-        """
-        Poll ``stream:pico_resp`` for a response matching *request_id*.
-        """
+        """Poll ``stream:pico_resp`` for a response matching *request_id*."""
         deadline = time.monotonic() + self.timeout
         while True:
             remaining = deadline - time.monotonic()
@@ -132,8 +148,8 @@ class PicoProxy:
                     f"No response for {self.name} within {self.timeout}s"
                 )
             block_ms = int(remaining * 1000)
-            result = self.redis.xread(
-                {RESP_STREAM: last_id}, block=block_ms, count=10
+            result = self.r.xread(
+                {PICO_RESP_STREAM: last_id}, block=block_ms, count=10
             )
             if not result:
                 raise TimeoutError(
@@ -149,10 +165,7 @@ class PicoProxy:
                         rid = rid.decode()
                     if rid != request_id:
                         continue
-                    # Found our response
-                    status = fields.get(b"status") or fields.get(
-                        "status"
-                    )
+                    status = fields.get(b"status") or fields.get("status")
                     if isinstance(status, bytes):
                         status = status.decode()
                     data_raw = fields.get(b"data") or fields.get(

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -100,11 +100,11 @@ class TestPicoDevice:
         assert device.redis_handler_seen_in_connect is None
         device.disconnect()
 
-    def test_redis_handler_with_client_is_bound_before_connect(self):
-        """Configured Redis handler is available during connect()."""
+    def test_redis_handler_with_writer_is_bound_before_connect(self):
+        """Configured metadata handler is available during connect()."""
 
-        class FakeRedis:
-            def add_metadata(self, _name, _data):
+        class FakeMetadataWriter:
+            def add(self, _key, _value):
                 pass
 
         class ProbePicoDevice(DummyPicoDevice):
@@ -112,7 +112,9 @@ class TestPicoDevice:
                 self.redis_handler_seen_in_connect = self.redis_handler
                 return super().connect()
 
-        device = ProbePicoDevice("/dev/dummy", eig_redis=FakeRedis())
+        device = ProbePicoDevice(
+            "/dev/dummy", metadata_writer=FakeMetadataWriter()
+        )
         assert callable(device.redis_handler_seen_in_connect)
         device.disconnect()
 

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -446,11 +446,13 @@ class TestRedisIntegration:
         """Verify that redis_handler receives status data when configured."""
         received = []
 
-        class FakeRedis:
-            def add_metadata(self, name, data):
+        class FakeMetadataWriter:
+            def add(self, name, data):
                 received.append((name, data))
 
-        mon = DummyPicoTempMon("/dev/dummy", eig_redis=FakeRedis())
+        mon = DummyPicoTempMon(
+            "/dev/dummy", metadata_writer=FakeMetadataWriter()
+        )
         cadence = mon.EMULATOR_CADENCE_MS
         wait_for_condition(
             lambda: len(received) > 0,

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -2,24 +2,29 @@
 Tests for picohost.manager.PicoManager.
 
 Uses the existing emulator-backed Dummy* devices from picohost.testing
-plus a small in-test MockRedis stub. We deliberately don't pull in
-fakeredis here — once the eigsep_redis package lands (Phase 2), tests
-can switch to its fakeredis-backed DummyEigsepRedisBase.
+plus ``eigsep_redis.testing.DummyTransport`` (fakeredis-backed) so the
+manager talks to a real in-process Redis without a live server.
 """
 
 import json
 
 import pytest
+from eigsep_redis import HeartbeatReader
+from eigsep_redis.testing import DummyTransport
 
+from picohost.buses import PicoConfigStore
+from picohost.keys import (
+    PICO_CMD_STREAM,
+    PICO_CONFIG_KEY,
+    PICO_RESP_STREAM,
+    pico_claim_key,
+    pico_heartbeat_name,
+)
 from picohost.manager import (
     APP_IDS,
     APP_NAMES,
-    CMD_STREAM,
-    CONFIG_HASH,
-    HEALTH_HASH,
+    HEARTBEAT_TTL,
     PICO_CLASSES,
-    PICOS_SET,
-    RESP_STREAM,
     PicoManager,
     _BLOCKED_ACTIONS,
 )
@@ -30,99 +35,46 @@ from picohost.testing import (
 )
 
 
-class MockRedis:
-    """
-    Minimal in-process Redis substitute that implements only the calls
-    PicoManager makes plus ``add_metadata`` so the picohost reader
-    thread doesn't blow up when it tries to publish status.
-    """
-
-    def __init__(self):
-        self._sets = {}
-        self._hashes = {}
-        self._keys = {}
-        self._streams = {}
-        # PicoManager._redis() returns self.r if it exists, else self.
-        self.r = self
-
-    # -- the picohost.base.redis_handler entry point --
-
-    def add_metadata(self, name, data):
-        pass
-
-    # -- sets --
-
-    def sadd(self, key, *values):
-        self._sets.setdefault(key, set()).update(values)
-
-    def srem(self, key, *values):
-        if key in self._sets:
-            self._sets[key] -= set(values)
-
-    def smembers(self, key):
-        return set(self._sets.get(key, set()))
-
-    # -- hashes --
-
-    def hset(self, name, key=None, value=None, mapping=None):
-        self._hashes.setdefault(name, {})
-        if key is not None:
-            self._hashes[name][key] = value
-        if mapping:
-            self._hashes[name].update(mapping)
-
-    def hget(self, name, key):
-        return self._hashes.get(name, {}).get(key)
-
-    def hgetall(self, name):
-        return dict(self._hashes.get(name, {}))
-
-    # -- keys --
-
-    def set(self, key, value, ex=None):
-        self._keys[key] = value
-
-    def get(self, key):
-        return self._keys.get(key)
-
-    def delete(self, *keys):
-        for key in keys:
-            self._keys.pop(key, None)
-
-    # -- streams --
-
-    def xadd(self, stream, fields, maxlen=None):
-        msgs = self._streams.setdefault(stream, [])
-        msg_id = f"{len(msgs)}-0"
-        msgs.append((msg_id, fields))
-        return msg_id
-
-    def xread(self, streams, block=None, count=None):
-        # The cmd_loop only uses xread for live polling — tests drive
-        # _process_command directly, so an empty result is correct.
-        return []
-
-
 # --- helpers --------------------------------------------------------------
 
 
 def _attach(mgr, name, dummy_cls):
-    """
-    Build a Dummy* device, register it under ``name`` in the manager's
-    dict, and mark it as published in the manager's Redis state — the
-    same effect ``discover()`` would have.
-    """
-    pico = dummy_cls("/dev/dummy", eig_redis=mgr.eig_redis, name=name)
+    """Build a Dummy device and register it the way ``discover()`` would."""
+    from eigsep_redis import HeartbeatWriter
+
+    pico = dummy_cls(
+        "/dev/dummy",
+        metadata_writer=mgr._metadata_writer,
+        name=name,
+    )
     mgr.picos[name] = pico
-    r = mgr._redis()
-    r.sadd(PICOS_SET, name)
+    mgr._heartbeats[name] = HeartbeatWriter(
+        mgr.transport, name=pico_heartbeat_name(name)
+    )
+    mgr._heartbeats[name].set(ex=HEARTBEAT_TTL, alive=True)
     return pico
+
+
+def _last_response(transport):
+    """Return the most recent response dict written to ``PICO_RESP_STREAM``."""
+    entries = transport.r.xrange(PICO_RESP_STREAM)
+    assert entries, "expected at least one response entry"
+    _, fields = entries[-1]
+    return {k.decode(): v.decode() for k, v in fields.items()}
+
+
+def _all_responses(transport):
+    """Return every response dict written to ``PICO_RESP_STREAM``."""
+    return [
+        {k.decode(): v.decode() for k, v in fields.items()}
+        for _, fields in transport.r.xrange(PICO_RESP_STREAM)
+    ]
 
 
 @pytest.fixture
 def mgr():
-    """A bare PicoManager wired to a fresh MockRedis."""
-    m = PicoManager(MockRedis())
+    """A bare PicoManager wired to a fresh in-memory transport."""
+    m = PicoManager(DummyTransport())
     yield m
     for pico in list(m.picos.values()):
         try:
@@ -211,9 +163,7 @@ class TestRouteCommand:
 class TestProcessCommand:
     def test_valid_command_publishes_ok_response(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -221,15 +171,12 @@ class TestProcessCommand:
                 "source": "test",
             },
         )
-        assert len(r._streams[RESP_STREAM]) == 1
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
         assert resp["source"] == "test"
 
     def test_unknown_target_publishes_error(self, mgr):
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "ghost",
@@ -237,15 +184,13 @@ class TestProcessCommand:
                 "source": "test",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "error"
         assert "unknown target" in json.loads(resp["data"])["error"]
 
     def test_invalid_json_publishes_error(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -253,18 +198,14 @@ class TestProcessCommand:
                 "source": "test",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "error"
 
     def test_bytes_fields_decoded(self, mgr):
-        """
-        Real Redis returns bytes; the manager must decode both keys and
-        values before parsing.
-        """
+        """Real Redis returns bytes; the manager must decode both keys
+        and values before parsing."""
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
         mgr._process_command(
-            r,
             b"1-0",
             {
                 b"target": b"rfswitch",
@@ -274,7 +215,7 @@ class TestProcessCommand:
                 b"source": b"test",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
 
 
@@ -284,9 +225,7 @@ class TestProcessCommand:
 class TestClaims:
     def test_claim_sets_owner(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -294,14 +233,15 @@ class TestClaims:
                 "source": "switch_loop",
             },
         )
-        assert r.get("pico_claim:rfswitch") == "switch_loop"
+        assert (
+            mgr.transport.r.get(pico_claim_key("rfswitch")).decode()
+            == "switch_loop"
+        )
 
     def test_release_clears_owner(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
-        r.set("pico_claim:rfswitch", "switch_loop")
+        mgr.transport.r.set(pico_claim_key("rfswitch"), "switch_loop")
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -309,14 +249,12 @@ class TestClaims:
                 "source": "switch_loop",
             },
         )
-        assert r.get("pico_claim:rfswitch") is None
+        assert mgr.transport.r.get(pico_claim_key("rfswitch")) is None
 
     def test_override_warns_but_allows(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
-        r.set("pico_claim:rfswitch", "switch_loop")
+        mgr.transport.r.set(pico_claim_key("rfswitch"), "switch_loop")
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -324,16 +262,14 @@ class TestClaims:
                 "source": "interactive",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
         assert "switch_loop" in resp["warning"]
 
     def test_owner_no_warning(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
-        r = mgr._redis()
-        r.set("pico_claim:rfswitch", "switch_loop")
+        mgr.transport.r.set(pico_claim_key("rfswitch"), "switch_loop")
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -341,7 +277,7 @@ class TestClaims:
                 "source": "switch_loop",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert "warning" not in resp
 
 
@@ -364,29 +300,62 @@ class TestLifecycle:
         assert switch.ser is None
         assert motor.ser is None
 
+    def test_stop_marks_heartbeats_dead(self, mgr):
+        _attach(mgr, "rfswitch", DummyPicoRFSwitch)
+        mgr.stop()
+        hb_reader = HeartbeatReader(
+            mgr.transport, name=pico_heartbeat_name("rfswitch")
+        )
+        assert hb_reader.check() is False
+
 
 # --- discovery ------------------------------------------------------------
 
 
 class TestDiscover:
-    def test_missing_config_is_a_noop(self, mgr, tmp_path):
-        mgr.config_file = tmp_path / "does-not-exist.json"
+    def test_empty_redis_is_a_noop_without_uf2(self, mgr, tmp_path):
+        """discover() with empty Redis and no UF2 just produces zero picos."""
+        mgr.uf2_path = tmp_path / "nonexistent.uf2"
         mgr.discover()
         assert mgr.picos == {}
 
-    def test_invalid_json_config_is_a_noop(self, mgr, tmp_path):
-        cfg = tmp_path / "bad.json"
-        cfg.write_text("{not valid json!!")
-        mgr.config_file = cfg
-        mgr.discover()  # must not raise
-        assert mgr.picos == {}
-
-    def test_flash_fallback_on_missing_config(
-        self, mgr, monkeypatch, tmp_path
-    ):
-        """discover() cascades to flash when Redis + file are empty."""
+    def test_redis_config_instantiates_devices(self, mgr, monkeypatch):
+        """discover() reads the PicoConfigStore and builds devices."""
         import picohost.manager as mgr_mod
+
+        monkeypatch.setitem(
+            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
+        )
+        PicoConfigStore(mgr.transport).upload(
+            [
+                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"},
+            ]
+        )
+        mgr.discover()
+        assert "rfswitch" in mgr.picos
+
+    def test_discover_emits_initial_heartbeat(self, mgr, monkeypatch):
+        """Each registered device gets an alive heartbeat as soon as it lands."""
+        import picohost.manager as mgr_mod
+
+        monkeypatch.setitem(
+            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
+        )
+        PicoConfigStore(mgr.transport).upload(
+            [
+                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"},
+            ]
+        )
+        mgr.discover()
+        hb_reader = HeartbeatReader(
+            mgr.transport, name=pico_heartbeat_name("rfswitch")
+        )
+        assert hb_reader.check() is True
+
+    def test_flash_fallback_on_empty_redis(self, mgr, monkeypatch):
+        """discover() falls through to flash when Redis is empty."""
         import picohost.flash_picos as fp_mod
+        import picohost.manager as mgr_mod
 
         monkeypatch.setitem(
             mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
@@ -398,194 +367,41 @@ class TestDiscover:
                 {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
             ],
         )
-
-        mgr.config_file = tmp_path / "does-not-exist.json"
         mgr.discover()
         assert "rfswitch" in mgr.picos
+        # Result is persisted back into Redis
+        stored = PicoConfigStore(mgr.transport).get()
+        assert stored == [
+            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
+        ]
 
     def test_flash_fallback_uf2_missing_is_noop(self, mgr, tmp_path):
-        mgr.config_file = tmp_path / "does-not-exist.json"
         mgr.uf2_path = tmp_path / "nonexistent.uf2"
         mgr._try_flash_discover()
         assert mgr.picos == {}
-
-    def test_publishes_devices_to_redis(self, mgr, monkeypatch, tmp_path):
-        # Stand the manager up against a config that points "rfswitch"
-        # at /dev/dummy, then patch PICO_CLASSES so discover()
-        # instantiates the dummy class instead of the real one.
-        import picohost.manager as mgr_mod
-
-        cfg = tmp_path / "pico_config.json"
-        cfg.write_text(
-            json.dumps(
-                [
-                    {
-                        "app_id": 5,
-                        "port": "/dev/dummy",
-                        "usb_serial": "ABC123",
-                    },
-                ]
-            )
-        )
-        mgr.config_file = cfg
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        mgr.discover()
-        assert "rfswitch" in mgr.picos
-        r = mgr._redis()
-        assert "rfswitch" in r.smembers(PICOS_SET)
-        health = json.loads(r.hget(HEALTH_HASH, "rfswitch"))
-        assert health["app_id"] == 5
-        assert health["connected"] is True
-
-
-# --- Redis config store ---------------------------------------------------
-
-
-class TestRedisConfig:
-    def test_discover_from_redis(self, mgr, monkeypatch):
-        """When Redis has config, discover() uses it without touching file."""
-        import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        r = mgr._redis()
-        r.hset(
-            CONFIG_HASH,
-            "rfswitch",
-            json.dumps(
-                {
-                    "app_id": 5,
-                    "port": "/dev/dummy",
-                    "usb_serial": "ABC",
-                }
-            ),
-        )
-        mgr.config_file = "/nonexistent/path.json"  # shouldn't be read
-        mgr.discover()
-        assert "rfswitch" in mgr.picos
-
-    def test_discover_skips_redis_when_disabled(
-        self, mgr, monkeypatch, tmp_path
-    ):
-        """--no-redis-config makes discover() skip Redis."""
-        import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        # Populate Redis — should be ignored
-        r = mgr._redis()
-        r.hset(
-            CONFIG_HASH,
-            "motor",
-            json.dumps(
-                {
-                    "app_id": 0,
-                    "port": "/dev/dummy",
-                    "usb_serial": "OLD",
-                }
-            ),
-        )
-        # Provide a file with rfswitch instead
-        cfg = tmp_path / "pico_config.json"
-        cfg.write_text(
-            json.dumps(
-                [
-                    {"app_id": 5, "port": "/dev/dummy", "usb_serial": "NEW"},
-                ]
-            )
-        )
-        mgr.config_file = cfg
-        mgr.use_redis_config = False
-        mgr.discover()
-        assert "rfswitch" in mgr.picos
-        assert "motor" not in mgr.picos
-
-    def test_discover_writes_back_to_file(self, mgr, monkeypatch, tmp_path):
-        """After discovering from Redis, config is written back to file."""
-        import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        r = mgr._redis()
-        r.hset(
-            CONFIG_HASH,
-            "rfswitch",
-            json.dumps(
-                {
-                    "app_id": 5,
-                    "port": "/dev/dummy",
-                    "usb_serial": "ABC",
-                }
-            ),
-        )
-        cfg = tmp_path / "pico_config.json"
-        mgr.config_file = cfg
-        mgr.discover()
-        assert cfg.exists()
-        written = json.loads(cfg.read_text())
-        assert len(written) == 1
-        assert written[0]["app_id"] == 5
-
-    def test_file_fallback_when_redis_empty(self, mgr, monkeypatch, tmp_path):
-        """When Redis is empty, discover() falls through to file."""
-        import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        cfg = tmp_path / "pico_config.json"
-        cfg.write_text(
-            json.dumps(
-                [
-                    {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
-                ]
-            )
-        )
-        mgr.config_file = cfg
-        mgr.discover()
-        assert "rfswitch" in mgr.picos
-        # Verify config was also published to Redis
-        stored = json.loads(mgr._redis().hget(CONFIG_HASH, "rfswitch"))
-        assert stored["app_id"] == 5
 
 
 # --- manager commands -----------------------------------------------------
 
 
 class TestManagerCommand:
-    def test_rediscover_clears_and_reloads(self, mgr, monkeypatch, tmp_path):
+    def test_rediscover_clears_and_reloads(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
 
         monkeypatch.setitem(
             mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
         )
-        # Start with a device
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         assert "rfswitch" in mgr.picos
 
-        # Set up Redis config for rediscover to find
-        r = mgr._redis()
-        r.hset(
-            CONFIG_HASH,
-            "rfswitch",
-            json.dumps(
-                {
-                    "app_id": 5,
-                    "port": "/dev/dummy",
-                    "usb_serial": "X",
-                }
-            ),
+        # Stage Redis config for the rediscover path to pick up
+        PicoConfigStore(mgr.transport).upload(
+            [
+                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
+            ]
         )
-        cfg = tmp_path / "pico_config.json"
-        mgr.config_file = cfg
 
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "manager",
@@ -593,16 +409,14 @@ class TestManagerCommand:
                 "source": "test",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
         data = json.loads(resp["data"])
         assert "rfswitch" in data["devices"]
         assert data["count"] == 1
 
     def test_unknown_manager_action_returns_error(self, mgr):
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "manager",
@@ -610,7 +424,7 @@ class TestManagerCommand:
                 "source": "test",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "error"
         assert "unknown manager action" in json.loads(resp["data"])["error"]
 
@@ -621,7 +435,6 @@ class TestManagerCommand:
 class TestReconnectHook:
     def test_motor_on_reconnect_replays_delay(self, mgr):
         motor = _attach(mgr, "motor", DummyPicoMotor)
-        # Sanity: ctor stored the delay kwargs
         assert motor._delay_kwargs is not None
 
         calls = []
@@ -649,7 +462,6 @@ class TestReconnectHook:
             "find_pico_ports",
             lambda: {"/dev/ttyACM5": "SER_ABC"},
         )
-        # _rediscover_port should update port
         switch._rediscover_port()
         assert switch.port == "/dev/ttyACM5"
         assert switch.port != old_port
@@ -687,5 +499,6 @@ def test_blocked_actions_includes_lifecycle():
 
 def test_cmd_stream_constant_unchanged():
     # Other consumers (eigsep_observing) read from this stream by name.
-    assert CMD_STREAM == "stream:pico_cmd"
-    assert RESP_STREAM == "stream:pico_resp"
+    assert PICO_CMD_STREAM == "stream:pico_cmd"
+    assert PICO_RESP_STREAM == "stream:pico_resp"
+    assert PICO_CONFIG_KEY == "pico_config"

--- a/picohost/tests/test_manager_integration.py
+++ b/picohost/tests/test_manager_integration.py
@@ -6,11 +6,11 @@ formatting) and test_emulator_integration.py (which tests individual
 devices directly), these tests verify the full pipeline:
 
     Redis command -> PicoManager -> DummyDevice -> MockSerial ->
-    Emulator -> state change -> reader thread -> redis_handler ->
-    MockRedis.add_metadata()
+    Emulator -> state change -> reader thread -> MetadataWriter.add()
 
-The enhanced MockRedis here captures ``add_metadata`` calls and supports
-blocking ``xread`` so that ``cmd_loop`` can pick up injected commands.
+The transport here is a fakeredis-backed ``DummyTransport``, so
+``cmd_loop`` really blocks on ``xread`` and ``MetadataWriter.add``
+really writes to an in-process Redis snapshot.
 """
 
 import json
@@ -18,17 +18,17 @@ import threading
 import time
 
 import pytest
-
 from conftest import wait_for_condition, wait_for_settle
-from picohost.manager import (
-    APP_IDS,
-    CMD_STREAM,
-    CONFIG_HASH,
-    HEALTH_HASH,
-    PICOS_SET,
-    RESP_STREAM,
-    PicoManager,
+from eigsep_redis import HeartbeatReader, MetadataSnapshotReader
+from eigsep_redis.testing import DummyTransport
+
+from picohost.buses import PicoConfigStore
+from picohost.keys import (
+    PICO_CMD_STREAM,
+    PICO_RESP_STREAM,
+    pico_heartbeat_name,
 )
+from picohost.manager import HEARTBEAT_TTL, PicoManager
 from picohost.testing import (
     DummyPicoMotor,
     DummyPicoPeltier,
@@ -38,156 +38,48 @@ from picohost.testing import (
 CADENCE_MS = 50  # matches DummyPico* EMULATOR_CADENCE_MS
 
 
-# --- Enhanced MockRedis ------------------------------------------------------
-
-
-class MockRedis:
-    """
-    In-process Redis substitute with metadata capture and blocking xread.
-
-    Extends the minimal stub pattern from test_manager.py with two
-    capabilities needed for integration testing:
-
-    * ``_metadata_log`` captures every ``add_metadata(name, data)`` call
-      so tests can assert that emulator status flows through the reader
-      thread's ``redis_handler``.
-
-    * ``xread`` supports blocking via ``threading.Event`` so that
-      ``cmd_loop()`` can pick up commands injected by tests.
-    """
-
-    def __init__(self):
-        self._sets = {}
-        self._hashes = {}
-        self._keys = {}
-        self._streams = {}
-        self._metadata_log = []
-        self._xread_event = threading.Event()
-        # PicoManager._redis() returns self.r if it exists, else self.
-        self.r = self
-
-    # -- redis_handler entry point --
-
-    def add_metadata(self, name, data):
-        self._metadata_log.append((name, dict(data)))
-
-    # -- sets --
-
-    def sadd(self, key, *values):
-        self._sets.setdefault(key, set()).update(values)
-
-    def srem(self, key, *values):
-        if key in self._sets:
-            self._sets[key] -= set(values)
-
-    def smembers(self, key):
-        return set(self._sets.get(key, set()))
-
-    # -- hashes --
-
-    def hset(self, name, key=None, value=None, mapping=None):
-        self._hashes.setdefault(name, {})
-        if key is not None:
-            self._hashes[name][key] = value
-        if mapping:
-            self._hashes[name].update(mapping)
-
-    def hget(self, name, key):
-        return self._hashes.get(name, {}).get(key)
-
-    def hgetall(self, name):
-        return dict(self._hashes.get(name, {}))
-
-    # -- keys --
-
-    def set(self, key, value, ex=None):
-        self._keys[key] = value
-
-    def get(self, key):
-        return self._keys.get(key)
-
-    def delete(self, *keys):
-        for key in keys:
-            self._keys.pop(key, None)
-
-    # -- streams --
-
-    def xadd(self, stream, fields, maxlen=None):
-        msgs = self._streams.setdefault(stream, [])
-        msg_id = f"{len(msgs)}-0"
-        msgs.append((msg_id, fields))
-        self._xread_event.set()
-        return msg_id
-
-    def xread(self, streams, block=None, count=None):
-        """Return messages newer than the requested ID.
-
-        When ``last_id == "$"`` and ``block > 0``, waits for new messages
-        via ``_xread_event`` (set by ``xadd``).
-        """
-        for stream_name, last_id in streams.items():
-            msgs = self._streams.get(stream_name, [])
-
-            if last_id == "$":
-                # "$" means only messages added after this call.
-                snapshot = len(msgs)
-                if block and block > 0:
-                    self._xread_event.wait(timeout=min(block / 1000.0, 0.5))
-                    self._xread_event.clear()
-                    msgs = self._streams.get(stream_name, [])
-                    new_msgs = msgs[snapshot:]
-                else:
-                    new_msgs = []
-            else:
-                # Return messages after last_id.
-                new_msgs = []
-                for i, (mid, _) in enumerate(msgs):
-                    if mid == last_id:
-                        new_msgs = msgs[i + 1 :]
-                        break
-
-            if new_msgs:
-                if count:
-                    new_msgs = new_msgs[:count]
-                return [(stream_name, new_msgs)]
-        return []
-
-
 # --- helpers -----------------------------------------------------------------
 
 
 def _attach(mgr, name, dummy_cls):
-    """
-    Build a Dummy* device, register it in the manager, and mark it
-    as published in Redis -- same effect as ``discover()``.
-    """
-    pico = dummy_cls("/dev/dummy", eig_redis=mgr.eig_redis, name=name)
-    mgr.picos[name] = pico
-    r = mgr._redis()
-    r.sadd(PICOS_SET, name)
-    r.hset(
-        CONFIG_HASH,
-        name,
-        json.dumps(
-            {
-                "port": "/dev/dummy",
-                "app_id": APP_IDS.get(name, -1),
-                "usb_serial": "DUMMY",
-            }
-        ),
+    """Build a Dummy device, register it, and emit initial heartbeat."""
+    from eigsep_redis import HeartbeatWriter
+
+    pico = dummy_cls(
+        "/dev/dummy",
+        metadata_writer=mgr._metadata_writer,
+        name=name,
     )
+    mgr.picos[name] = pico
+    mgr._heartbeats[name] = HeartbeatWriter(
+        mgr.transport, name=pico_heartbeat_name(name)
+    )
+    mgr._heartbeats[name].set(ex=HEARTBEAT_TTL, alive=True)
     return pico
 
 
-def _metadata_names(mock_redis):
-    """Set of sensor names that have appeared in add_metadata calls."""
-    return {name for name, _ in mock_redis._metadata_log}
+def _last_response(transport):
+    entries = transport.r.xrange(PICO_RESP_STREAM)
+    assert entries, "expected at least one response entry"
+    _, fields = entries[-1]
+    return {k.decode(): v.decode() for k, v in fields.items()}
+
+
+def _all_responses(transport):
+    return [
+        {k.decode(): v.decode() for k, v in fields.items()}
+        for _, fields in transport.r.xrange(PICO_RESP_STREAM)
+    ]
+
+
+def _metadata_snapshot(transport):
+    return MetadataSnapshotReader(transport)
 
 
 @pytest.fixture
 def mgr():
-    """PicoManager wired to an enhanced MockRedis."""
-    m = PicoManager(MockRedis())
+    """PicoManager wired to a fakeredis-backed transport."""
+    m = PicoManager(DummyTransport())
     yield m
     m._running = False
     if m._cmd_thread:
@@ -206,29 +98,25 @@ def mgr():
 
 
 class TestStatusPublication:
-    """Emulator status flows through redis_handler into add_metadata()."""
+    """Emulator status flows through MetadataWriter into Redis."""
 
-    def test_add_metadata_receives_status(self, mgr):
-        mock = mgr.eig_redis
+    def test_metadata_snapshot_receives_status(self, mgr):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
+        snap = _metadata_snapshot(mgr.transport)
         wait_for_condition(
-            lambda: len(mock._metadata_log) > 0,
+            lambda: "rfswitch" in snap.get(),
             cadence_ms=CADENCE_MS,
         )
-        names = _metadata_names(mock)
-        assert "rfswitch" in names
-        _, data = next(
-            (n, d) for n, d in mock._metadata_log if n == "rfswitch"
-        )
-        assert "sensor_name" in data
+        data = snap.get("rfswitch")
+        assert data["sensor_name"] == "rfswitch"
         assert "sw_state" in data
 
     def test_multiple_devices_publish_independently(self, mgr):
-        mock = mgr.eig_redis
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         _attach(mgr, "motor", DummyPicoMotor)
+        snap = _metadata_snapshot(mgr.transport)
         wait_for_condition(
-            lambda: _metadata_names(mock) >= {"rfswitch", "motor"},
+            lambda: {"rfswitch", "motor"}.issubset(snap.get()),
             cadence_ms=CADENCE_MS,
         )
 
@@ -250,29 +138,35 @@ class TestStatusPublication:
 class TestHealthMonitoring:
     """_check_health() against live emulator-backed devices."""
 
-    def test_live_device_reported_healthy(self, mgr):
+    def test_live_device_heartbeat_alive(self, mgr):
         pico = _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         wait_for_condition(
             lambda: pico.last_status_time is not None,
             cadence_ms=CADENCE_MS,
         )
         mgr._check_health()
-        r = mgr._redis()
-        health = json.loads(r.hget(HEALTH_HASH, "rfswitch"))
-        assert health["connected"] is True
-        assert health["last_seen"] > 0
-        assert health["app_id"] == APP_IDS["rfswitch"]
+        hb_reader = HeartbeatReader(
+            mgr.transport, name=pico_heartbeat_name("rfswitch")
+        )
+        assert hb_reader.check() is True
 
-    def test_health_reflects_actual_status_time(self, mgr):
+    def test_stopped_device_heartbeat_dead(self, mgr, monkeypatch):
         pico = _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         wait_for_condition(
             lambda: pico.last_status_time is not None,
             cadence_ms=CADENCE_MS,
         )
+        # Simulate a silent, unreachable device: disconnect, backdate
+        # last_status_time past HEALTH_TIMEOUT, and force reconnect()
+        # to fail so _check_health gives up and writes alive=False.
+        pico.disconnect()
+        pico.last_status_time = time.time() - 60
+        monkeypatch.setattr(pico, "reconnect", lambda: False)
         mgr._check_health()
-        r = mgr._redis()
-        health = json.loads(r.hget(HEALTH_HASH, "rfswitch"))
-        assert health["last_seen"] == pico.last_status_time
+        hb_reader = HeartbeatReader(
+            mgr.transport, name=pico_heartbeat_name("rfswitch")
+        )
+        assert hb_reader.check() is False
 
 
 # --- TestCommandRelay -------------------------------------------------------
@@ -287,10 +181,8 @@ class TestCommandRelay:
             lambda: pico.last_status.get("sensor_name") is not None,
             cadence_ms=CADENCE_MS,
         )
-        r = mgr._redis()
         before = pico.last_status.get("sw_state")
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -305,7 +197,7 @@ class TestCommandRelay:
             max_cycles=10,
         )
         assert settled == pico.paths["VNAO"]
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
 
     def test_motor_moves_to_target(self, mgr):
@@ -314,9 +206,7 @@ class TestCommandRelay:
             lambda: pico.last_status_time is not None,
             cadence_ms=CADENCE_MS,
         )
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "motor",
@@ -344,9 +234,7 @@ class TestCommandRelay:
             lambda: pico.last_status_time is not None,
             cadence_ms=CADENCE_MS,
         )
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "tempctrl",
@@ -360,13 +248,12 @@ class TestCommandRelay:
                 "source": "test",
             },
         )
-        # Only verify the target was set, not convergence.
         wait_for_condition(
             lambda: pico.last_status.get("LNA_T_target") == 30.0,
             cadence_ms=CADENCE_MS,
             max_cycles=10,
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
 
     def test_raw_command_rejected(self, mgr):
@@ -375,9 +262,7 @@ class TestCommandRelay:
             lambda: pico.last_status.get("sensor_name") is not None,
             cadence_ms=CADENCE_MS,
         )
-        r = mgr._redis()
         mgr._process_command(
-            r,
             "1-0",
             {
                 "target": "rfswitch",
@@ -385,7 +270,7 @@ class TestCommandRelay:
                 "source": "test",
             },
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "error"
         assert "action" in resp["data"]
 
@@ -406,6 +291,9 @@ class TestCmdLoopEndToEnd:
         )
         mgr._cmd_thread.start()
 
+    def _count_responses(self, mgr):
+        return mgr.transport.r.xlen(PICO_RESP_STREAM)
+
     def test_stream_message_processed(self, mgr):
         pico = _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         wait_for_condition(
@@ -413,26 +301,23 @@ class TestCmdLoopEndToEnd:
             cadence_ms=CADENCE_MS,
         )
         self._start_cmd_loop(mgr)
-        r = mgr._redis()
         before = pico.last_status.get("sw_state")
-        r.xadd(
-            CMD_STREAM,
+        mgr.transport.r.xadd(
+            PICO_CMD_STREAM,
             {
                 "target": "rfswitch",
                 "cmd": json.dumps({"action": "switch", "state": "VNAO"}),
                 "source": "e2e_test",
             },
         )
-        # Wait for response in RESP_STREAM.
         wait_for_condition(
-            lambda: len(r._streams.get(RESP_STREAM, [])) > 0,
+            lambda: self._count_responses(mgr) > 0,
             cadence_ms=CADENCE_MS,
             max_cycles=40,
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "ok"
         assert resp["target"] == "rfswitch"
-        # Verify emulator state actually changed.
         settled = wait_for_settle(
             lambda: pico.last_status.get("sw_state"),
             initial=before,
@@ -448,17 +333,16 @@ class TestCmdLoopEndToEnd:
             cadence_ms=CADENCE_MS,
         )
         self._start_cmd_loop(mgr)
-        r = mgr._redis()
-        r.xadd(
-            CMD_STREAM,
+        mgr.transport.r.xadd(
+            PICO_CMD_STREAM,
             {
                 "target": "rfswitch",
                 "cmd": json.dumps({"action": "switch", "state": "VNAO"}),
                 "source": "test",
             },
         )
-        r.xadd(
-            CMD_STREAM,
+        mgr.transport.r.xadd(
+            PICO_CMD_STREAM,
             {
                 "target": "rfswitch",
                 "cmd": json.dumps({"action": "switch", "state": "RFANT"}),
@@ -466,14 +350,13 @@ class TestCmdLoopEndToEnd:
             },
         )
         wait_for_condition(
-            lambda: len(r._streams.get(RESP_STREAM, [])) >= 2,
+            lambda: self._count_responses(mgr) >= 2,
             cadence_ms=CADENCE_MS,
             max_cycles=40,
         )
         assert all(
-            resp["status"] == "ok" for _, resp in r._streams[RESP_STREAM]
+            resp["status"] == "ok" for resp in _all_responses(mgr.transport)
         )
-        # Final state should match the last command.
         settled = wait_for_settle(
             lambda: pico.last_status.get("sw_state"),
             cadence_ms=CADENCE_MS,
@@ -483,9 +366,12 @@ class TestCmdLoopEndToEnd:
 
     def test_error_for_unknown_target(self, mgr):
         self._start_cmd_loop(mgr)
-        r = mgr._redis()
-        r.xadd(
-            CMD_STREAM,
+        # Give cmd_loop a moment to reach its first blocking xread so
+        # the $ cursor is in place before we xadd (otherwise the add
+        # races ahead of the read and the message is missed).
+        time.sleep(0.1)
+        mgr.transport.r.xadd(
+            PICO_CMD_STREAM,
             {
                 "target": "nonexistent",
                 "cmd": "{}",
@@ -493,11 +379,11 @@ class TestCmdLoopEndToEnd:
             },
         )
         wait_for_condition(
-            lambda: len(r._streams.get(RESP_STREAM, [])) > 0,
+            lambda: self._count_responses(mgr) > 0,
             cadence_ms=CADENCE_MS,
             max_cycles=40,
         )
-        _, resp = r._streams[RESP_STREAM][0]
+        resp = _last_response(mgr.transport)
         assert resp["status"] == "error"
         assert "unknown target" in json.loads(resp["data"])["error"]
 
@@ -508,22 +394,18 @@ class TestCmdLoopEndToEnd:
 class TestDiscoverIntegration:
     """discover() with Dummy classes produces live devices."""
 
-    def test_discover_creates_live_device(self, mgr, monkeypatch, tmp_path):
+    def test_discover_creates_live_device(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
 
-        cfg = tmp_path / "pico_config.json"
-        cfg.write_text(
-            json.dumps(
-                [
-                    {
-                        "app_id": 5,
-                        "port": "/dev/dummy",
-                        "usb_serial": "INT123",
-                    },
-                ]
-            )
+        PicoConfigStore(mgr.transport).upload(
+            [
+                {
+                    "app_id": 5,
+                    "port": "/dev/dummy",
+                    "usb_serial": "INT123",
+                },
+            ]
         )
-        mgr.config_file = cfg
         monkeypatch.setitem(
             mgr_mod.PICO_CLASSES,
             "rfswitch",
@@ -537,9 +419,9 @@ class TestDiscoverIntegration:
             lambda: pico.last_status.get("sensor_name") == "rfswitch",
             cadence_ms=CADENCE_MS,
         )
-        # Status should also flow to add_metadata.
-        mock = mgr.eig_redis
+        # Status flows into the metadata snapshot.
+        snap = _metadata_snapshot(mgr.transport)
         wait_for_condition(
-            lambda: "rfswitch" in _metadata_names(mock),
+            lambda: "rfswitch" in snap.get(),
             cadence_ms=CADENCE_MS,
         )

--- a/picohost/tests/test_proxy.py
+++ b/picohost/tests/test_proxy.py
@@ -1,200 +1,53 @@
 """
 Tests for picohost.proxy — Redis-backed device proxies.
 
-Uses an in-test MockRedis with thread-safe stream support so that
-PicoManager's cmd_loop thread can process commands in the background
-while the proxy reads responses in the foreground.
+Uses the fakeredis-backed ``DummyTransport`` from eigsep_redis so the
+full command/response round-trip exercises real xadd/xread semantics
+with a live PicoManager.cmd_loop running in a background thread.
 """
 
-import json
-import threading
-import time
-
 import pytest
+from eigsep_redis import HeartbeatWriter
+from eigsep_redis.testing import DummyTransport
 
-from picohost.manager import (
-    PICOS_SET,
-    RESP_STREAM,
-    PicoManager,
+from picohost.keys import (
+    PICO_RESP_STREAM,
+    pico_heartbeat_name,
 )
+from picohost.manager import HEARTBEAT_TTL, PicoManager
 from picohost.proxy import PicoProxy
 from picohost.testing import DummyPicoRFSwitch
-
-
-class MockRedis:
-    """
-    Thread-safe MockRedis with blocking ``xread`` support.
-
-    Messages use integer-prefixed IDs (``"0-0"``, ``"1-0"``, ...)
-    so that ``cmd_loop`` and the proxy can interleave reads.
-    """
-
-    def __init__(self):
-        self._sets = {}
-        self._hashes = {}
-        self._keys = {}
-        self._streams = {}
-        self._counter = 0
-        self._cv = threading.Condition()
-        self.r = self
-
-    def add_metadata(self, name, data):
-        pass
-
-    # -- sets --
-
-    def sadd(self, key, *values):
-        with self._cv:
-            self._sets.setdefault(key, set()).update(
-                v if isinstance(v, str) else v.decode()
-                for v in values
-            )
-
-    def srem(self, key, *values):
-        with self._cv:
-            s = self._sets.get(key, set())
-            for v in values:
-                s.discard(v if isinstance(v, str) else v.decode())
-
-    def smembers(self, key):
-        with self._cv:
-            return set(self._sets.get(key, set()))
-
-    def sismember(self, key, member):
-        with self._cv:
-            if isinstance(member, bytes):
-                member = member.decode()
-            return member in self._sets.get(key, set())
-
-    # -- hashes --
-
-    def hset(self, name, key=None, value=None, mapping=None):
-        with self._cv:
-            self._hashes.setdefault(name, {})
-            if key is not None:
-                self._hashes[name][key] = value
-            if mapping:
-                self._hashes[name].update(mapping)
-
-    def hget(self, name, key):
-        with self._cv:
-            return self._hashes.get(name, {}).get(key)
-
-    def hgetall(self, name):
-        with self._cv:
-            return dict(self._hashes.get(name, {}))
-
-    # -- keys --
-
-    def set(self, key, value, ex=None):
-        with self._cv:
-            self._keys[key] = value
-
-    def get(self, key):
-        with self._cv:
-            return self._keys.get(key)
-
-    def delete(self, *keys):
-        with self._cv:
-            for key in keys:
-                self._keys.pop(key, None)
-
-    # -- streams (thread-safe with blocking xread) --
-
-    def xadd(self, stream, fields, maxlen=None):
-        with self._cv:
-            msgs = self._streams.setdefault(stream, [])
-            msg_id = f"{self._counter}-0"
-            self._counter += 1
-            msgs.append((msg_id, fields))
-            self._cv.notify_all()
-            return msg_id
-
-    def xinfo_stream(self, stream):
-        with self._cv:
-            msgs = self._streams.get(stream, [])
-            if not msgs:
-                raise Exception(f"no such key: {stream}")
-            return {"last-generated-id": msgs[-1][0]}
-
-    def xread(self, streams, block=None, count=None):
-        timeout_s = (block / 1000.0) if block else 0
-        deadline = time.time() + timeout_s if block else 0
-
-        with self._cv:
-            # Resolve "$" → current stream end
-            resolved = {}
-            for stream_name, last_id in streams.items():
-                if isinstance(last_id, bytes):
-                    last_id = last_id.decode()
-                if last_id == "$":
-                    msgs = self._streams.get(stream_name, [])
-                    last_id = msgs[-1][0] if msgs else "-1-0"
-                resolved[stream_name] = last_id
-
-            while True:
-                result = self._collect(resolved, count)
-                if result:
-                    return result
-                if not block or time.time() >= deadline:
-                    return []
-                remaining = deadline - time.time()
-                if remaining <= 0:
-                    return []
-                self._cv.wait(timeout=min(remaining, 0.05))
-
-    def _collect(self, resolved, count):
-        result = []
-        for stream_name, last_id in resolved.items():
-            msgs = self._streams.get(stream_name, [])
-            new = [
-                (mid, f) for mid, f in msgs
-                if self._id_gt(mid, last_id)
-            ]
-            if new:
-                key = (
-                    stream_name.encode()
-                    if isinstance(stream_name, str)
-                    else stream_name
-                )
-                result.append((key, new[:count] if count else new))
-        return result
-
-    @staticmethod
-    def _id_gt(a, b):
-        """Compare Redis stream IDs numerically."""
-        try:
-            return int(a.split("-")[0]) > int(b.split("-")[0])
-        except (ValueError, IndexError):
-            return a > b
 
 
 # --- fixtures ---------------------------------------------------------------
 
 
 @pytest.fixture
-def redis():
-    return MockRedis()
+def transport():
+    return DummyTransport()
 
 
 @pytest.fixture
-def mgr(redis):
+def mgr(transport):
     """PicoManager with a DummyPicoRFSwitch, cmd_loop running."""
-    m = PicoManager(redis)
+    m = PicoManager(transport)
     pico = DummyPicoRFSwitch(
-        "/dev/dummy", eig_redis=redis, name="rfswitch"
+        "/dev/dummy", metadata_writer=m._metadata_writer, name="rfswitch"
     )
     m.picos["rfswitch"] = pico
-    redis.sadd(PICOS_SET, "rfswitch")
+    m._heartbeats["rfswitch"] = HeartbeatWriter(
+        transport, name=pico_heartbeat_name("rfswitch")
+    )
+    m._heartbeats["rfswitch"].set(ex=HEARTBEAT_TTL, alive=True)
     m.start()
     yield m
     m.stop()
 
 
 @pytest.fixture
-def sw(redis, mgr):
+def sw(transport, mgr):
     """PicoProxy for the rfswitch device wired to the running manager."""
-    return PicoProxy("rfswitch", redis, source="test", timeout=5.0)
+    return PicoProxy("rfswitch", transport, source="test", timeout=5.0)
 
 
 # --- PicoProxy -------------------------------------------------------------
@@ -209,8 +62,8 @@ class TestPicoProxy:
         # Manager wraps the device return as {"action": ..., "result": ...}
         assert result["action"] == "switch"
 
-    def test_send_command_unavailable_returns_none(self, redis):
-        proxy = PicoProxy("nonexistent", redis, timeout=1.0)
+    def test_send_command_unavailable_returns_none(self, transport):
+        proxy = PicoProxy("nonexistent", transport, timeout=1.0)
         assert proxy.send_command("switch", state="RFANT") is None
 
     def test_send_command_invalid_state_raises(self, sw):
@@ -218,40 +71,30 @@ class TestPicoProxy:
         with pytest.raises(RuntimeError, match="Invalid switch state"):
             sw.send_command("switch", state="BOGUS")
 
-    def test_send_command_timeout(self, redis):
+    def test_send_command_timeout(self, transport):
         """If manager never responds, proxy raises TimeoutError."""
-        redis.sadd(PICOS_SET, "orphan")
-        proxy = PicoProxy("orphan", redis, timeout=0.2)
+        # Fake an "alive" device with no manager to route commands
+        HeartbeatWriter(
+            transport, name=pico_heartbeat_name("orphan")
+        ).set(ex=60, alive=True)
+        proxy = PicoProxy("orphan", transport, timeout=0.2)
         with pytest.raises(TimeoutError, match="No response"):
             proxy.send_command("switch", state="RFANT")
 
-    def test_send_command_error_raises_runtime(self, redis, mgr):
+    def test_send_command_error_raises_runtime(self, transport, mgr):
         """If manager returns an error, proxy raises RuntimeError."""
-        proxy = PicoProxy("rfswitch", redis, source="test", timeout=5.0)
+        proxy = PicoProxy(
+            "rfswitch", transport, source="test", timeout=5.0
+        )
         with pytest.raises(RuntimeError, match="not allowed"):
             proxy.send_command("disconnect")
 
     def test_is_available_true(self, sw):
         assert sw.is_available is True
 
-    def test_is_available_false(self, redis):
-        proxy = PicoProxy("ghost", redis, timeout=1.0)
+    def test_is_available_false(self, transport):
+        proxy = PicoProxy("ghost", transport, timeout=1.0)
         assert proxy.is_available is False
-
-    def test_health_available(self, sw, redis):
-        # PicoManager writes health in _check_health, but we can also
-        # manually set it to verify the proxy reads it.
-        redis.hset(
-            "pico_health", "rfswitch",
-            json.dumps({"connected": True, "last_seen": 1.0, "app_id": 5}),
-        )
-        h = sw.health
-        assert h["connected"] is True
-        assert h["app_id"] == 5
-
-    def test_health_missing(self, redis):
-        proxy = PicoProxy("ghost", redis)
-        assert proxy.health is None
 
 
 # --- request_id echo -------------------------------------------------------
@@ -259,19 +102,18 @@ class TestPicoProxy:
 
 class TestRequestId:
 
-    def test_response_contains_request_id(self, sw, redis):
+    def test_response_contains_request_id(self, sw, transport):
         """The manager echoes request_id in the response."""
         sw.send_command("switch", state="RFANT")
-        # Check that RESP_STREAM has at least one message with request_id
-        msgs = redis._streams.get(RESP_STREAM, [])
-        assert len(msgs) > 0
-        _, fields = msgs[-1]
-        assert "request_id" in fields
-        assert fields["request_id"] != ""
+        entries = transport.r.xrange(PICO_RESP_STREAM)
+        assert entries
+        _, fields = entries[-1]
+        assert b"request_id" in fields
+        assert fields[b"request_id"] != b""
 
-    def test_request_id_unique_per_call(self, sw, redis):
+    def test_request_id_unique_per_call(self, sw, transport):
         sw.send_command("switch", state="RFANT")
         sw.send_command("switch", state="RFNON")
-        msgs = redis._streams.get(RESP_STREAM, [])
-        ids = [f["request_id"] for _, f in msgs]
+        entries = transport.r.xrange(PICO_RESP_STREAM)
+        ids = [fields[b"request_id"].decode() for _, fields in entries]
         assert len(set(ids)) == len(ids)


### PR DESCRIPTION
Make Redis the source of truth for pico-manager and drop the
``pico_config.json`` cascade. ``flash-picos`` now publishes the
discovered device list straight into a new :class:`PicoConfigStore`
(under ``pico_config``), and :class:`PicoManager` reads the same
store at boot, falling back to flash-and-discover only when Redis
is empty. No intermediate file, no ``--config``, no
``use_redis_config`` toggle.

Every raw ``r.hset`` / ``r.xadd`` / ``r.sadd`` call in the manager
is gone. The manager now holds an ``eigsep_redis.Transport`` and
builds its writers/readers on top of it:

- :class:`eigsep_redis.MetadataWriter` — passed to each
  :class:`PicoDevice` so firmware status packets land on the same
  ``metadata`` snapshot hash and ``stream:{sensor}`` streams as
  every other sensor in the system. ``PicoDevice.__init__`` accepts
  ``metadata_writer=`` instead of ``eig_redis=``; the old
  ``EigsepRedis.add_metadata`` shim is no longer used.
- :class:`eigsep_redis.HeartbeatWriter` — one per device, keyed
  ``heartbeat:pico:{name}`` via the new ``name=`` kwarg upstream.
  Replaces the bespoke ``pico_health`` hash and ``picos`` set; a
  consumer checks :class:`HeartbeatReader.check` instead of
  parsing JSON out of ``hget``.
- :class:`eigsep_redis.StatusWriter` — manager log events
  (discover, reconnect, stop) land on the shared ``stream:status``
  alongside every other service.
- :class:`picohost.buses.PicoCmdReader` /
  :class:`picohost.buses.PicoRespWriter` /
  :class:`picohost.buses.PicoClaimStore` — command/response stream
  and soft claims, the one picohost-specific surface with no
  eigsep_observing analogue. These live in picohost (mirroring how
  eigsep_observing owns CorrWriter/CorrReader) because no other
  service needs them.

:class:`PicoProxy` now takes a ``Transport`` instead of a raw
redis client and uses :class:`HeartbeatReader` for its
``is_available`` check, replacing the old ``health`` property that
read the bespoke health hash.

The vestigial ``picohost/scripts/flash-picos`` wrapper is removed;
``pyproject.toml`` has declared ``flash-picos`` as an entry point
since 1.x and the script was never referenced by anything.

BREAKING CHANGE: Redis schema rework. ``pico_config`` /
``pico_health`` / ``picos`` keys are replaced by the new
config-store blob and per-device ``heartbeat:pico:{name}`` keys.
``flash-picos`` now publishes to Redis by default
(``--output-file`` is an opt-in for offline provisioning).
``PicoDevice`` / ``PicoMotor`` / ``PicoPeltier`` /
``PicoPotentiometer`` constructors take ``metadata_writer=``
instead of ``eig_redis=``. ``PicoProxy`` takes a ``Transport``
instead of a raw redis client.

Requires eigsep_redis with the named-heartbeat change (branch
``feat/named-heartbeat``).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
