### PR TITLE
fix(flash-picos): use PICO_CONFIG_KEY in confirmation message + README tag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ You have two options: download a prebuilt `pico_multi.uf2` from a GitHub Release
 
 Each tagged release has `pico_multi.uf2` attached as an asset, built from the matching source tree by CI.
 
-- **Browser:** open <https://github.com/EIGSEP/pico-firmware/releases>, pick a release (e.g. `picohost-v3.1.0`), and download `pico_multi.uf2` from the **Assets** section.
+- **Browser:** open <https://github.com/EIGSEP/pico-firmware/releases>, pick a release (e.g. `v3.1.0`), and download `pico_multi.uf2` from the **Assets** section.
 - **Command line (pinned, reproducible):**
   ```bash
-  gh release download picohost-v3.1.0 --pattern pico_multi.uf2 --repo EIGSEP/pico-firmware
+  gh release download v3.1.0 --pattern pico_multi.uf2 --repo EIGSEP/pico-firmware
   # or without gh:
   curl -L -o pico_multi.uf2 \
-    https://github.com/EIGSEP/pico-firmware/releases/download/picohost-v3.1.0/pico_multi.uf2
+    https://github.com/EIGSEP/pico-firmware/releases/download/v3.1.0/pico_multi.uf2
   ```
 - **Latest non-prerelease:**
   ```bash

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -12,6 +12,7 @@ from serial import Serial
 from serial.tools import list_ports
 
 from .buses import PicoConfigStore
+from .keys import PICO_CONFIG_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,8 @@ def main():
             _publish_to_redis(all_devices, args.redis_host, args.redis_port)
             print(
                 f"Published {len(all_devices)} device(s) to Redis at "
-                f"{args.redis_host}:{args.redis_port} (key: pico_config)."
+                f"{args.redis_host}:{args.redis_port} "
+                f"(key: {PICO_CONFIG_KEY})."
             )
         except Exception as e:
             print(


### PR DESCRIPTION
## Summary

Two small fixes bundled together:

- **`fix(flash-picos)`**: the post-publish print message hardcoded the literal `pico_config` key name instead of using `PICO_CONFIG_KEY` from `picohost.keys` like every other call site. The 3.0.0 Redis schema rework already proved this name isn't load-bearing — if it gets renamed again, the user-facing confirmation would silently lie about the key actually written.
- **`docs(readme)`**: the download instructions for prebuilt `pico_multi.uf2` referenced tag `picohost-v3.1.0`, but tags are cut as `v3.1.0` (`include-component-in-tag = false` in `release-please-config.json`). The `gh` / `curl` commands as written would 404. Updated all three references.

## Why now

`eigsep-field`'s image build (`scripts/fetch_firmware.py` → `gh release download v3.1.0 --pattern pico_multi.uf2`) is failing because the v3.1.0 release has no assets attached. Root cause: PR #64 (which added the `firmware-publish` job that uploads `pico_multi.uf2`) merged on 2026-05-01, *after* v3.1.0 was tagged on 2026-04-30. So no release has ever exercised the upload path. Cutting v3.1.1 will trigger `firmware-publish` for the first time and unblock the field image build downstream.

## Test plan

- [ ] release-please picks up `fix(flash-picos)` and proposes v3.1.1
- [ ] On merge of the release PR, `firmware-publish` job builds and attaches `pico_multi.uf2` to the v3.1.1 GitHub Release
- [ ] `gh release download v3.1.1 --pattern pico_multi.uf2 --repo EIGSEP/pico-firmware` succeeds (the README's own example, now consistent with actual tag format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)