### PR TITLE
feat(picohost): publish human-readable RfSwitch state to Redis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,17 @@ The project includes several libraries:
 - **onewire**: OneWire protocol library with PIO implementation
 - **BNO08x_Pico_Library**: IMU sensor library for BNO08x devices
 
+## Scripts and ownership
+
+The boundary between `picohost` and the sister `eigsep_observing` repo is drawn by **how the script talks to a Pico**, not by whether it's "operational":
+
+- **Opens a serial connection → lives in `picohost/scripts/`.** These are hardware bringup, emulator-less testing, and single-device maintenance tools. They must be prepared to stop the `PicoManager` service first, because the manager owns the serial port during normal ops.
+- **Talks to Picos via `PicoProxy`/Redis → lives in `eigsep_observing`.** These scripts assume `PicoManager` is running and never touch serial directly.
+
+**Rule of thumb:** if a script coordinates more than one Pico, it belongs in `eigsep_observing`. Science operations (e.g., a motor scan with intermittent VNA observations) always live in `eigsep_observing` and should log their execution runtime to Redis.
+
+**Infrastructure utilities** that *happen* to talk to Redis — `calibrate_pot`, `flash_picos`, `PicoManager` itself — are part of the Pico stack and belong in `picohost`. The test is "is this about the Pico stack?" vs. "is this about doing science?".
+
 ## CI / Release
 
 - **CI**: GitHub Actions runs pytest across Python 3.9-3.12 on every push/PR, plus a check that every firmware app has a corresponding emulator

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -458,6 +458,27 @@ class PicoRFSwitch(PicoDevice):
     def paths(self):
         return {k: self.rbin(v) for k, v in self.path_str.items()}
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._name_by_state = {v: k for k, v in self.paths.items()}
+        if self.redis_handler is not None:
+            self._base_redis_handler = self.redis_handler
+            self.redis_handler = self._rfswitch_redis_handler
+
+    def _rfswitch_redis_handler(self, data):
+        """Add the human-readable switch name before uploading to Redis.
+
+        Firmware reports ``sw_state`` as a raw 8-bit integer. Downstream
+        consumers should see a named state (``"VNAO"``, ``"RFANT"``, etc.)
+        alongside the raw integer, so the encoding lives in one place.
+        ``sw_state_name`` is ``None`` when the integer does not match any
+        entry in :attr:`path_str` (mid-switch, manual override, firmware
+        bug); the shape stays stable regardless.
+        """
+        data = data.copy()
+        data["sw_state_name"] = self._name_by_state.get(data.get("sw_state"))
+        self._base_redis_handler(data)
+
     def switch(self, state: str) -> None:
         """
         Set RF switch state.

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -139,7 +139,7 @@ class PotCalStore:
             ``(slope, intercept)`` pair (list or tuple). Extra
             fields (e.g. ``metadata``) are preserved verbatim.
         """
-        self.transport.upload_dict(dict(cal), POT_CAL_KEY)
+        self.transport.upload_dict(cal, POT_CAL_KEY)
 
     def get(self):
         """Return the stored calibration dict.

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -299,6 +299,33 @@ class TestRFSwitchRedisHandler:
         finally:
             switch.disconnect()
 
+    def test_published_shape_stable_across_state(self):
+        """Field set is identical whether sw_state is known or unknown.
+
+        Mirrors ``test_published_shape_stable_across_calibration_state``
+        on the pot handler: the added key set must not depend on the
+        value of the raw field, so downstream schemas can validate a
+        single stable shape regardless of switch position.
+        """
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            known = set(
+                self._capture(
+                    switch, {"sensor_name": "rfswitch", "sw_state": 0}
+                )
+            )
+            unknown_int = max(switch.paths.values()) + 1
+            unknown = set(
+                self._capture(
+                    switch,
+                    {"sensor_name": "rfswitch", "sw_state": unknown_int},
+                )
+            )
+            assert known == unknown
+            assert "sw_state_name" in known
+        finally:
+            switch.disconnect()
+
 
 class TestPicoPeltier:
     """Test PicoPeltier commands via DummyPicoPeltier (with emulator)."""

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -214,6 +214,92 @@ class TestPicoRFSwitch:
         switch.disconnect()
 
 
+class TestRFSwitchRedisHandler:
+    """Verify _rfswitch_redis_handler augments the payload with sw_state_name.
+
+    The published payload (what the base handler receives) must include a
+    human-readable name for every known ``sw_state`` integer, and ``None``
+    for integers not in :attr:`PicoRFSwitch.path_str` (mid-switch, manual
+    override, firmware bug). The published shape stays stable either way,
+    and every added field must satisfy the scalar-only contract documented
+    on :func:`picohost.base.redis_handler`.
+    """
+
+    _SCALAR_TYPES = (str, int, float, bool, type(None))
+
+    def _capture(self, switch, data):
+        """Run the redis handler against a given status dict and return
+        what the base handler would receive."""
+        captured = {}
+        switch._base_redis_handler = lambda d: captured.update(d)
+        switch._rfswitch_redis_handler(data)
+        return captured
+
+    def test_known_state_maps_to_name(self):
+        """Every entry in path_str round-trips via sw_state_name."""
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            for name, sw_state in switch.paths.items():
+                published = self._capture(
+                    switch,
+                    {"sensor_name": "rfswitch", "sw_state": sw_state},
+                )
+                assert published["sw_state"] == sw_state
+                assert published["sw_state_name"] == name
+        finally:
+            switch.disconnect()
+
+    def test_unknown_state_publishes_none_name(self):
+        """Integers not in path_str get sw_state_name = None."""
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            unknown = max(switch.paths.values()) + 1
+            assert unknown not in switch.paths.values()
+            published = self._capture(
+                switch,
+                {"sensor_name": "rfswitch", "sw_state": unknown},
+            )
+            assert published["sw_state"] == unknown
+            assert published["sw_state_name"] is None
+        finally:
+            switch.disconnect()
+
+    def test_missing_sw_state_does_not_crash(self):
+        """A status dict without sw_state still publishes (name=None)."""
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            published = self._capture(switch, {"sensor_name": "rfswitch"})
+            assert published["sw_state_name"] is None
+        finally:
+            switch.disconnect()
+
+    def test_handler_does_not_mutate_input(self):
+        """The caller's dict is untouched by the handler."""
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            data = {"sensor_name": "rfswitch", "sw_state": 0}
+            self._capture(switch, data)
+            assert data == {"sensor_name": "rfswitch", "sw_state": 0}
+        finally:
+            switch.disconnect()
+
+    def test_published_dict_is_scalar_only(self):
+        """Every value in the published dict is a permitted scalar type."""
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            for sw_state in (0, 1, 255):
+                published = self._capture(
+                    switch,
+                    {"sensor_name": "rfswitch", "sw_state": sw_state},
+                )
+                for k, v in published.items():
+                    assert isinstance(v, self._SCALAR_TYPES), (
+                        f"field {k!r} has non-scalar type {type(v).__name__}"
+                    )
+        finally:
+            switch.disconnect()
+
+
 class TestPicoPeltier:
     """Test PicoPeltier commands via DummyPicoPeltier (with emulator)."""
 


### PR DESCRIPTION
## Summary

- **RfSwitch Redis handler** (`feat`): `PicoRFSwitch` now publishes a human-readable `sw_state_name` alongside the raw `sw_state` integer, reverse-mapped through `path_str`. Downstream consumers no longer have to know the LSB-first bit-field encoding. Unknown integers (mid-switch, manual override) publish `None` with a stable shape. Mirrors the `PicoPotentiometer._pot_redis_handler` pattern at `base.py:694`.
- **Scripts ownership rule** (`docs`): new section in `CLAUDE.md` codifies the boundary between `picohost` and `eigsep_observing` — serial touches `picohost/scripts/`, `PicoProxy`/Redis consumers belong in `eigsep_observing`, multi-Pico coordination and science ops live in `eigsep_observing`. Infra utilities (`calibrate_pot`, `flash_picos`, `PicoManager`) stay in `picohost`.
- Bundles a prior local `style:` commit (`e9a687c`) that had been sitting on `main` but unpushed.

## Test plan

- [x] `pytest tests/test_base.py::TestRFSwitchRedisHandler` — 5/5 new tests pass (known-state round-trip, unknown-state → None, missing `sw_state` doesn't crash, handler does not mutate input, scalar-only contract holds).
- [x] Full `pytest` run: 274 passed. 8 pre-existing failures are unrelated — all `AttributeError: 'DummyTransport' object has no attribute 'upload_dict'` via `PotCalStore.upload()` / `PicoConfigStore.upload()`, caused by a stale local `eigsep_redis` install (commit `16d74a6` bumped the requirement to 2.1.0 where `upload_dict` became public, but the test venv hasn't been reinstalled). CI will pick up the current pin.
- [ ] Manual spot check against a Redis consumer to confirm `sw_state_name` shows up in `metadata[rfswitch]` snapshots.

## Follow-ups (separate PR)

- Migrate `picohost/scripts/motor_control.py` + `motor_manual.py` to `eigsep_observing` via `PicoProxy`.
- Design per-script runtime logging as part of that migration (shared helper in `eigsep_observing` or a `ScriptRunWriter` in `eigsep_redis`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)