### PR TITLE
fix(motor): publish position fields as float, not int

### DIFF
--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -50,6 +50,43 @@ class PicoMotor(PicoDevice):
             verbose=verbose,
         )
         self.set_delay()
+        # Wrap the base redis handler to publish position fields as
+        # floats. See _motor_redis_handler.
+        if self.redis_handler is not None:
+            self._base_redis_handler = self.redis_handler
+            self.redis_handler = self._motor_redis_handler
+
+    _POSITION_FIELDS = (
+        "az_pos",
+        "az_target_pos",
+        "el_pos",
+        "el_target_pos",
+    )
+
+    def _motor_redis_handler(self, data):
+        """Cast position fields to float before uploading to Redis.
+
+        The C firmware emits position fields with ``KV_INT`` (raw step
+        counts), which the JSON parser surfaces as Python ``int``.
+        Position values legitimately change within a single consumer
+        integration window during a scan, so the consumer-side
+        per-integration reduction needs the float→mean policy rather
+        than the int→min "invariant" policy. Coercing here at the
+        publish boundary keeps the consumer schema clean (positions
+        declared as ``float``, mean reduction) without requiring a
+        firmware reflash.
+
+        Mirrors :meth:`PicoPotentiometer._pot_redis_handler` and
+        :meth:`PicoRFSwitch._rfswitch_redis_handler`: both adapt the
+        raw firmware payload to the published Redis shape at the same
+        boundary.
+        """
+        data = data.copy()
+        for key in self._POSITION_FIELDS:
+            v = data.get(key)
+            if v is not None:
+                data[key] = float(v)
+        self._base_redis_handler(data)
 
     def on_reconnect(self):
         """Re-apply delay configuration after a serial reconnect."""

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -49,12 +49,14 @@ class PicoMotor(PicoDevice):
             usb_serial=usb_serial,
             verbose=verbose,
         )
-        self.set_delay()
         # Wrap the base redis handler to publish position fields as
-        # floats. See _motor_redis_handler.
+        # floats. See _motor_redis_handler. Install this immediately
+        # after super().__init__ because the base class may already
+        # have started the reader thread.
         if self.redis_handler is not None:
             self._base_redis_handler = self.redis_handler
             self.redis_handler = self._motor_redis_handler
+        self.set_delay()
 
     _POSITION_FIELDS = (
         "az_pos",

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -373,6 +373,130 @@ class TestRFSwitchRedisHandler:
             switch.disconnect()
 
 
+class TestMotorRedisHandler:
+    """Verify _motor_redis_handler coerces position fields to float.
+
+    The C firmware emits ``az_pos``/``el_pos``/``az_target_pos``/
+    ``el_target_pos`` with ``KV_INT``, which the JSON parser surfaces
+    as Python ``int``. The downstream consumer schema declares these
+    as ``float`` so the per-integration reduction picks the
+    float→mean policy (positions legitimately change within an
+    integration during a scan). Coercing here at the publish boundary
+    is what makes the producer satisfy that contract.
+    """
+
+    _POSITION_KEYS = ("az_pos", "az_target_pos", "el_pos", "el_target_pos")
+
+    def _capture(self, motor, data):
+        captured = {}
+        motor._base_redis_handler = lambda d: captured.update(d)
+        motor._motor_redis_handler(data)
+        return captured
+
+    def test_int_positions_are_published_as_float(self):
+        motor = DummyPicoMotor("/dev/dummy")
+        try:
+            published = self._capture(
+                motor,
+                {
+                    "sensor_name": "motor",
+                    "status": "update",
+                    "app_id": 0,
+                    "az_pos": 100,
+                    "az_target_pos": 200,
+                    "el_pos": -50,
+                    "el_target_pos": 0,
+                },
+            )
+            for key in self._POSITION_KEYS:
+                assert isinstance(published[key], float), (
+                    f"{key} published as {type(published[key]).__name__}"
+                )
+            assert published["az_pos"] == 100.0
+            assert published["el_pos"] == -50.0
+        finally:
+            motor.disconnect()
+
+    def test_float_positions_pass_through(self):
+        """Already-float values are not double-cast or otherwise mangled."""
+        motor = DummyPicoMotor("/dev/dummy")
+        try:
+            published = self._capture(
+                motor,
+                {
+                    "sensor_name": "motor",
+                    "az_pos": 1.5,
+                    "az_target_pos": 2.5,
+                    "el_pos": 3.5,
+                    "el_target_pos": 4.5,
+                },
+            )
+            assert published["az_pos"] == 1.5
+            assert published["el_pos"] == 3.5
+        finally:
+            motor.disconnect()
+
+    def test_missing_position_keys_do_not_crash(self):
+        """A partial payload (e.g. early status before all fields are
+        populated) still publishes; absent keys stay absent."""
+        motor = DummyPicoMotor("/dev/dummy")
+        try:
+            published = self._capture(
+                motor, {"sensor_name": "motor", "az_pos": 0}
+            )
+            assert published["az_pos"] == 0.0
+            assert "el_pos" not in published
+        finally:
+            motor.disconnect()
+
+    def test_none_positions_pass_through(self):
+        """None gap-fill values are preserved (not coerced to 0.0)."""
+        motor = DummyPicoMotor("/dev/dummy")
+        try:
+            published = self._capture(
+                motor,
+                {
+                    "sensor_name": "motor",
+                    "az_pos": None,
+                    "az_target_pos": None,
+                    "el_pos": None,
+                    "el_target_pos": None,
+                },
+            )
+            for key in self._POSITION_KEYS:
+                assert published[key] is None
+        finally:
+            motor.disconnect()
+
+    def test_handler_does_not_mutate_input(self):
+        """The caller's dict is untouched by the handler."""
+        motor = DummyPicoMotor("/dev/dummy")
+        try:
+            data = {"sensor_name": "motor", "az_pos": 7, "el_pos": 9}
+            self._capture(motor, data)
+            assert data == {"sensor_name": "motor", "az_pos": 7, "el_pos": 9}
+            assert isinstance(data["az_pos"], int)
+        finally:
+            motor.disconnect()
+
+    def test_emulator_payload_publishes_float_positions(self):
+        """End-to-end: a fresh MotorEmulator status, run through the
+        handler, must publish all position fields as floats. Catches
+        regressions where the C firmware adds a new position field that
+        bypasses the cast."""
+        from picohost.emulators import MotorEmulator
+
+        motor = DummyPicoMotor("/dev/dummy")
+        try:
+            published = self._capture(motor, MotorEmulator().get_status())
+            for key in self._POSITION_KEYS:
+                assert isinstance(published[key], float), (
+                    f"{key} published as {type(published[key]).__name__}"
+                )
+        finally:
+            motor.disconnect()
+
+
 class TestPicoPeltier:
     """Test PicoPeltier commands via DummyPicoPeltier (with emulator)."""
 


### PR DESCRIPTION
## Summary

- The C firmware emits `az_pos`/`el_pos`/`az_target_pos`/`el_target_pos` with `KV_INT`, so the JSON parser surfaces them as Python `int` on the host. The downstream consumer in `eigsep_observing` reduces per-integration sensor readings using a per-type policy: `int` fields use `min` reduction (intended for invariant constants like `app_id`), and `float` fields use `np.mean` reduction. Motor positions legitimately change within an integration during a scan, so the right reduction is `mean` — and that requires the published type to be `float`.
- Adds `PicoMotor._motor_redis_handler` that casts the four position fields to `float` at the Redis-publish boundary, mirroring the existing `_pot_redis_handler` / `_rfswitch_redis_handler` pattern. Wired in `__init__` after `super().__init__()` so the base handler from the metadata writer is in place to wrap.
- Handles `None` gap-fills, missing keys, and already-float values without surprises. Does not mutate the caller's dict.

## Why a Python-side adapter rather than a firmware change

The firmware naturally represents step counts as ints. Casting to float in the firmware would mean adding a `KV_FLOAT` codepath plus reflashing every Pico in the field. The Python adapter at the publish boundary is the established pattern for "make the producer payload match the consumer contract" — same approach used for potmon's calibration scalars and rfswitch's `sw_state_name`. Going through the adapter ensures the published Redis shape always satisfies the consumer schema regardless of firmware version.

## Discovered via

`logs/observe.log` from a fake observation in `eigsep_observing` had hundreds of `WARNING:eigsep_observing.io:No schema for sensor 'motor'; skipping validation` lines. Adding the schema on the consumer side surfaced the deeper issue: positions arrived as `int`, the strict `float` reducer filtered them all out, and every integration row would have stored `az_pos: None`. Companion PR on the consumer side: EIGSEP/eigsep_observing#TBD.

## Test plan

- [x] New `TestMotorRedisHandler` class in `tests/test_base.py` (6 cases): int→float coercion, float pass-through, missing-key handling, `None` preservation, no input mutation, end-to-end with `MotorEmulator`.
- [x] Existing `TestPicoMotor` and `TestMotorEmulator` suites still pass (119 picohost tests green).
- [x] Companion PR in `eigsep_observing` validates the post-handler shape against `SENSOR_SCHEMAS["motor"]` via the producer-contract test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)