### PR TITLE
ci: add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds Python 3.13 to the picohost test matrix in `.github/workflows/ci.yml` (previously 3.10-3.12).
- No source changes needed: all 308 tests pass on 3.13 locally with no edits to the package.

## Why

This is part of the eigsep-field bookworm -> trixie / Python 3.11 -> 3.13 migration. The trixie field image ships system Python 3.13, so every sibling pinned by the `eigsep-field` manifest needs to have its CI prove 3.13 support before being repinned. picohost is the simplest of those siblings -- a single matrix line.

Once this merges, the next picohost tag (e.g. `v3.1.1`) will be repinnable in `eigsep-field`'s `manifest.toml`.

## Test plan

- [x] Local: `uv venv --python 3.13 && uv pip install -e ".[dev]" && pytest` -> 308 passed
- [x] CI: this PR's matrix run shows green on 3.10, 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)