### PR TITLE
fix(picohost): drop --config flag from pico-manager.service ExecStart

### DIFF
--- a/picohost/pico-manager.service
+++ b/picohost/pico-manager.service
@@ -5,7 +5,7 @@ Requires=redis-server.service
 
 [Service]
 Environment=PYTHONUNBUFFERED=1
-ExecStart=%h/venv/bin/pico-manager --config %h/eigsep/pico-firmware/pico_config.json --uf2 %h/eigsep/pico-firmware/build/pico_multi.uf2
+ExecStart=%h/venv/bin/pico-manager --uf2 %h/eigsep/pico-firmware/build/pico_multi.uf2
 Restart=always
 RestartSec=5
 TimeoutStartSec=120


### PR DESCRIPTION
## Summary

- The cascading-config refactor (`2f5c873`, shipped in v3.1.1) moved device config to Redis (`PicoConfigStore`) and dropped the JSON-file fallback. The CLI's argparse was updated — only `--uf2`, `--redis-host`, `--redis-port`, `--clear-config`, `--log-level` are accepted — but the systemd unit's ExecStart kept the legacy `--config %h/eigsep/pico-firmware/pico_config.json` argument.
- As shipped in v3.1.1, the service fails on every start with `pico-manager: error: unrecognized arguments: --config ...` and systemd restart-loops indefinitely.
- This drops the dead `--config` argument from ExecStart. No code changes — the CLI's behavior is unchanged; only the unit catches up.

## How it surfaced

First panda-Pi bring-up of the eigsep-field image (downstream pins picohost at `v3.1.1`). Journal showed:

```
eigsep-pico[1823]: usage: pico-manager [-h] [--uf2 UF2] [--redis-host REDIS_HOST]
                                       [--redis-port REDIS_PORT] [--clear-config]
                                       [--log-level {DEBUG,INFO,WARNING,ERROR}]
eigsep-pico[1823]: pico-manager: error: unrecognized arguments: --config /etc/eigsep/pico_config.json
systemd[1]: picomanager.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```

## Test plan

- [ ] release-please picks this up as a patch bump → `v3.1.2`
- [ ] After downstream bumps `picohost` to v3.1.2 and copies the new unit, panda-Pi `picomanager.service` starts cleanly with `Active: active (running)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)