### PR TITLE
fix: emit status="error" per-cycle on firmware data-refresh failure

### DIFF
--- a/picohost/src/picohost/emulators/imu.py
+++ b/picohost/src/picohost/emulators/imu.py
@@ -31,6 +31,9 @@ class ImuEmulator(PicoEmulator):
         self.is_initialized = True
         self._last_event_time = time.monotonic()
         self._sensor_failed = False  # set via simulate_sensor_failure()
+        # Per-cycle freshness flag: True iff a packet was produced since
+        # the last get_status() call. Drives the "status" field.
+        self.got_packet_this_cycle = False
         # Name depends on app_id: mirrors imu.cpp init_eigsep_imu()
         APP_IMU_EL, APP_IMU_AZ = 3, 6
         if app_id == APP_IMU_EL:
@@ -107,8 +110,11 @@ class ImuEmulator(PicoEmulator):
             9.81 * cp * cr + np.random.normal(0, NOISE_STDDEV)
         )
 
+        self.got_packet_this_cycle = True
+
     def get_status(self):
-        status = "update" if self.is_initialized else "error"
+        status = "update" if self.got_packet_this_cycle else "error"
+        self.got_packet_this_cycle = False
         return {
             "sensor_name": self.name,
             "status": status,

--- a/picohost/src/picohost/emulators/lidar.py
+++ b/picohost/src/picohost/emulators/lidar.py
@@ -11,6 +11,10 @@ class LidarEmulator(PicoEmulator):
     def __init__(self, app_id=4, **kwargs):
         self._base_distance = 100.0  # meters
         self.distance = self._base_distance
+        self._sensor_failed = False  # set via simulate_sensor_failure()
+        # Per-cycle freshness flag: True iff op() refreshed the
+        # distance reading since the last get_status() call.
+        self.last_op_ok = False
         super().__init__(app_id=app_id, **kwargs)
 
     def init(self):
@@ -19,13 +23,28 @@ class LidarEmulator(PicoEmulator):
     def server(self, cmd):
         pass  # lidar does not handle commands
 
+    def simulate_sensor_failure(self):
+        """Simulate i2c read failure / TF-Luna not-ready loop."""
+        self._sensor_failed = True
+
+    def simulate_sensor_recovery(self):
+        """Simulate sensor coming back after a failure."""
+        self._sensor_failed = False
+
     def op(self):
+        if self._sensor_failed:
+            # Matches firmware: i2c_read_timeout or dist_cm==0 → reset+return,
+            # leaving previous distance unchanged and last_op_ok at False.
+            return
         self.distance = self._base_distance + np.random.normal(0, NOISE_STDDEV)
+        self.last_op_ok = True
 
     def get_status(self):
+        status = "update" if self.last_op_ok else "error"
+        self.last_op_ok = False
         return {
             "sensor_name": "lidar",
-            "status": "update",
+            "status": status,
             "app_id": self.app_id,
             "distance_m": self.distance,
         }

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -401,6 +401,20 @@ class TestLidarEmulator:
         expected_keys = {"sensor_name", "status", "app_id", "distance_m"}
         assert set(status.keys()) == expected_keys
 
+    def test_failure_then_recovery_returns_to_update(self):
+        """One failed cycle reports "error"; the next good op() returns to "update"."""
+        emu = LidarEmulator()
+        emu.op()
+        assert emu.get_status()["status"] == "update"
+
+        emu.simulate_sensor_failure()
+        emu.op()
+        assert emu.get_status()["status"] == "error"
+
+        emu.simulate_sensor_recovery()
+        emu.op()
+        assert emu.get_status()["status"] == "update"
+
 
 class TestRFSwitchEmulator:
     def test_initial_state_settled_when_instant(self):
@@ -671,11 +685,22 @@ class TestTempMonErrorState:
 
 
 class TestImuErrorState:
-    def test_init_failure_reports_error(self):
-        """When not initialized, status reports error."""
+    def test_persistent_failure_then_recovery(self):
+        """Sustained sensor failure flips status="error"; recovery returns to "update"."""
+        import picohost.emulators.imu as imu_mod
+
         emu = ImuEmulator()
-        emu.inject_init_failure()
+        emu.op()
+        assert emu.get_status()["status"] == "update"
+
+        emu.simulate_sensor_failure()
+        emu._last_event_time -= imu_mod.IMU_EVENT_TIMEOUT_S + 1
+        emu.op()
         assert emu.get_status()["status"] == "error"
+
+        emu.simulate_sensor_recovery()
+        emu.op()
+        assert emu.get_status()["status"] == "update"
 
 
 # ---------------------------------------------------------------------------

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -313,10 +313,15 @@ class TestImuProtocol:
         after = emu.get_status()
         assert before == after
 
-    def test_error_status_when_not_initialized(self):
-        """imu.c: status="error" if !is_initialized."""
+    def test_status_is_per_cycle(self):
+        """imu.c: status="update" iff a packet arrived since last get_status()."""
         emu = ImuEmulator()
-        emu.inject_init_failure()
+        # No op() yet: no packet this cycle → "error".
+        assert emu.get_status()["status"] == "error"
+        # op() simulates a fresh packet.
+        emu.op()
+        assert emu.get_status()["status"] == "update"
+        # get_status() resets the flag; without another op() it's "error" again.
         assert emu.get_status()["status"] == "error"
 
     def test_euler_angles_are_degrees(self):
@@ -350,6 +355,30 @@ class TestLidarProtocol:
         emu = LidarEmulator()
         emu.op()
         assert isinstance(emu.get_status()["distance_m"], float)
+
+    def test_status_is_per_cycle(self):
+        """lidar.c: status="update" iff op() refreshed distance this cycle."""
+        emu = LidarEmulator()
+        # No op() yet: status defaults to "error".
+        assert emu.get_status()["status"] == "error"
+        emu.op()
+        assert emu.get_status()["status"] == "update"
+        # get_status() resets the flag.
+        assert emu.get_status()["status"] == "error"
+
+    def test_simulated_failure_emits_error_with_stale_distance(self):
+        """Failure path: distance unchanged from previous good read, status="error"."""
+        emu = LidarEmulator()
+        emu.op()
+        good = emu.get_status()
+        assert good["status"] == "update"
+        prev_distance = good["distance_m"]
+
+        emu.simulate_sensor_failure()
+        emu.op()
+        bad = emu.get_status()
+        assert bad["status"] == "error"
+        assert bad["distance_m"] == prev_distance
 
 
 # ---------------------------------------------------------------------------

--- a/src/imu.c
+++ b/src/imu.c
@@ -140,13 +140,14 @@ void imu_op(uint8_t app_id) {
 
     if (got_packet) {
         imu.last_event_time = now;
+        imu.got_packet_this_cycle = true;
     } else if ((now - imu.last_event_time) > IMU_EVENT_TIMEOUT_MS) {
         imu.is_initialized = false;
     }
 }
 
 void imu_status(uint8_t app_id) {
-    const char *status = imu.is_initialized ? "update" : "error";
+    const char *status = imu.got_packet_this_cycle ? "update" : "error";
 
     send_json(9,
         KV_STR,   "sensor_name", imu.name,
@@ -159,4 +160,5 @@ void imu_status(uint8_t app_id) {
         KV_FLOAT, "accel_y",     imu.data.accel_y,
         KV_FLOAT, "accel_z",     imu.data.accel_z
     );
+    imu.got_packet_this_cycle = false;
 }

--- a/src/imu.h
+++ b/src/imu.h
@@ -44,6 +44,10 @@ typedef struct {
     RvcData   data;
     bool      is_initialized;
     uint32_t  last_event_time;    /* ms since boot of last valid packet */
+    /* Set on every valid packet, cleared by imu_status(); drives the
+       per-cycle "status" field while is_initialized continues to gate
+       the longer hardware-recovery timeout. */
+    bool      got_packet_this_cycle;
     /* Partial-packet receive buffer */
     uint8_t   rx_buf[RVC_PACKET_SIZE];
     uint8_t   rx_pos;

--- a/src/lidar.c
+++ b/src/lidar.c
@@ -13,6 +13,7 @@
 
 static struct {
     float distance;
+    bool last_op_ok;
 } lidar_data = {0};
 
 static void init_i2c() {
@@ -60,12 +61,14 @@ void lidar_server(uint8_t app_id, const char *json_str) {
 }
 
 void lidar_status(uint8_t app_id) {
+    const char *status = lidar_data.last_op_ok ? "update" : "error";
     send_json(4,
         KV_STR, "sensor_name", "lidar",
-        KV_STR, "status", "update",
+        KV_STR, "status", status,
         KV_INT, "app_id", app_id,
         KV_FLOAT, "distance_m", lidar_data.distance
     );
+    lidar_data.last_op_ok = false;
 }
 
 
@@ -89,6 +92,7 @@ void lidar_op(uint8_t app_id) {
         return;
     }
     lidar_data.distance = dist_cm / 100.0;
+    lidar_data.last_op_ok = true;
 }
 
 

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -112,6 +112,10 @@ void tempctrl_status(uint8_t app_id) {
     const uint32_t time_lna = temp_sensor_get_conversion_time(&tempctrl_lna.temp_sensor);
     const uint32_t time_load = temp_sensor_get_conversion_time(&tempctrl_load.temp_sensor);
 
+    /* read_error is set/cleared on every temp_sensor_read() attempt, so
+       LNA_status / LOAD_status reflect the most recent attempt rather
+       than a stale timeout window. Matches the per-cycle status contract
+       enforced by eigsep_observing._avg_sensor_values. */
     const char *status_lna = temp_sensor_has_error(&tempctrl_lna.temp_sensor) ? "error" : "update";
     const char *status_load = temp_sensor_has_error(&tempctrl_load.temp_sensor) ? "error" : "update";
 


### PR DESCRIPTION
## Summary

Extends the per-failure status pattern already in `imu.c` and
`tempctrl.c` to every other app, so `status: "error"` on a periodic
status update is a truthful per-cycle signal that the data fields in
*this* JSON came from a failed read.

This matters because `eigsep_observing._avg_sensor_values` (the
contract authority, documented in that repo's `CLAUDE.md:176-187`)
filters samples with `status == "error"` out of every per-field
reduction and collapses per-row `status` to `"error"` if any raw
sample errored. Apps that hard-code `"update"` on failure (today:
lidar, motor, rfswitch, potmon) silently pollute integration
averages with stale values whenever a sensor read fails.

## Per-app changes

- **lidar.c**: `lidar_data` gains `last_op_ok`. Set true only on a
  successful non-zero distance read; both failure paths (i2c
  timeout, `dist_cm == 0` sentinel) leave it false. `lidar_status()`
  emits the right value and resets.
- **imu.c / imu.h**: add `got_packet_this_cycle` to `ImuState`.
  Set on every valid RVC packet, consumed + reset by `imu_status()`.
  The existing `is_initialized` / `IMU_EVENT_TIMEOUT_MS` hardware
  recovery loop is intentionally left untouched — status is
  per-cycle (200 ms), recovery is still timeout-based (5 s). The
  two flags can diverge for a few cycles when packets stop arriving;
  that's deliberate.
- **tempctrl.c**: comment-only — `LNA_status` / `LOAD_status` are
  already per-attempt via `temp_sensor_has_error()`.
- **motor.c / rfswitch.c / potmon.c**: no change. These apps have
  no per-cycle failure mode (pure software state or non-failing
  reads).

Picohost emulators (lidar, imu) updated to mirror the firmware.

## Test plan

- [x] `./build.sh` rebuilds firmware cleanly for `PICO_BOARD=pico2`.
- [x] `cd picohost && pytest` — 318 passed (315 prior + 3 new).
  - `TestLidarProtocol::test_status_is_per_cycle`
  - `TestLidarProtocol::test_simulated_failure_emits_error_with_stale_distance`
  - `TestLidarEmulator::test_failure_then_recovery_returns_to_update`
  - Updated: `TestImuProtocol::test_status_is_per_cycle` (was
    `test_error_status_when_not_initialized`)
  - Updated: `TestImuErrorState::test_persistent_failure_then_recovery`
    (was `test_init_failure_reports_error`)
- [ ] Hardware smoke test (operator-driven): flash a Pico in
  `APP_LIDAR`, disconnect the sensor cable, confirm `picohost` shows
  `status: "error"` within ~200 ms; reconnect, confirm `status`
  returns to `"update"`.

## Open design points

1. **IMU recovery cadence mismatch is intentional.** Status flips to
   `"error"` after one missed 200 ms cycle, but hardware recovery
   only triggers after the 5 s `IMU_EVENT_TIMEOUT_MS` window — so
   the host sees ~25 `"error"` emissions (with stale yaw/pitch/roll)
   before the firmware attempts a re-init. Acceptable per the
   contract: those samples are filtered from averages.
2. **rfswitch transition not flagged as error.** Relying on the
   existing `_avg_rfswitch_metadata` UNKNOWN-state handling in
   eigsep_observing. If we ever want averager to see `"error"`
   during a switch settle window, that's a contract change there,
   not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)