### PR TITLE
feat(picohost): make Redis the canonical pot calibration store

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 [project.scripts]
 flash-picos = "picohost.flash_picos:main"
 pico-manager = "picohost.manager:main"
+calibrate-pot = "picohost.calibrate_pot:main"
 
 [project.optional-dependencies]
 dev = [

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -637,6 +637,7 @@ class PicoPotentiometer(PicoDevice):
         self,
         port,
         calibration_file=None,
+        pot_cal_store=None,
         timeout=5.0,
         name=None,
         metadata_writer=None,
@@ -648,8 +649,14 @@ class PicoPotentiometer(PicoDevice):
         port : str
             Serial port device.
         calibration_file : str, optional
-            Path to a JSON calibration file. If provided, calibration
-            parameters are loaded at init.
+            Path to a JSON calibration file. Used only when Redis has
+            no calibration (or no ``pot_cal_store`` was provided).
+        pot_cal_store : picohost.buses.PotCalStore, optional
+            Redis-backed calibration store. When provided and the
+            store holds a calibration, it takes precedence over
+            ``calibration_file`` — the cal is applied before the
+            first status tick, so a pot Pico that reboots picks its
+            cal up from Redis without any on-disk file.
         timeout : float
             Serial read timeout in seconds (default: 5.0).
         name : str, optional
@@ -666,7 +673,18 @@ class PicoPotentiometer(PicoDevice):
             metadata_writer=metadata_writer,
             usb_serial=usb_serial,
         )
-        if calibration_file is not None:
+        # Cal source precedence: Redis wins, JSON fallback,
+        # uncalibrated if neither (matches the project decision that
+        # Redis is the canonical cal store).
+        cal_from_redis = None
+        if pot_cal_store is not None:
+            cal_from_redis = pot_cal_store.get()
+        if cal_from_redis is not None:
+            if "pot_el" in cal_from_redis:
+                self._cal["pot_el"] = tuple(cal_from_redis["pot_el"])
+            if "pot_az" in cal_from_redis:
+                self._cal["pot_az"] = tuple(cal_from_redis["pot_az"])
+        elif calibration_file is not None:
             self.load_calibration(calibration_file)
         # Wrap the base redis handler to convert voltages to angles
         if self.redis_handler is not None:

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -6,11 +6,16 @@ pattern in ``eigsep_observing.corr``: each class takes an
 ``eigsep_redis.Transport`` at construction, and the concerns are
 split into the smallest stable surface per bus.
 
-Four buses here:
+Five buses here:
 
 - :class:`PicoConfigStore` — persistent single-key blob holding the
   list of picos (app id, serial port, usb serial) written once by
   ``flash-picos`` and read on manager boot as the source of truth.
+- :class:`PotCalStore` — persistent single-key blob holding the
+  potentiometer calibration (voltage-to-angle slope/intercept for
+  both pots). Written by ``calibrate-pot`` and read by
+  :class:`picohost.PicoPotentiometer` at startup so a rebooted
+  pot Pico picks up its cal from Redis without a local JSON file.
 - :class:`PicoCmdReader` — blocking reader for the pico command
   stream. Consumed by the manager's command-relay thread.
 - :class:`PicoRespWriter` — writer for the pico response stream.
@@ -35,6 +40,7 @@ from .keys import (
     PICO_CMD_STREAM,
     PICO_CONFIG_KEY,
     PICO_RESP_STREAM,
+    POT_CAL_KEY,
     pico_claim_key,
 )
 
@@ -99,6 +105,67 @@ class PicoConfigStore:
     def clear(self):
         """Delete the stored config. Used by ``--clear-config``."""
         self.transport.r.delete(PICO_CONFIG_KEY)
+
+
+class PotCalStore:
+    """
+    Persistent single-key store for potentiometer calibration.
+
+    The value under :data:`POT_CAL_KEY` is a JSON object shaped like
+    ``{"pot_el": [m, b], "pot_az": [m, b], "metadata": {...},
+    "upload_time": ...}`` — the canonical ``upload_time`` field is
+    injected by :meth:`Transport.upload_dict` at the top level.
+    ``metadata`` carries audit fields written by ``calibrate-pot``
+    (timestamp, port, sample count, raw voltages) and is preserved
+    verbatim on upload/get.
+
+    ``calibrate-pot`` uploads after each calibration run. A fresh
+    :class:`picohost.PicoPotentiometer` reads this store at
+    ``__init__`` time when given a :class:`PotCalStore` and applies
+    the cal before the first status tick — so a pot Pico that
+    reboots without a local cal file comes up calibrated from Redis.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload(self, cal):
+        """Upload calibration parameters.
+
+        Parameters
+        ----------
+        cal : dict
+            Must carry ``pot_el`` and ``pot_az`` entries, each a
+            ``(slope, intercept)`` pair (list or tuple). Extra
+            fields (e.g. ``metadata``) are preserved verbatim.
+        """
+        self.transport.upload_dict(dict(cal), POT_CAL_KEY)
+
+    def get(self):
+        """Return the stored calibration dict.
+
+        Returns
+        -------
+        dict or None
+            ``None`` if no calibration has been uploaded, or if the
+            stored JSON fails to decode. The caller falls back to
+            its next source (JSON file, then uncalibrated).
+        """
+        raw = self.transport.get_raw(POT_CAL_KEY)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Corrupted {POT_CAL_KEY} in Redis ({e}); "
+                "falling back to next calibration source."
+            )
+            return None
+
+    def clear(self):
+        """Delete the stored calibration."""
+        self.transport.r.delete(POT_CAL_KEY)
 
 
 class PicoCmdReader:

--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -1,27 +1,75 @@
 """
-Manual potentiometer calibration script for lab use.
+Manual potentiometer calibration entry point.
 
-Connects to a potentiometer Pico, prompts the user to set min and max
-positions, collects voltage samples, computes a linear fit, and saves
-calibration to a JSON file that PicoPotentiometer.load_calibration() can read.
+Auto-discovers the potentiometer Pico (by USB VID/PID + probing the
+``sensor_name`` field of its status JSON), walks the user through a
+voltage-to-angle sweep, computes a linear fit, and publishes the result
+to both Redis (canonical, via :class:`picohost.buses.PotCalStore`) and
+a timestamped JSON artifact on disk (audit). A rebooted
+:class:`picohost.PicoPotentiometer` picks the Redis cal up at
+``__init__`` time so no JSON file needs to be accessible on the Pico
+host.
 
 Two modes:
   --mode minmax   : collect only at min and max (2-point fit, default)
   --mode turns    : collect at every full turn from min to max (least-squares)
 
 Usage:
-    python calibrate_pot.py -p /dev/ttyACM0 -o pot_calibration.json
-    python calibrate_pot.py -p /dev/ttyACM0 --mode turns
+    calibrate-pot
+    calibrate-pot -p /dev/ttyACM0 --mode turns
+    calibrate-pot --no-redis -o pot_cal_bench.json
 """
 
 from argparse import ArgumentParser
 import json
+import logging
+import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import numpy as np
+from eigsep_redis import Transport
 
-from picohost import PicoPotentiometer
+from .base import PicoPotentiometer
+from .buses import PotCalStore
+from .flash_picos import find_pico_ports, read_json_from_serial
+
+logger = logging.getLogger(__name__)
+
+POTMON_SENSOR_NAME = "potmon"
+
+
+def discover_pot_port(probe_timeout=3.0):
+    """Return the serial port of the connected potentiometer Pico.
+
+    Opens each Pico-VID port in turn, reads one JSON status line, and
+    matches on ``sensor_name == "potmon"``. Raises if zero or multiple
+    pot Picos are found — in those cases the caller must pass ``-p``
+    to disambiguate or fix the wiring.
+    """
+    ports = find_pico_ports()
+    if not ports:
+        raise RuntimeError("No Raspberry Pi Pico serial ports found.")
+    matches = []
+    for port_dev in ports:
+        try:
+            data = read_json_from_serial(port_dev, 115200, probe_timeout)
+        except RuntimeError:
+            continue
+        if data.get("sensor_name") == POTMON_SENSOR_NAME:
+            matches.append(port_dev)
+    if not matches:
+        raise RuntimeError(
+            "No potentiometer Pico found. Confirm the pot pico is flashed "
+            "with APP_POTMON and connected."
+        )
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Multiple potentiometer Picos found on {matches}. "
+            "Pass -p <port> to pick one."
+        )
+    return matches[0]
 
 
 def collect_samples(pot, n, interval=0.25):
@@ -95,23 +143,37 @@ def collect_per_turn(pot, n_samples, turns):
     return voltages_0, voltages_1, angles
 
 
+def _default_output_path():
+    """Timestamped default filename — never overwrites prior runs."""
+    # Use "-" instead of ":" in the time part so the filename is valid
+    # on every filesystem (Windows/macOS reject ":" in filenames).
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    return f"pot_cal_{stamp}.json"
+
+
 def main():
     parser = ArgumentParser(
-        description="Calibrate potentiometer voltage-to-angle mapping."
+        description="Calibrate potentiometer voltage-to-angle mapping.",
     )
     parser.add_argument(
         "-p",
         "--port",
         type=str,
-        required=True,
-        help="Serial port for the potentiometer Pico",
+        default=None,
+        help=(
+            "Serial port for the potentiometer Pico. Auto-discovered "
+            "when omitted."
+        ),
     )
     parser.add_argument(
         "-o",
         "--output",
         type=str,
-        default="pot_calibration.json",
-        help="Output calibration file (default: pot_calibration.json)",
+        default=None,
+        help=(
+            "Output JSON artifact path. Defaults to a timestamped file "
+            "in the current directory so prior runs aren't overwritten."
+        ),
     )
     parser.add_argument(
         "-t",
@@ -125,7 +187,10 @@ def main():
         "--n-samples",
         type=int,
         default=10,
-        help="Number of voltage samples to average at each position (default: 10)",
+        help=(
+            "Number of voltage samples to average at each position "
+            "(default: 10)"
+        ),
     )
     parser.add_argument(
         "-m",
@@ -133,10 +198,44 @@ def main():
         type=str,
         choices=["minmax", "turns"],
         default="minmax",
-        help="Calibration mode: 'minmax' for 2-point, 'turns' for per-turn "
-        "least-squares (default: minmax)",
+        help=(
+            "Calibration mode: 'minmax' for 2-point, 'turns' for "
+            "per-turn least-squares (default: minmax)"
+        ),
+    )
+    parser.add_argument(
+        "--redis-host",
+        default="localhost",
+        help="Redis host for PotCalStore publication",
+    )
+    parser.add_argument(
+        "--redis-port",
+        type=int,
+        default=6379,
+        help="Redis port for PotCalStore publication",
+    )
+    parser.add_argument(
+        "--no-redis",
+        action="store_true",
+        help=(
+            "Skip Redis publication. The JSON artifact is still written; "
+            "use this on a bench host without a Redis instance."
+        ),
     )
     args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    if args.port is None:
+        try:
+            args.port = discover_pot_port()
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+        print(f"Discovered potentiometer Pico on {args.port}.")
 
     total_degrees = 360.0 * args.turns
 
@@ -164,8 +263,8 @@ def main():
     cal1 = compute_linear_fit(voltages_1, angles)
 
     if cal0 is None or cal1 is None:
-        print("\nCalibration failed. Exiting.")
-        raise SystemExit(1)
+        print("\nCalibration failed. Exiting.", file=sys.stderr)
+        sys.exit(1)
 
     cal_data = {
         "pot_el": list(cal0),
@@ -184,9 +283,28 @@ def main():
         },
     }
 
-    with open(args.output, "w") as f:
+    # Redis publication (canonical source for PicoManager-spawned pots)
+    if not args.no_redis:
+        try:
+            transport = Transport(host=args.redis_host, port=args.redis_port)
+            PotCalStore(transport).upload(cal_data)
+            print(
+                f"Published calibration to Redis at "
+                f"{args.redis_host}:{args.redis_port} (key: pot_calibration)."
+            )
+        except Exception as e:
+            print(
+                f"Redis publication failed: {e}\n"
+                "Re-run with --no-redis if Redis is not available.",
+                file=sys.stderr,
+            )
+            # Keep going so the JSON artifact still lands on disk.
+
+    # JSON artifact (audit / bench fallback)
+    output_path = Path(args.output) if args.output else Path(_default_output_path())
+    with open(output_path, "w") as f:
         json.dump(cal_data, f, indent=2)
-    print(f"\nCalibration saved to {args.output}")
+    print(f"\nCalibration saved to {output_path}")
     print(f"  pot_el: angle = {cal0[0]:.4f} * V + {cal0[1]:.4f}")
     print(f"  pot_az: angle = {cal1[0]:.4f} * V + {cal1[1]:.4f}")
     if args.mode == "turns":

--- a/picohost/src/picohost/keys.py
+++ b/picohost/src/picohost/keys.py
@@ -10,6 +10,7 @@ or eigsep_observing (``stream:corr``, ``corr_config``, …).
 """
 
 PICO_CONFIG_KEY = "pico_config"
+POT_CAL_KEY = "pot_calibration"
 PICO_CMD_STREAM = "stream:pico_cmd"
 PICO_RESP_STREAM = "stream:pico_resp"
 PICO_CLAIM_PREFIX = "pico_claim"

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -57,6 +57,7 @@ from .buses import (
     PicoCmdReader,
     PicoConfigStore,
     PicoRespWriter,
+    PotCalStore,
 )
 from .keys import pico_heartbeat_name
 from .motor import PicoMotor
@@ -143,6 +144,7 @@ class PicoManager:
             :class:`MetadataWriter` (passed to each ``PicoDevice``),
             per-device :class:`HeartbeatWriter`,
             :class:`StatusWriter`, :class:`PicoConfigStore`,
+            :class:`PotCalStore` (passed to ``PicoPotentiometer``),
             :class:`PicoCmdReader`, :class:`PicoRespWriter`, and
             :class:`PicoClaimStore`.
         uf2_path : str or Path
@@ -155,6 +157,7 @@ class PicoManager:
         self._heartbeats = {}
         self._metadata_writer = MetadataWriter(transport)
         self._config_store = PicoConfigStore(transport)
+        self._pot_cal_store = PotCalStore(transport)
         self._cmd_reader = PicoCmdReader(transport)
         self._resp_writer = PicoRespWriter(transport)
         self._claim_store = PicoClaimStore(transport)
@@ -244,13 +247,15 @@ class PicoManager:
                 raise ValueError(f"Duplicate device name '{name}' in config")
 
             cls = PICO_CLASSES.get(name, PicoDevice)
+            kwargs = {
+                "metadata_writer": self._metadata_writer,
+                "name": name,
+                "usb_serial": usb_serial,
+            }
+            if cls is PicoPotentiometer:
+                kwargs["pot_cal_store"] = self._pot_cal_store
             try:
-                pico = cls(
-                    port,
-                    metadata_writer=self._metadata_writer,
-                    name=name,
-                    usb_serial=usb_serial,
-                )
+                pico = cls(port, **kwargs)
                 self.picos[name] = pico
                 self._heartbeats[name] = HeartbeatWriter(
                     self.transport, name=pico_heartbeat_name(name)

--- a/picohost/tests/test_potentiometer.py
+++ b/picohost/tests/test_potentiometer.py
@@ -8,8 +8,11 @@ import json
 import tempfile
 
 import pytest
+from eigsep_redis.testing import DummyTransport
 
 from conftest import wait_for_condition
+from picohost.buses import PotCalStore
+from picohost.keys import POT_CAL_KEY
 from picohost.testing import DummyPicoPotentiometer
 
 
@@ -193,3 +196,126 @@ class TestPotRedisHandler:
         }
         assert expected_added.issubset(before)
         pot.disconnect()
+
+
+class TestPotCalStore:
+    """Round-trip and error-path coverage for the Redis cal store."""
+
+    def _cal_payload(self):
+        return {
+            "pot_el": [100.0, -50.0],
+            "pot_az": [200.0, -100.0],
+            "metadata": {"port": "/dev/ttyACM0", "turns": 10},
+        }
+
+    def test_empty_store_returns_none(self):
+        store = PotCalStore(DummyTransport())
+        assert store.get() is None
+
+    def test_upload_get_round_trip_preserves_fields(self):
+        """upload()/get() round-trips all fields including metadata."""
+        store = PotCalStore(DummyTransport())
+        payload = self._cal_payload()
+        store.upload(payload)
+        loaded = store.get()
+        assert loaded["pot_el"] == payload["pot_el"]
+        assert loaded["pot_az"] == payload["pot_az"]
+        assert loaded["metadata"] == payload["metadata"]
+        # Transport.upload_dict injects an upload_time field on every write.
+        assert "upload_time" in loaded
+
+    def test_corrupt_json_returns_none(self):
+        """Garbage in Redis → get() returns None so callers fall back."""
+        transport = DummyTransport()
+        transport.r.set(POT_CAL_KEY, b"not-json-{")
+        assert PotCalStore(transport).get() is None
+
+    def test_clear_removes_key(self):
+        store = PotCalStore(DummyTransport())
+        store.upload(self._cal_payload())
+        assert store.get() is not None
+        store.clear()
+        assert store.get() is None
+
+
+class TestPicoPotentiometerCalSource:
+    """Precedence: Redis wins, JSON fallback, uncalibrated if neither.
+
+    Validates the init-time source selection added for the Redis-as-
+    canonical-cal-store migration. Each test asserts on ``_cal`` directly
+    because the emulator sends voltages that the scalar-only contract
+    tests already cover; here we only care where the (m, b) pair came
+    from.
+    """
+
+    def _redis_cal(self):
+        return {
+            "pot_el": [100.0, -50.0],
+            "pot_az": [200.0, -100.0],
+        }
+
+    def _json_cal_file(self, tmp_path, cal):
+        path = tmp_path / "pot_cal.json"
+        with open(path, "w") as f:
+            json.dump(cal, f)
+        return str(path)
+
+    def test_redis_wins_over_json(self, tmp_path):
+        """Both sources present → Redis cal is applied, JSON is ignored."""
+        transport = DummyTransport()
+        store = PotCalStore(transport)
+        store.upload(self._redis_cal())
+        file_cal = {"pot_el": [1.0, 2.0], "pot_az": [3.0, 4.0]}
+        pot = DummyPicoPotentiometer(
+            "/dev/dummy",
+            calibration_file=self._json_cal_file(tmp_path, file_cal),
+            pot_cal_store=store,
+        )
+        try:
+            assert pot.is_calibrated
+            assert pot._cal["pot_el"] == (100.0, -50.0)
+            assert pot._cal["pot_az"] == (200.0, -100.0)
+        finally:
+            pot.disconnect()
+
+    def test_json_fallback_when_redis_empty(self, tmp_path):
+        """Redis miss + JSON present → JSON cal is applied."""
+        store = PotCalStore(DummyTransport())
+        file_cal = {"pot_el": [1.0, 2.0], "pot_az": [3.0, 4.0]}
+        pot = DummyPicoPotentiometer(
+            "/dev/dummy",
+            calibration_file=self._json_cal_file(tmp_path, file_cal),
+            pot_cal_store=store,
+        )
+        try:
+            assert pot.is_calibrated
+            assert pot._cal["pot_el"] == (1.0, 2.0)
+            assert pot._cal["pot_az"] == (3.0, 4.0)
+        finally:
+            pot.disconnect()
+
+    def test_uncalibrated_when_both_missing(self):
+        """No store and no file → pot is uncalibrated (current behavior)."""
+        pot = DummyPicoPotentiometer("/dev/dummy")
+        try:
+            assert pot.is_calibrated is False
+            assert pot._cal == {"pot_el": None, "pot_az": None}
+        finally:
+            pot.disconnect()
+
+    def test_corrupt_redis_falls_back_to_json(self, tmp_path):
+        """Garbage in Redis → PotCalStore.get returns None → JSON wins."""
+        transport = DummyTransport()
+        transport.r.set(POT_CAL_KEY, b"not-json-{")
+        file_cal = {"pot_el": [1.0, 2.0], "pot_az": [3.0, 4.0]}
+        pot = DummyPicoPotentiometer(
+            "/dev/dummy",
+            calibration_file=self._json_cal_file(tmp_path, file_cal),
+            pot_cal_store=PotCalStore(transport),
+        )
+        try:
+            assert pot.is_calibrated
+            assert pot._cal["pot_el"] == (1.0, 2.0)
+            assert pot._cal["pot_az"] == (3.0, 4.0)
+        finally:
+            pot.disconnect()


### PR DESCRIPTION
## Summary
- Adds `PotCalStore` in `picohost/buses.py` so pot calibration can live in Redis alongside `PicoConfigStore` (same transport pattern, single well-known key `pot_calibration`).
- Teaches `PicoPotentiometer.__init__` to read cal from Redis at startup via a new `pot_cal_store=` kwarg. Precedence: Redis wins, JSON fallback, uncalibrated if neither — so a pot Pico that reboots picks up its cal without a local JSON file. `PicoManager` constructs one `PotCalStore` and hands it to each `PicoPotentiometer` it spawns.
- Promotes `calibrate_pot.py` from a loose script to an installed `calibrate-pot` entry point. It auto-discovers the pot Pico (USB VID/PID + `sensor_name` probe), writes to Redis (canonical) and a timestamped JSON artifact (audit) by default, and supports `--no-redis` for bench hosts without a Redis instance.

No changes to `eigsep_redis` (pico-specific stores belong in picohost) or `eigsep_observing` (the `potmon` schema already accepts the scalar cal fields that `_pot_redis_handler` publishes).

## Test plan
- [x] `pytest` — 277/277 pass (includes new `TestPotCalStore` round-trip/empty/corrupt-JSON/clear and `TestPicoPotentiometerCalSource` for all four precedence paths)
- [x] `ruff check` on all changed files
- [x] Emulator-coverage CI check runs clean locally
- [ ] Bench verification: run `calibrate-pot` against a real pot Pico, confirm the Redis key lands and the published `potmon` stream shows live `pot_{el,az}_cal_slope`/`_cal_intercept`/`_angle` after the next status tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)