### PR TITLE
feat(tempctrl): split status into per-channel Redis streams

### DIFF
--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -598,7 +598,51 @@ class PicoPeltier(PicoDevice):
             usb_serial=usb_serial,
             verbose=verbose,
         )
+        if self.redis_handler is not None:
+            self._base_redis_handler = self.redis_handler
+            self.redis_handler = self._peltier_redis_handler
         self._start_keepalive()
+
+    _PELTIER_CHANNEL_FIELDS = (
+        "T_now",
+        "timestamp",
+        "T_target",
+        "drive_level",
+        "enabled",
+        "active",
+        "int_disabled",
+        "hysteresis",
+        "clamp",
+    )
+    _PELTIER_STREAMS = (("LNA", "tempctrl_lna"), ("LOAD", "tempctrl_load"))
+
+    def _peltier_redis_handler(self, data):
+        """Fan out the combined tempctrl status dict into two Redis streams.
+
+        The firmware emits one combined message per status tick with
+        ``LNA_*`` / ``LOAD_*`` prefixed fields plus the device-wide
+        watchdog state. We publish two streams (``tempctrl_lna``,
+        ``tempctrl_load``), each matching the standard one-stream-per-
+        sensor schema with a top-level ``status`` derived from the
+        channel's ``LNA_status`` / ``LOAD_status``. The device-wide
+        watchdog fields are duplicated into both streams; both come from
+        the same firmware tick so a momentary tick-to-tick disagreement
+        is harmless.
+        """
+        app_id = data.get("app_id")
+        watchdog_tripped = data.get("watchdog_tripped")
+        watchdog_timeout_ms = data.get("watchdog_timeout_ms")
+        for prefix, stream in self._PELTIER_STREAMS:
+            out = {
+                "sensor_name": stream,
+                "app_id": app_id,
+                "status": data.get(f"{prefix}_status"),
+                "watchdog_tripped": watchdog_tripped,
+                "watchdog_timeout_ms": watchdog_timeout_ms,
+            }
+            for k in self._PELTIER_CHANNEL_FIELDS:
+                out[k] = data.get(f"{prefix}_{k}")
+            self._base_redis_handler(out)
 
     def _start_keepalive(self):
         """Start the background keepalive thread (idempotent)."""

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -761,3 +761,158 @@ class TestPicoPeltierReconnectReplay:
             assert {"LNA_enable": True, "LOAD_enable": False} in sent
         finally:
             peltier.disconnect()
+
+
+class TestPicoPeltierRedisHandler:
+    """Verify _peltier_redis_handler fans the firmware tick into two streams.
+
+    The firmware emits one combined dict per status tick (sensor_name
+    "tempctrl", flat LNA_*/LOAD_* fields, device-wide watchdog_*). The
+    handler must publish two streams ("tempctrl_lna" and "tempctrl_load"),
+    each carrying a top-level ``status`` derived from the matching
+    ``{channel}_status`` and the device-wide watchdog fields duplicated.
+    """
+
+    _SCALAR_TYPES = (str, int, float, bool, type(None))
+
+    _SAMPLE = {
+        "sensor_name": "tempctrl",
+        "app_id": 1,
+        "watchdog_tripped": False,
+        "watchdog_timeout_ms": 30000,
+        "LNA_status": "update",
+        "LNA_T_now": 25.4,
+        "LNA_timestamp": 750.0,
+        "LNA_T_target": 25.0,
+        "LNA_drive_level": 0.42,
+        "LNA_enabled": True,
+        "LNA_active": True,
+        "LNA_int_disabled": False,
+        "LNA_hysteresis": 0.5,
+        "LNA_clamp": 0.8,
+        "LOAD_status": "error",
+        "LOAD_T_now": None,
+        "LOAD_timestamp": 750.0,
+        "LOAD_T_target": 25.0,
+        "LOAD_drive_level": 0.0,
+        "LOAD_enabled": True,
+        "LOAD_active": False,
+        "LOAD_int_disabled": True,
+        "LOAD_hysteresis": 0.5,
+        "LOAD_clamp": 0.8,
+    }
+
+    _EXPECTED_KEYS = {
+        "sensor_name",
+        "app_id",
+        "status",
+        "watchdog_tripped",
+        "watchdog_timeout_ms",
+        "T_now",
+        "timestamp",
+        "T_target",
+        "drive_level",
+        "enabled",
+        "active",
+        "int_disabled",
+        "hysteresis",
+        "clamp",
+    }
+
+    def _capture_all(self, peltier, data):
+        captured = []
+        peltier._base_redis_handler = (
+            lambda d: captured.append(dict(d))  # type: ignore[method-assign]
+        )
+        peltier._peltier_redis_handler(data)
+        return captured
+
+    def test_publishes_two_streams_per_tick(self):
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            published = self._capture_all(peltier, self._SAMPLE)
+            assert len(published) == 2
+            names = [p["sensor_name"] for p in published]
+            assert names == ["tempctrl_lna", "tempctrl_load"]
+        finally:
+            peltier.disconnect()
+
+    def test_channel_status_derived_from_prefixed_status(self):
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            lna, load = self._capture_all(peltier, self._SAMPLE)
+            assert lna["status"] == "update"
+            assert load["status"] == "error"
+        finally:
+            peltier.disconnect()
+
+    def test_channel_fields_have_prefix_stripped(self):
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            lna, load = self._capture_all(peltier, self._SAMPLE)
+            assert lna["T_now"] == pytest.approx(25.4)
+            assert lna["drive_level"] == pytest.approx(0.42)
+            assert lna["active"] is True
+            assert lna["int_disabled"] is False
+            assert load["T_now"] is None
+            assert load["active"] is False
+            assert load["int_disabled"] is True
+        finally:
+            peltier.disconnect()
+
+    def test_watchdog_fields_duplicated(self):
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            lna, load = self._capture_all(peltier, self._SAMPLE)
+            for entry in (lna, load):
+                assert entry["watchdog_tripped"] is False
+                assert entry["watchdog_timeout_ms"] == 30000
+                assert entry["app_id"] == 1
+        finally:
+            peltier.disconnect()
+
+    def test_published_shape_stable_across_channel_state(self):
+        """Both streams expose the same key set regardless of values."""
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            lna, load = self._capture_all(peltier, self._SAMPLE)
+            assert set(lna) == self._EXPECTED_KEYS
+            assert set(load) == self._EXPECTED_KEYS
+        finally:
+            peltier.disconnect()
+
+    def test_published_dict_is_scalar_only(self):
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            for entry in self._capture_all(peltier, self._SAMPLE):
+                for k, v in entry.items():
+                    assert isinstance(v, self._SCALAR_TYPES), (
+                        f"field {k!r} has non-scalar type "
+                        f"{type(v).__name__}"
+                    )
+        finally:
+            peltier.disconnect()
+
+    def test_handler_does_not_mutate_input(self):
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            data = dict(self._SAMPLE)
+            original = dict(self._SAMPLE)
+            self._capture_all(peltier, data)
+            assert data == original
+        finally:
+            peltier.disconnect()
+
+    def test_missing_fields_publish_none(self):
+        """Channel status absent from the source dict publishes None."""
+        peltier = DummyPicoPeltier("/dev/dummy")
+        try:
+            partial = {"sensor_name": "tempctrl", "app_id": 1}
+            lna, load = self._capture_all(peltier, partial)
+            assert lna["status"] is None
+            assert load["status"] is None
+            assert lna["T_now"] is None
+            assert lna["watchdog_tripped"] is None
+            assert lna["watchdog_timeout_ms"] is None
+        finally:
+            peltier.disconnect()

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -462,6 +462,42 @@ class TestRedisIntegration:
         names = [name for name, _ in received]
         assert "temp_mon" in names
 
+    def test_peltier_publishes_two_streams_per_tick(self):
+        """PicoPeltier splits its combined firmware tick into LNA and LOAD."""
+        received = []
+
+        class FakeMetadataWriter:
+            def add(self, name, data):
+                received.append((name, dict(data)))
+
+        peltier = DummyPicoPeltier(
+            "/dev/dummy", metadata_writer=FakeMetadataWriter()
+        )
+        cadence = peltier.EMULATOR_CADENCE_MS
+        wait_for_condition(
+            lambda: any(n == "tempctrl_load" for n, _ in received),
+            cadence_ms=cadence,
+        )
+        peltier.disconnect()
+        names = [name for name, _ in received]
+        assert "tempctrl_lna" in names
+        assert "tempctrl_load" in names
+        # No legacy "tempctrl" entries should leak through.
+        assert "tempctrl" not in names
+        # Each tick must publish exactly one entry per stream; check the
+        # tail of the buffer to avoid races on disconnect timing.
+        last_two = received[-2:]
+        last_names = sorted(n for n, _ in last_two)
+        assert last_names == ["tempctrl_lna", "tempctrl_load"]
+        lna_entry = next(d for n, d in reversed(received) if n == "tempctrl_lna")
+        load_entry = next(d for n, d in reversed(received) if n == "tempctrl_load")
+        assert lna_entry["sensor_name"] == "tempctrl_lna"
+        assert load_entry["sensor_name"] == "tempctrl_load"
+        assert "status" in lna_entry and "status" in load_entry
+        assert "T_now" in lna_entry and "T_now" in load_entry
+        assert "watchdog_timeout_ms" in lna_entry
+        assert "watchdog_timeout_ms" in load_entry
+
 
 # --- Convergence Timing ---
 


### PR DESCRIPTION
## Summary

`PicoPeltier.redis_handler` now fans the firmware's combined tempctrl status tick into two Redis streams — `tempctrl_lna` and `tempctrl_load` — each carrying:

- a top-level `status` derived from the firmware's per-channel `LNA_status` / `LOAD_status`,
- the channel-data fields with the `LNA_`/`LOAD_` prefix stripped (`T_now`, `drive_level`, `T_target`, `enabled`, `active`, `int_disabled`, `hysteresis`, `clamp`, `timestamp`),
- the device-wide `watchdog_tripped` / `watchdog_timeout_ms` duplicated into both streams.

Mirrors the additive-handler pattern used by `_pot_redis_handler` / `_rfswitch_redis_handler`.

**Unchanged:** the firmware's 24-field `send_json` in `src/tempctrl.c`, `TempCtrlEmulator.get_status()`, and the `PicoProxy("tempctrl")` command/response stream. Only the metadata publish path splits.

## Why

Every other sensor publishes a top-level `status` field. tempctrl was the odd one out — it carried `LNA_status` / `LOAD_status` per channel and no top-level `status`, which is exactly the field eigsep_observing's live dashboard reads to color the tile. Result: the tempctrl tile rendered `?` instead of update/error. Splitting at the producer fixes the tile, removes a 70-line `_avg_temp_metadata` special case downstream, and aligns the data model with the physics (two independent control loops sharing one Pico).

## Breaking change

Redis-stream contract: anything that reads `metadata.tempctrl` now reads `metadata.tempctrl_lna` and `metadata.tempctrl_load`. **Must land alongside the eigsep_observing companion PR**, which updates the schema, consumers, and tests.

Companion PR (draft, gated on this one): EIGSEP/eigsep_observing

## Test plan

- [x] `pytest` — 327 passed, including 8 new `TestPicoPeltierRedisHandler` tests asserting two `.add()` calls per tick, derived status, watchdog duplication, scalar-only shape, and immutability of caller dicts
- [x] New integration test in `test_emulator_integration.py` confirms the live emulator path publishes both streams and never publishes a legacy "tempctrl" entry
- [ ] Once both PRs land: emulator-backed dashboard sanity check (two tempctrl tiles, force one channel error to confirm independent color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)