### PR TITLE
perf(picohost): cut test suite runtime ~48%

### DIFF
--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -58,7 +58,7 @@ from .buses import (
     PicoConfigStore,
     PicoRespWriter,
 )
-from .keys import pico_heartbeat_name
+from .keys import PICO_CMD_STREAM, pico_heartbeat_name
 from .motor import PicoMotor
 
 logger = logging.getLogger(__name__)
@@ -160,6 +160,7 @@ class PicoManager:
         self._claim_store = PicoClaimStore(transport)
         self._status_writer = StatusWriter(transport)
         self._running = False
+        self._stop_event = threading.Event()
         self._health_thread = None
         self._cmd_thread = None
         # Serializes mutations of self.picos / self._heartbeats between
@@ -296,7 +297,8 @@ class PicoManager:
             except Exception as e:
                 if self._running:
                     self.logger.error(f"health_loop error: {e}")
-            time.sleep(HEALTH_CHECK_INTERVAL)
+            if self._stop_event.wait(HEALTH_CHECK_INTERVAL):
+                break
 
     def _check_health(self):
         """Run one iteration of health checks for all picos."""
@@ -346,6 +348,8 @@ class PicoManager:
             try:
                 messages = self._cmd_reader.read(timeout=1.0, count=10)
                 for msg_id, fields in messages:
+                    if not self._running:
+                        return
                     self._process_command(msg_id, fields)
             except Exception as e:
                 if self._running:
@@ -524,6 +528,7 @@ class PicoManager:
     def start(self):
         """Start the health monitor and command relay threads."""
         self._running = True
+        self._stop_event.clear()
         self._health_thread = threading.Thread(
             target=self.health_loop, daemon=True, name="health"
         )
@@ -538,6 +543,13 @@ class PicoManager:
         """Graceful shutdown: stop threads, disconnect picos, mark dead."""
         self._status("PicoManager stopping...")
         self._running = False
+        self._stop_event.set()
+        # Wake cmd_loop's blocking xread so it observes _running = False
+        # without waiting out the full block timeout.
+        try:
+            self.transport.r.xadd(PICO_CMD_STREAM, {"__shutdown__": "1"})
+        except Exception:
+            pass
         if self._health_thread:
             self._health_thread.join(timeout=HEALTH_CHECK_INTERVAL + 1)
         if self._cmd_thread:

--- a/picohost/tests/test_main_loop_scheduling.py
+++ b/picohost/tests/test_main_loop_scheduling.py
@@ -15,6 +15,7 @@ These tests model the main loop algorithm in Python and verify that:
 """
 
 import time
+from collections import deque
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +34,7 @@ class MainLoopModel:
 
     def __init__(self, max_read_only_s=MAX_READ_ONLY_S):
         self.max_read_only_s = max_read_only_s
-        self.input_queue: list[str] = []
+        self.input_queue: deque[str] = deque()
         self.buffer: list[str] = []
         self.op_call_times: list[float] = []
         self.server_calls: list[str] = []  # completed commands
@@ -46,7 +47,7 @@ class MainLoopModel:
     def _getchar(self):
         """Non-blocking read of one character (models getchar_timeout_us(0))."""
         if self.input_queue:
-            return self.input_queue.pop(0)
+            return self.input_queue.popleft()
         return None
 
     def _app_op(self):
@@ -134,11 +135,11 @@ class TestAntiStarvation:
         threshold = 0.005  # 5 ms
         model = MainLoopModel(max_read_only_s=threshold)
         # Push a large block of data with no newline
-        model.push_input("x" * 500_000)
+        model.push_input("x" * 100_000)
 
         start = time.monotonic()
         op_ran = False
-        for _ in range(500_000):
+        for _ in range(100_000):
             if model.tick():
                 op_ran = True
                 break
@@ -156,11 +157,11 @@ class TestAntiStarvation:
         model = MainLoopModel(max_read_only_s=0.005)
         # Push partial command (no newline), enough to trigger forced op()
         partial = '{"cmd":"hello'
-        padding = "x" * 500_000  # ensure we exceed the time threshold
+        padding = "x" * 100_000  # ensure we exceed the time threshold
         model.push_input(partial + padding)
 
         # Run until op() is forced (and beyond)
-        for _ in range(500_000):
+        for _ in range(100_000):
             model.tick()
 
         assert len(model.op_call_times) >= 1, "op() should have been forced"
@@ -179,9 +180,9 @@ class TestAntiStarvation:
     def test_op_called_multiple_times_during_long_flood(self):
         """During a very long flood, op() should be called repeatedly."""
         model = MainLoopModel(max_read_only_s=0.005)
-        model.push_input("x" * 500_000)
+        model.push_input("x" * 100_000)
 
-        for _ in range(500_000):
+        for _ in range(100_000):
             model.tick()
 
         # With 5ms threshold, we should get multiple op() calls


### PR DESCRIPTION
## Summary

Before: 274 tests in ~172s. After: same 274 tests in ~90s. No coverage loss — two targeted root-cause fixes.

- **Manager shutdown no longer waits for blocking I/O.** `health_loop` used `time.sleep(5)`, so `PicoManager.stop()` had to wait out the full cadence before its `join()` returned. `cmd_loop`'s `xread(block=1000)` added up to another second. Seven `test_proxy.py` teardowns paid ~5s each (~38s); `test_start_stop` paid another 5s. Now `health_loop` uses `threading.Event.wait()` (interrupted by `stop()`), and `stop()` xadds a `__shutdown__` sentinel on `CMD_STREAM` to unblock `cmd_loop`'s xread. `cmd_loop` re-checks `_running` between messages so the sentinel is dropped without dispatch. This also improves production `Ctrl+C` responsiveness.
- **Main-loop scheduling tests use deque.** The anti-starvation tests pushed 500k chars through a `list` and `pop(0)` each tick — O(n²). Switched to `collections.deque.popleft()` (O(1)) and trimmed the flood to 100k (still orders of magnitude beyond the 5ms threshold). Two tests drop from ~20s each to sub-second.

## Test plan

- [x] `pytest --no-cov` passes all 274 tests (~90s, down from ~172s)
- [x] Spot-check on CI that the full matrix (Python 3.10–3.12) stays green
- [ ] Manual verification that `pico-manager` still shuts down cleanly on `Ctrl+C`

🤖 Generated with [Claude Code](https://claude.com/claude-code)