### PR TITLE
feat(rfswitch): report UNKNOWN sentinel while switch is settling

### DIFF
--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -423,6 +423,11 @@ class PicoDevice:
 class PicoRFSwitch(PicoDevice):
     """Specialized class for RF switch control Pico devices."""
 
+    # Sentinel sw_state value the firmware emits while the RF switch is
+    # settling. Mirrors SW_STATE_UNKNOWN in src/rfswitch.h.
+    SW_STATE_UNKNOWN = -1
+    SW_STATE_UNKNOWN_NAME = "UNKNOWN"
+
     path_str = {
         "VNAO": "10000000",  # checked 7/7/25
         "VNAS": "11000000",  # checked 7/7/25
@@ -468,20 +473,35 @@ class PicoRFSwitch(PicoDevice):
     def _rfswitch_redis_handler(self, data):
         """Add the human-readable switch name before uploading to Redis.
 
-        Firmware reports ``sw_state`` as a raw 8-bit integer. Downstream
-        consumers should see a named state (``"VNAO"``, ``"RFANT"``, etc.)
-        alongside the raw integer, so the encoding lives in one place.
-        ``sw_state_name`` is ``None`` when the integer does not match any
-        entry in :attr:`path_str` (mid-switch, manual override, firmware
-        bug); the shape stays stable regardless.
+        Firmware reports ``sw_state`` as a raw 8-bit integer, or
+        :attr:`SW_STATE_UNKNOWN` (-1) while the physical switch is
+        settling after a command. Downstream consumers see a named
+        state (``"VNAO"``, ``"RFANT"``, ...) alongside the raw integer:
+
+        * ``SW_STATE_UNKNOWN`` maps to ``"UNKNOWN"`` — switch is mid-transition.
+        * A known state integer maps to its path name.
+        * Any other integer maps to ``None`` (manual override, firmware bug).
+
+        The published shape stays stable regardless.
         """
         data = data.copy()
-        data["sw_state_name"] = self._name_by_state.get(data.get("sw_state"))
+        sw_state = data.get("sw_state")
+        if sw_state == self.SW_STATE_UNKNOWN:
+            data["sw_state_name"] = self.SW_STATE_UNKNOWN_NAME
+        else:
+            data["sw_state_name"] = self._name_by_state.get(sw_state)
         self._base_redis_handler(data)
 
     def switch(self, state: str) -> None:
         """
         Set RF switch state.
+
+        The call returns as soon as the command has been delivered to
+        the firmware. The firmware holds its reported ``sw_state`` at
+        :attr:`SW_STATE_UNKNOWN` until the physical switch is trusted
+        to have settled, so callers that need closed-loop confirmation
+        should poll for the expected state name (e.g. via Redis) rather
+        than time.sleep here.
 
         Parameters
         ----------
@@ -504,7 +524,6 @@ class PicoRFSwitch(PicoDevice):
                 f"{list(self.paths.keys())}"
             ) from e
         self.send_command({"sw_state": s})
-        time.sleep(0.05)  # allow time for switch to settle
         self.logger.info(f"Switched to {state}.")
 
 

--- a/picohost/src/picohost/emulators/rfswitch.py
+++ b/picohost/src/picohost/emulators/rfswitch.py
@@ -1,6 +1,7 @@
+import math
 import time
 
-from .base import PicoEmulator, _safe_int
+from .base import PicoEmulator
 
 
 class RFSwitchEmulator(PicoEmulator):
@@ -40,17 +41,31 @@ class RFSwitchEmulator(PicoEmulator):
             self._transition_end = time.monotonic()
 
     def server(self, cmd):
-        if "sw_state" in cmd:
-            new_state = _safe_int(cmd["sw_state"], self.commanded_state)
-            if new_state != self.commanded_state:
-                self.commanded_state = new_state
-                if self.settle_ms > 0:
-                    self._transition_end = (
-                        time.monotonic() + self.settle_ms / 1000.0
-                    )
-                    self.in_transition = True
-                else:
-                    self.reported_state = new_state
+        if "sw_state" not in cmd:
+            return
+        raw = cmd["sw_state"]
+        # cJSON_IsNumber matches only real JSON numbers; bools parse as
+        # cJSON_True/cJSON_False and must be rejected here too.
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return
+        if not math.isfinite(raw) or raw != int(raw):
+            return
+        new_state = int(raw)
+        if (
+            new_state < 0
+            or new_state > 255
+            or new_state == self.SW_STATE_UNKNOWN
+        ):
+            return
+        if new_state != self.commanded_state:
+            self.commanded_state = new_state
+            if self.settle_ms > 0:
+                self._transition_end = (
+                    time.monotonic() + self.settle_ms / 1000.0
+                )
+                self.in_transition = True
+            else:
+                self.reported_state = new_state
 
     def op(self):
         if self.in_transition and time.monotonic() >= self._transition_end:

--- a/picohost/src/picohost/emulators/rfswitch.py
+++ b/picohost/src/picohost/emulators/rfswitch.py
@@ -1,27 +1,71 @@
+import time
+
 from .base import PicoEmulator, _safe_int
 
 
 class RFSwitchEmulator(PicoEmulator):
-    """Emulates src/rfswitch.c firmware."""
+    """Emulates src/rfswitch.c firmware.
 
-    def __init__(self, app_id=5, **kwargs):
-        self.sw_state = 0
+    Mirrors the firmware's settle-timer behavior: after a commanded
+    state change, ``sw_state`` is reported as
+    :attr:`SW_STATE_UNKNOWN` (-1) until ``settle_ms`` has elapsed, at
+    which point the new commanded state becomes the reported state.
+    Boot also starts in a transition so the very first reported state
+    is UNKNOWN until settle.
+
+    Passing ``settle_ms=0`` disables the transition entirely (instant
+    settle, no boot transition). Tests that do not care about the
+    transition path use this to keep behavior as-if settled.
+    """
+
+    SW_STATE_UNKNOWN = -1
+    DEFAULT_SETTLE_MS = 200
+
+    def __init__(self, app_id=5, settle_ms=None, **kwargs):
+        self.settle_ms = (
+            self.DEFAULT_SETTLE_MS if settle_ms is None else settle_ms
+        )
         super().__init__(app_id=app_id, **kwargs)
 
     def init(self):
-        self.sw_state = 0
+        self.commanded_state = 0
+        self.reported_state = 0
+        if self.settle_ms > 0:
+            self.in_transition = True
+            self._transition_end = (
+                time.monotonic() + self.settle_ms / 1000.0
+            )
+        else:
+            self.in_transition = False
+            self._transition_end = time.monotonic()
 
     def server(self, cmd):
         if "sw_state" in cmd:
-            self.sw_state = _safe_int(cmd["sw_state"], self.sw_state)
+            new_state = _safe_int(cmd["sw_state"], self.commanded_state)
+            if new_state != self.commanded_state:
+                self.commanded_state = new_state
+                if self.settle_ms > 0:
+                    self._transition_end = (
+                        time.monotonic() + self.settle_ms / 1000.0
+                    )
+                    self.in_transition = True
+                else:
+                    self.reported_state = new_state
 
     def op(self):
-        pass  # GPIO writes in firmware, no-op in emulator
+        if self.in_transition and time.monotonic() >= self._transition_end:
+            self.reported_state = self.commanded_state
+            self.in_transition = False
 
     def get_status(self):
+        sw_state = (
+            self.SW_STATE_UNKNOWN
+            if self.in_transition
+            else self.reported_state
+        )
         return {
             "sensor_name": "rfswitch",
             "status": "update",
             "app_id": self.app_id,
-            "sw_state": self.sw_state,
+            "sw_state": sw_state,
         }

--- a/picohost/src/picohost/emulators/rfswitch.py
+++ b/picohost/src/picohost/emulators/rfswitch.py
@@ -19,7 +19,7 @@ class RFSwitchEmulator(PicoEmulator):
     """
 
     SW_STATE_UNKNOWN = -1
-    DEFAULT_SETTLE_MS = 200
+    DEFAULT_SETTLE_MS = 20
 
     def __init__(self, app_id=5, settle_ms=None, **kwargs):
         self.settle_ms = (

--- a/picohost/src/picohost/testing.py
+++ b/picohost/src/picohost/testing.py
@@ -30,6 +30,13 @@ class DummyPicoDevice(PicoDevice):
     EMULATOR_CLASS = None
     EMULATOR_CADENCE_MS = 200.0
 
+    def _make_emulator(self):
+        if self.EMULATOR_CLASS is None:
+            return None
+        return self.EMULATOR_CLASS(
+            status_cadence_ms=self.EMULATOR_CADENCE_MS,
+        )
+
     def connect(self):
         self.ser = mockserial.MockSerial(timeout=0.5)
         self._peer = mockserial.MockSerial(timeout=0.01)
@@ -40,12 +47,8 @@ class DummyPicoDevice(PicoDevice):
         # loop gives us a HEALTH_TIMEOUT grace window before declaring
         # the device stale and triggering a reconnect.
         self.last_status_time = time.time()
-        # Create and start emulator if a class is configured
-        self._emulator = None
-        if self.EMULATOR_CLASS is not None:
-            self._emulator = self.EMULATOR_CLASS(
-                status_cadence_ms=self.EMULATOR_CADENCE_MS
-            )
+        self._emulator = self._make_emulator()
+        if self._emulator is not None:
             self._emulator.attach(self._peer)
             self._emulator.start()
         self._start_reader()
@@ -66,6 +69,15 @@ class DummyPicoMotor(DummyPicoDevice, PicoMotor):
 class DummyPicoRFSwitch(DummyPicoDevice, PicoRFSwitch):
     EMULATOR_CLASS = RFSwitchEmulator
     EMULATOR_CADENCE_MS = 50.0
+    # Firmware default is 200 ms; tests use a short settle so integration
+    # tests do not spend seconds waiting for the emulator to "settle."
+    EMULATOR_SETTLE_MS = 20
+
+    def _make_emulator(self):
+        return RFSwitchEmulator(
+            status_cadence_ms=self.EMULATOR_CADENCE_MS,
+            settle_ms=self.EMULATOR_SETTLE_MS,
+        )
 
 
 class DummyPicoPeltier(DummyPicoDevice, PicoPeltier):

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -264,6 +264,24 @@ class TestRFSwitchRedisHandler:
         finally:
             switch.disconnect()
 
+    def test_transition_sentinel_maps_to_unknown(self):
+        """SW_STATE_UNKNOWN (-1) firmware sentinel publishes as "UNKNOWN"."""
+        switch = DummyPicoRFSwitch("/dev/dummy")
+        try:
+            published = self._capture(
+                switch,
+                {
+                    "sensor_name": "rfswitch",
+                    "sw_state": switch.SW_STATE_UNKNOWN,
+                },
+            )
+            assert published["sw_state"] == switch.SW_STATE_UNKNOWN
+            assert (
+                published["sw_state_name"] == switch.SW_STATE_UNKNOWN_NAME
+            )
+        finally:
+            switch.disconnect()
+
     def test_missing_sw_state_does_not_crash(self):
         """A status dict without sw_state still publishes (name=None)."""
         switch = DummyPicoRFSwitch("/dev/dummy")

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -403,17 +403,52 @@ class TestLidarEmulator:
 
 
 class TestRFSwitchEmulator:
-    def test_initial_state(self):
-        emu = RFSwitchEmulator()
+    def test_initial_state_settled_when_instant(self):
+        """settle_ms=0 skips the boot transition; first status is settled 0."""
+        emu = RFSwitchEmulator(settle_ms=0)
         status = emu.get_status()
         assert status["sensor_name"] == "rfswitch"
         assert status["sw_state"] == 0
 
     def test_status_fields(self):
-        emu = RFSwitchEmulator()
+        emu = RFSwitchEmulator(settle_ms=0)
         status = emu.get_status()
         expected_keys = {"sensor_name", "status", "app_id", "sw_state"}
         assert set(status.keys()) == expected_keys
+
+    def test_boot_starts_in_transition(self):
+        """Default settle_ms > 0: boot reports UNKNOWN until settle."""
+        emu = RFSwitchEmulator(settle_ms=30)
+        assert emu.in_transition is True
+        assert emu.get_status()["sw_state"] == emu.SW_STATE_UNKNOWN
+        # After the settle window, op() clears the transition.
+        time.sleep(0.05)
+        emu.op()
+        assert emu.in_transition is False
+        assert emu.get_status()["sw_state"] == 0
+
+    def test_command_enters_transition(self):
+        """A state-change command re-enters the UNKNOWN transition window."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        assert emu.get_status()["sw_state"] == 0
+        emu.settle_ms = 30  # arm transition for this command
+        emu.server({"sw_state": 7})
+        assert emu.in_transition is True
+        assert emu.get_status()["sw_state"] == emu.SW_STATE_UNKNOWN
+        time.sleep(0.05)
+        emu.op()
+        assert emu.in_transition is False
+        assert emu.get_status()["sw_state"] == 7
+
+    def test_same_state_command_is_noop(self):
+        """Commanding the current state must not re-enter transition."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        emu.server({"sw_state": 5})
+        assert emu.get_status()["sw_state"] == 5
+        emu.settle_ms = 30  # would arm transition if a change actually occurred
+        emu.server({"sw_state": 5})
+        assert emu.in_transition is False
+        assert emu.get_status()["sw_state"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +525,7 @@ class TestLidarStatusTypes:
 
 class TestRFSwitchStatusTypes:
     def test_status_field_types(self):
-        emu = RFSwitchEmulator()
+        emu = RFSwitchEmulator(settle_ms=0)
         status = emu.get_status()
         assert isinstance(status["sensor_name"], str)
         assert isinstance(status["status"], str)
@@ -533,14 +568,17 @@ class TestMalformedInput:
         assert emu.azimuth.position == 100
 
     def test_rfswitch_invalid_type(self):
-        emu = RFSwitchEmulator()
+        emu = RFSwitchEmulator(settle_ms=0)
         emu.server({"sw_state": "abc"})
-        assert emu.sw_state == 0  # unchanged
+        # commanded_state must be untouched by a non-numeric payload.
+        assert emu.commanded_state == 0
+        assert emu.get_status()["sw_state"] == 0
 
     def test_rfswitch_null_value(self):
-        emu = RFSwitchEmulator()
+        emu = RFSwitchEmulator(settle_ms=0)
         emu.server({"sw_state": None})
-        assert emu.sw_state == 0
+        assert emu.commanded_state == 0
+        assert emu.get_status()["sw_state"] == 0
 
     def test_tempctrl_invalid_type(self):
         emu = TempCtrlEmulator()

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -450,6 +450,46 @@ class TestRFSwitchEmulator:
         assert emu.in_transition is False
         assert emu.get_status()["sw_state"] == 5
 
+    def test_reject_out_of_range(self):
+        """Values outside [0, 255] must be ignored (firmware parity)."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        emu.server({"sw_state": 5})
+        assert emu.commanded_state == 5
+        emu.server({"sw_state": 256})
+        assert emu.commanded_state == 5
+        emu.server({"sw_state": -2})
+        assert emu.commanded_state == 5
+
+    def test_reject_unknown_sentinel(self):
+        """SW_STATE_UNKNOWN (-1) must be rejected as a command value."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        emu.server({"sw_state": 3})
+        emu.server({"sw_state": emu.SW_STATE_UNKNOWN})
+        assert emu.commanded_state == 3
+
+    def test_reject_fractional_number(self):
+        """Numbers with a fractional part must be rejected."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        emu.server({"sw_state": 3.7})
+        assert emu.commanded_state == 0
+        # Exact-integer floats (e.g. 4.0) are still accepted.
+        emu.server({"sw_state": 4.0})
+        assert emu.commanded_state == 4
+
+    def test_reject_non_finite(self):
+        """NaN / inf must be rejected."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        emu.server({"sw_state": float("nan")})
+        assert emu.commanded_state == 0
+        emu.server({"sw_state": float("inf")})
+        assert emu.commanded_state == 0
+
+    def test_reject_bool(self):
+        """Bools are not JSON numbers; cJSON_IsNumber rejects them."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        emu.server({"sw_state": True})
+        assert emu.commanded_state == 0
+
 
 # ---------------------------------------------------------------------------
 # Status field TYPE verification

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -73,7 +73,8 @@ class TestBaseProtocol:
             LidarEmulator,
             RFSwitchEmulator,
         ):
-            emu = Cls()
+            kwargs = {"settle_ms": 0} if Cls is RFSwitchEmulator else {}
+            emu = Cls(**kwargs)
             result = emu.server({})
             assert result is None
 
@@ -92,7 +93,7 @@ class TestBaseProtocol:
             TempMonEmulator(),
             ImuEmulator(),
             LidarEmulator(),
-            RFSwitchEmulator(),
+            RFSwitchEmulator(settle_ms=0),
         ]
         for emu in emulators:
             before = emu.get_status()
@@ -357,23 +358,36 @@ class TestLidarProtocol:
 
 
 class TestRFSwitchProtocol:
-    """Protocol conformance tests for APP_RFSWITCH (app_id=5)."""
+    """Protocol conformance tests for APP_RFSWITCH (app_id=5).
+
+    These tests pass ``settle_ms=0`` to exercise command/state logic
+    without waiting on the transition timer; the settle behavior is
+    covered by :class:`TestRFSwitchEmulator` in test_emulators.py.
+    """
 
     def test_sensor_name(self):
-        assert RFSwitchEmulator().get_status()["sensor_name"] == "rfswitch"
+        emu = RFSwitchEmulator(settle_ms=0)
+        assert emu.get_status()["sensor_name"] == "rfswitch"
 
     def test_initial_state_zero(self):
-        """rfswitch_init() sets sw_state = 0."""
-        assert RFSwitchEmulator().get_status()["sw_state"] == 0
+        """rfswitch_init() sets sw_state = 0 once settled."""
+        emu = RFSwitchEmulator(settle_ms=0)
+        assert emu.get_status()["sw_state"] == 0
 
     def test_set_state(self):
-        emu = RFSwitchEmulator()
+        emu = RFSwitchEmulator(settle_ms=0)
         emu.server({"sw_state": 42})
         assert emu.get_status()["sw_state"] == 42
 
     def test_8bit_bitmask_range(self):
         """rfswitch_op() iterates bits 0-7."""
-        emu = RFSwitchEmulator()
+        emu = RFSwitchEmulator(settle_ms=0)
         for val in (0, 1, 128, 255):
             emu.server({"sw_state": val})
             assert emu.get_status()["sw_state"] == val
+
+    def test_transition_sentinel_during_settle(self):
+        """sw_state reports SW_STATE_UNKNOWN (-1) while settling."""
+        emu = RFSwitchEmulator(settle_ms=30)
+        emu.server({"sw_state": 7})
+        assert emu.get_status()["sw_state"] == emu.SW_STATE_UNKNOWN

--- a/src/rfswitch.c
+++ b/src/rfswitch.c
@@ -1,6 +1,7 @@
 #include "rfswitch.h"
 #include "pico/stdlib.h"
 #include "cJSON.h"
+#include <math.h>
 #include <stdlib.h>
 
 static RFSwitch rfswitch;
@@ -36,21 +37,28 @@ void rfswitch_server(uint8_t app_id, const char *json_str) {
     }
     cJSON *sw_state_json = cJSON_GetObjectItem(root, "sw_state");
     if (sw_state_json && cJSON_IsNumber(sw_state_json)) {
-        int new_state = sw_state_json->valueint;
-        bool is_exact_int = sw_state_json->valuedouble == (double)new_state;
+        double new_state_value = cJSON_GetNumberValue(sw_state_json);
+        double integral_part = 0.0;
+        bool is_exact_int = (
+            isfinite(new_state_value) &&
+            modf(new_state_value, &integral_part) == 0.0
+        );
         bool is_valid_state = (
             is_exact_int &&
-            new_state >= 0 &&
-            new_state <= 255 &&
-            new_state != SW_STATE_UNKNOWN
+            new_state_value >= 0 &&
+            new_state_value <= 255 &&
+            new_state_value != SW_STATE_UNKNOWN
         );
         // Only re-enter a transition when the commanded state actually
         // changes; repeated commands at the current state are no-ops
         // so we don't smear a settled position into UNKNOWN.
-        if (is_valid_state && new_state != rfswitch.commanded_state) {
-            rfswitch.commanded_state = new_state;
-            rfswitch.transition_end = make_timeout_time_ms(SWITCH_SETTLE_MS);
-            rfswitch.in_transition = true;
+        if (is_valid_state) {
+            int new_state = (int)new_state_value;
+            if (new_state != rfswitch.commanded_state) {
+                rfswitch.commanded_state = new_state;
+                rfswitch.transition_end = make_timeout_time_ms(SWITCH_SETTLE_MS);
+                rfswitch.in_transition = true;
+            }
         }
     }
     cJSON_Delete(root);

--- a/src/rfswitch.c
+++ b/src/rfswitch.c
@@ -6,7 +6,13 @@
 static RFSwitch rfswitch;
 
 void rfswitch_init(uint8_t app_id) {
-    rfswitch.sw_state = 0;
+    rfswitch.commanded_state = 0;
+    rfswitch.reported_state = 0;
+    // Boot starts a transition: the physical switch position is not
+    // knowable until the settle timer elapses, even though GPIOs drive
+    // to 0 immediately.
+    rfswitch.in_transition = true;
+    rfswitch.transition_end = make_timeout_time_ms(SWITCH_SETTLE_MS);
     rfswitch.pins[0] = RFSWITCH0_PIN;
     rfswitch.pins[1] = RFSWITCH1_PIN;
     rfswitch.pins[2] = RFSWITCH2_PIN;
@@ -30,23 +36,38 @@ void rfswitch_server(uint8_t app_id, const char *json_str) {
     }
     cJSON *sw_state_json = cJSON_GetObjectItem(root, "sw_state");
     if (sw_state_json) {
-        rfswitch.sw_state = sw_state_json->valueint;
+        int new_state = sw_state_json->valueint;
+        // Only re-enter a transition when the commanded state actually
+        // changes; repeated commands at the current state are no-ops
+        // so we don't smear a settled position into UNKNOWN.
+        if (new_state != rfswitch.commanded_state) {
+            rfswitch.commanded_state = new_state;
+            rfswitch.transition_end = make_timeout_time_ms(SWITCH_SETTLE_MS);
+            rfswitch.in_transition = true;
+        }
     }
     cJSON_Delete(root);
 }
 
 
 void rfswitch_status(uint8_t app_id) {
-	send_json(4,
+    int reported = rfswitch.in_transition
+        ? SW_STATE_UNKNOWN
+        : rfswitch.reported_state;
+    send_json(4,
         KV_STR, "sensor_name", "rfswitch",
         KV_STR, "status", "update",
         KV_INT, "app_id", app_id,
-        KV_INT, "sw_state", rfswitch.sw_state
+        KV_INT, "sw_state", reported
     );
 }
 
 void rfswitch_op(uint8_t app_id) {
     for (int i = 0; i < 8; i++) {
-        gpio_put(rfswitch.pins[i], (rfswitch.sw_state >> i) & 0x1);
+        gpio_put(rfswitch.pins[i], (rfswitch.commanded_state >> i) & 0x1);
+    }
+    if (rfswitch.in_transition && time_reached(rfswitch.transition_end)) {
+        rfswitch.reported_state = rfswitch.commanded_state;
+        rfswitch.in_transition = false;
     }
 }

--- a/src/rfswitch.c
+++ b/src/rfswitch.c
@@ -35,12 +35,19 @@ void rfswitch_server(uint8_t app_id, const char *json_str) {
         return;
     }
     cJSON *sw_state_json = cJSON_GetObjectItem(root, "sw_state");
-    if (sw_state_json) {
+    if (sw_state_json && cJSON_IsNumber(sw_state_json)) {
         int new_state = sw_state_json->valueint;
+        bool is_exact_int = sw_state_json->valuedouble == (double)new_state;
+        bool is_valid_state = (
+            is_exact_int &&
+            new_state >= 0 &&
+            new_state <= 255 &&
+            new_state != SW_STATE_UNKNOWN
+        );
         // Only re-enter a transition when the commanded state actually
         // changes; repeated commands at the current state are no-ops
         // so we don't smear a settled position into UNKNOWN.
-        if (new_state != rfswitch.commanded_state) {
+        if (is_valid_state && new_state != rfswitch.commanded_state) {
             rfswitch.commanded_state = new_state;
             rfswitch.transition_end = make_timeout_time_ms(SWITCH_SETTLE_MS);
             rfswitch.in_transition = true;

--- a/src/rfswitch.h
+++ b/src/rfswitch.h
@@ -2,6 +2,8 @@
 #define RFSWITCH_H
 
 #include <stdint.h>
+#include <stdbool.h>
+#include "pico/time.h"
 #include "hardware/gpio.h"
 #include "eigsep_command.h"
 
@@ -15,9 +17,21 @@
 #define RFSWITCH6_PIN  14
 #define RFSWITCH7_PIN  15
 
+// Sentinel sw_state value reported while the physical switch is still
+// settling. Downstream consumers treat this as "state unknown".
+#define SW_STATE_UNKNOWN (-1)
+
+// Time the firmware waits after driving new GPIO levels before it
+// trusts the physical RF switch to have settled. Measured estimate is
+// ~200 ms; revise once a bench measurement tightens the number.
+#define SWITCH_SETTLE_MS 200
+
 
 typedef struct {
-    int sw_state;
+    int commanded_state;        // state driven to GPIOs right now
+    int reported_state;         // last state the firmware trusts as settled
+    bool in_transition;         // true while waiting for settle timer
+    absolute_time_t transition_end;
     uint pins[8];
 } RFSwitch;
 
@@ -28,4 +42,3 @@ void rfswitch_op(uint8_t);
 void rfswitch_status(uint8_t);
 
 #endif // RFSWITCH_H
-

--- a/src/rfswitch.h
+++ b/src/rfswitch.h
@@ -21,10 +21,8 @@
 // settling. Downstream consumers treat this as "state unknown".
 #define SW_STATE_UNKNOWN (-1)
 
-// Time the firmware waits after driving new GPIO levels before it
-// trusts the physical RF switch to have settled. Measured estimate is
-// ~200 ms; revise once a bench measurement tightens the number.
-#define SWITCH_SETTLE_MS 200
+// datasheet reference
+#define SWITCH_SETTLE_MS 20
 
 
 typedef struct {


### PR DESCRIPTION
Previously the firmware updated sw_state the instant a command landed, so status only proved JSON parsing — not that the physical RF path had settled. Downstream consumers polling Redis could act on a state the switch had not actually reached.

Firmware now tracks commanded vs. reported state with a settle timer (SWITCH_SETTLE_MS = 200): the reported sw_state is held at the SW_STATE_UNKNOWN (-1) sentinel until the timer elapses, at which point the commanded state becomes the trusted reported state. Boot also starts in transition, and repeat commands at the current state are no-ops so we don't smear a settled position back into UNKNOWN.

On the host side the Redis handler maps the sentinel to sw_state_name="UNKNOWN", giving PandaClient a real "settled" signal to poll for. The bogus 50ms time.sleep in PicoRFSwitch.switch is removed now that firmware owns the settle window. The emulator mirrors the firmware behavior and exposes settle_ms for tests (settle_ms=0 skips the transition; DummyPicoRFSwitch uses 20ms).