### PR TITLE
ci: attach pico_multi.uf2 to GitHub Release on tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,3 +42,27 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: picohost/dist/
+
+  firmware-publish:
+    # Build pico_multi.uf2 from the freshly-tagged source tree and attach
+    # it to the GitHub Release so downstream consumers (notably the
+    # eigsep-field image build) can pull a versioned, immutable artifact
+    # via `gh release download <tag> --pattern pico_multi.uf2` instead of
+    # rebuilding from source themselves.
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install ARM toolchain
+        run: sudo apt-get update && sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi
+      - name: Build firmware
+        run: ./build.sh
+      - name: Attach pico_multi.uf2 to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" build/pico_multi.uf2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 0
           submodules: recursive
       - name: Install ARM toolchain
         run: sudo apt-get update && sudo apt-get install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi
@@ -65,4 +67,4 @@ jobs:
       - name: Attach pico_multi.uf2 to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" build/pico_multi.uf2
+        run: gh release upload --clobber "${{ needs.release-please.outputs.tag_name }}" build/pico_multi.uf2


### PR DESCRIPTION
The release-please workflow has been publishing the picohost Python
package to PyPI on each tagged release but the firmware build artifact
(`build/pico_multi.uf2`) was only produced in CI and discarded. Anyone
needing a binary copy at a specific version had to clone, install the
ARM toolchain, and run `./build.sh` themselves.

Add a `firmware-publish` job that runs on release creation, builds with
the same toolchain CI already uses for `build-firmware`, and attaches
`pico_multi.uf2` to the GitHub Release. Downstream consumers (notably
the eigsep-field image build, which currently invokes `gh release
download --pattern pico_multi.uf2` against the tag) can then pull a
versioned, immutable artifact instead of rebuilding from source.
