### PR TITLE
feat: add flash-test CLI and BOOTSEL test firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ add_executable(pico_test_blink
 target_link_libraries(pico_test_blink
     pico_stdlib
     hardware_gpio
+    pico_unique_id
 )
 pico_enable_stdio_usb(pico_test_blink 1)
 pico_enable_stdio_uart(pico_test_blink 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,3 +77,18 @@ pico_add_extra_outputs(pico_multi)
 # set output name
 set_target_properties(pico_multi PROPERTIES OUTPUT_NAME "pico_multi")
 
+# Test image: blinks LED in a heartbeat pattern and exposes USB-CDC so
+# the Pico can subsequently be re-flashed with the production image via
+# `flash-picos`.
+add_executable(pico_test_blink
+    src/test_blink.c
+)
+target_link_libraries(pico_test_blink
+    pico_stdlib
+    hardware_gpio
+)
+pico_enable_stdio_usb(pico_test_blink 1)
+pico_enable_stdio_uart(pico_test_blink 0)
+pico_add_extra_outputs(pico_test_blink)
+set_target_properties(pico_test_blink PROPERTIES OUTPUT_NAME "pico_test_blink")
+

--- a/build.sh
+++ b/build.sh
@@ -59,15 +59,24 @@ if [ -f "pico_multi.uf2" ]; then
     echo "DIP switch combinations:"
     echo "  000 - Motor app (APP_MOTOR)"
     echo "  001 - Temperature controller (APP_TEMPCTRL)"
-    echo "  010 - Temperature monitor (APP_TEMPMON)" 
+    echo "  010 - Temperature monitor (APP_TEMPMON)"
     echo "  011 - IMU sensor, elevation (APP_IMU_EL)"
     echo "  100 - Lidar sensor (APP_LIDAR)"
     echo "  101 - RF switch control (APP_RFSWITCH)"
     echo "  110 - IMU sensor, azimuth (APP_IMU_AZ)"
     echo "==================================="
-    
+
     # Show file size
     ls -lh pico_multi.uf2
+
+    if [ -f "pico_test_blink.uf2" ]; then
+        echo ""
+        echo "Also built: build/pico_test_blink.uf2"
+        echo "  Heartbeat LED test image — flash onto BOOTSEL-mode Picos"
+        echo "  via \`flash-test\` to bring up USB-CDC before running"
+        echo "  \`flash-picos\` with the production image."
+        ls -lh pico_test_blink.uf2
+    fi
 else
     echo "❌ Build failed - pico_multi.uf2 not found"
     exit 1

--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 
 [project.scripts]
 flash-picos = "picohost.flash_picos:main"
+flash-test = "picohost.flash_test:main"
 pico-manager = "picohost.manager:main"
 calibrate-pot = "picohost.calibrate_pot:main"
 

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -23,14 +23,18 @@ PICO_PID_CDC = 0x0009  # CDC serial mode PID
 
 def find_pico_ports():
     """
-    Return a dict of device: serial pairs for all ttyACM*/ttyUSB* ports
-    whose USB VID/PID matches the Pico in CDC mode.
+    Return a dict of ``device: serial`` pairs for all ttyACM*/ttyUSB*
+    ports whose USB VID/PID matches a Pico running CDC firmware
+    (VID 0x2E8A, PID 0x0009).
+
+    BOOTSEL-mode Picos (PID 0x0003) are mass-storage devices and do
+    not appear in ``list_ports.comports()`` at all — use ``flash-test``
+    to install a CDC-capable image first.
     """
     ports = {}
     for info in list_ports.comports():
-        if info.vid == PICO_VID:
-            if info.pid in (PICO_PID_BOOTSEL, PICO_PID_CDC):
-                ports[info.device] = info.serial_number
+        if info.vid == PICO_VID and info.pid == PICO_PID_CDC:
+            ports[info.device] = info.serial_number
     return ports
 
 

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""`flash-test`: load the heartbeat test UF2 onto a Pico in BOOTSEL mode.
+
+`flash-picos` discovers Picos by enumerating CDC serial ports, which
+means a fresh / wiped Pico (USB PID 0x0003, mass-storage) is invisible
+to it. This CLI is a thin wrapper around ``picotool load`` that targets
+a BOOTSEL-mode Pico directly, so the test image can be installed,
+USB-CDC comes up, and the normal ``flash-picos`` workflow becomes
+available.
+"""
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build_picotool_cmd(uf2_path, bus=None, address=None):
+    """Return the argv for ``picotool load`` targeting BOOTSEL."""
+    cmd = ["picotool", "load", "-f", "-x", str(uf2_path)]
+    if bus is not None:
+        cmd += ["--bus", str(bus)]
+    if address is not None:
+        cmd += ["--address", str(address)]
+    return cmd
+
+
+def flash_test_image(uf2_path, bus=None, address=None):
+    """Flash *uf2_path* onto a BOOTSEL-mode Pico via picotool.
+
+    Parameters
+    ----------
+    uf2_path : str or Path
+        Path to the test UF2.
+    bus, address : int, optional
+        USB bus / device address. Forwarded to picotool to disambiguate
+        when multiple BOOTSEL devices are connected. Discover values
+        with ``picotool info -ab``.
+
+    Raises
+    ------
+    FileNotFoundError
+        UF2 not present.
+    RuntimeError
+        picotool exited non-zero.
+    """
+    uf2_path = Path(uf2_path)
+    if not uf2_path.is_file():
+        raise FileNotFoundError(f"UF2 file not found: {uf2_path}")
+
+    cmd = build_picotool_cmd(uf2_path, bus=bus, address=address)
+    print(f"Running: {' '.join(cmd)}")
+    res = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    print(res.stdout, end="")
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"picotool failed (exit {res.returncode}). "
+            "If multiple BOOTSEL Picos are connected, pass "
+            "--bus and --address from `picotool info -ab`."
+        )
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=(
+            "Flash a small heartbeat-LED test image onto a Pico in "
+            "BOOTSEL mode. After this, the Pico enumerates as USB-CDC "
+            "and can be re-flashed with the production image using "
+            "`flash-picos`."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--uf2",
+        default="build/pico_test_blink.uf2",
+        help="Path to the test UF2 (build with ./build.sh).",
+    )
+    p.add_argument(
+        "--bus",
+        type=int,
+        default=None,
+        help=(
+            "USB bus number of the target Pico. Use only when more "
+            "than one BOOTSEL device is connected."
+        ),
+    )
+    p.add_argument(
+        "--address",
+        type=int,
+        default=None,
+        help="USB device address of the target Pico (companion to --bus).",
+    )
+    args = p.parse_args()
+
+    try:
+        flash_test_image(args.uf2, bus=args.bus, address=args.address)
+    except FileNotFoundError as e:
+        print(
+            f"{e}\nBuild the test image first with ./build.sh.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        "\nFlash complete. The Pico should now blink in a heartbeat "
+        "pattern and enumerate as /dev/ttyACM* (USB VID:PID "
+        "2e8a:0009).\nRun `flash-picos --uf2 build/pico_multi.uf2` to "
+        "install the production image."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -52,13 +52,18 @@ def flash_test_image(uf2_path, bus=None, address=None):
     res = subprocess.run(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
     )
-    print(res.stdout, end="")
+    output = res.stdout or ""
     if res.returncode != 0:
+        if output:
+            print(output, end="", file=sys.stderr)
         raise RuntimeError(
             f"picotool failed (exit {res.returncode}). "
             "If multiple BOOTSEL Picos are connected, pass "
             "--bus and --address from `picotool info -ab`."
+            + (f"\npicotool output:\n{output}" if output else "")
         )
+    if output:
+        print(output, end="")
 
 
 def main():

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -1,0 +1,74 @@
+"""Tests for picohost.flash_test."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from picohost.flash_test import build_picotool_cmd, flash_test_image
+
+
+class TestBuildPicotoolCmd:
+    def test_minimal(self):
+        cmd = build_picotool_cmd("foo.uf2")
+        assert cmd == ["picotool", "load", "-f", "-x", "foo.uf2"]
+
+    def test_with_bus_and_address(self):
+        cmd = build_picotool_cmd("foo.uf2", bus=1, address=4)
+        assert cmd == [
+            "picotool", "load", "-f", "-x", "foo.uf2",
+            "--bus", "1", "--address", "4",
+        ]
+
+    def test_accepts_path(self):
+        cmd = build_picotool_cmd(Path("foo.uf2"))
+        assert cmd[-1] == "foo.uf2"
+
+
+class TestFlashTestImage:
+    def test_missing_uf2_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="UF2 file not found"):
+            flash_test_image(tmp_path / "nonexistent.uf2")
+
+    def test_invokes_picotool(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        flash_test_image(uf2)
+
+        assert captured["cmd"] == [
+            "picotool", "load", "-f", "-x", str(uf2),
+        ]
+
+    def test_passes_bus_and_address(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        flash_test_image(uf2, bus=2, address=7)
+
+        assert captured["cmd"][-4:] == ["--bus", "2", "--address", "7"]
+
+    def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="boom\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="picotool failed"):
+            flash_test_image(uf2)

--- a/src/test_blink.c
+++ b/src/test_blink.c
@@ -1,0 +1,27 @@
+// Standalone test image: heartbeat-blinks the onboard LED and exposes
+// USB-CDC so the Pico can be reflashed via `flash-picos`.
+//
+// The blink pattern (80 ms on / 80 ms off / 80 ms on / 760 ms off) is
+// intentionally distinct from production firmware's steady 200 ms
+// toggle (see src/main.c) so a tech can tell at a glance which image
+// is running.
+
+#include "pico/stdlib.h"
+
+int main(void) {
+    stdio_init_all();
+
+    gpio_init(PICO_DEFAULT_LED_PIN);
+    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+
+    while (true) {
+        gpio_put(PICO_DEFAULT_LED_PIN, 1);
+        sleep_ms(80);
+        gpio_put(PICO_DEFAULT_LED_PIN, 0);
+        sleep_ms(80);
+        gpio_put(PICO_DEFAULT_LED_PIN, 1);
+        sleep_ms(80);
+        gpio_put(PICO_DEFAULT_LED_PIN, 0);
+        sleep_ms(760);
+    }
+}


### PR DESCRIPTION
## Summary

- New `pico_test_blink` firmware target (44 KB) that brings up USB-CDC and blinks the onboard LED in an 80/80/80/760 ms heartbeat pattern, visually distinct from production's 200 ms toggle.
- New `flash-test` CLI: wraps `picotool load -f -x` to install the test UF2 onto a Pico in BOOTSEL mode. Provisions virgin / wiped Picos that `flash-picos` cannot discover (since CDC serial enumeration misses MSC-mode devices).
- Drops the misleading `PICO_PID_BOOTSEL` branch from `find_pico_ports` — `list_ports.comports()` never returns BOOTSEL devices, so the check was dead code.

## Test plan

- [x] `./build.sh` produces both `build/pico_multi.uf2` (167 K) and `build/pico_test_blink.uf2` (44 K).
- [x] `pytest` — 315 passing (incl. 7 new `test_flash_test.py` cases; existing flash-picos tests unchanged).
- [x] `flash-test --help` renders correctly.
- [ ] On hardware: BOOTSEL Pico flashed with `flash-test` shows heartbeat blink and enumerates as `/dev/ttyACM*`.
- [ ] On hardware: `flash-picos --uf2 build/pico_multi.uf2 --no-redis` then succeeds with the production image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)