### PR TITLE
feat(picohost): identify Picos by USB serial in flash CLIs

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -28,6 +28,7 @@ flash-picos = "picohost.flash_picos:main"
 flash-test = "picohost.flash_test:main"
 pico-manager = "picohost.manager:main"
 calibrate-pot = "picohost.calibrate_pot:main"
+picohost-resolve = "picohost.resolve:main"
 
 [project.optional-dependencies]
 dev = [

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -102,7 +102,11 @@ def _resolve_post_flash_port(
 
 
 def flash_and_discover(
-    uf2_path="build/pico_multi.uf2", port=None, baud=115200, timeout=10
+    uf2_path="build/pico_multi.uf2",
+    port=None,
+    usb_serial=None,
+    baud=115200,
+    timeout=10,
 ):
     """
     Flash all attached Picos and read device config from each.
@@ -114,6 +118,11 @@ def flash_and_discover(
     port : str, optional
         Limit to a single serial port.  ``None`` means all discovered
         Picos.
+    usb_serial : str, optional
+        Limit to the Pico with this USB serial number (board unique
+        ID). Stable across reboots and port renumbering — preferred
+        over ``port`` for targeted flashing. If both are given, the
+        device must match both.
     baud : int
         Serial baud rate for reading JSON after flash.
     timeout : int
@@ -137,6 +146,8 @@ def flash_and_discover(
     ports = find_pico_ports()
     if port:
         ports = {k: v for k, v in ports.items() if k == port}
+    if usb_serial:
+        ports = {k: v for k, v in ports.items() if v == usb_serial}
 
     if not ports:
         logger.info("No Raspberry Pi Pico serial ports found")
@@ -207,6 +218,16 @@ def main():
         "--port", default=None, help="Serial port of pico, None means all"
     )
     p.add_argument(
+        "--usb-serial",
+        default=None,
+        help=(
+            "USB serial number (Pico board unique ID). Stable across "
+            "reboots and port renumbering — preferred over --port for "
+            "targeted flashing. Look up in `devices_info.json` or with "
+            "`picotool info -a`."
+        ),
+    )
+    p.add_argument(
         "--uf2",
         default="build/pico_multi.uf2",
         help="Path to your pico_multi.uf2",
@@ -261,6 +282,7 @@ def main():
         all_devices = flash_and_discover(
             uf2_path=args.uf2,
             port=args.port,
+            usb_serial=args.usb_serial,
             baud=args.baud,
             timeout=args.timeout,
         )

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -14,9 +14,11 @@ import sys
 from pathlib import Path
 
 
-def build_picotool_cmd(uf2_path, bus=None, address=None):
+def build_picotool_cmd(uf2_path, bus=None, address=None, usb_serial=None):
     """Return the argv for ``picotool load`` targeting BOOTSEL."""
     cmd = ["picotool", "load", "-f", "-x", str(uf2_path)]
+    if usb_serial is not None:
+        cmd += ["--ser", str(usb_serial)]
     if bus is not None:
         cmd += ["--bus", str(bus)]
     if address is not None:
@@ -24,7 +26,7 @@ def build_picotool_cmd(uf2_path, bus=None, address=None):
     return cmd
 
 
-def flash_test_image(uf2_path, bus=None, address=None):
+def flash_test_image(uf2_path, bus=None, address=None, usb_serial=None):
     """Flash *uf2_path* onto a BOOTSEL-mode Pico via picotool.
 
     Parameters
@@ -35,6 +37,9 @@ def flash_test_image(uf2_path, bus=None, address=None):
         USB bus / device address. Forwarded to picotool to disambiguate
         when multiple BOOTSEL devices are connected. Discover values
         with ``picotool info -ab``.
+    usb_serial : str, optional
+        Pico board unique ID (flash serial). Stable across reboots and
+        BOOTSEL toggles; preferred over bus/address when known.
 
     Raises
     ------
@@ -47,7 +52,9 @@ def flash_test_image(uf2_path, bus=None, address=None):
     if not uf2_path.is_file():
         raise FileNotFoundError(f"UF2 file not found: {uf2_path}")
 
-    cmd = build_picotool_cmd(uf2_path, bus=bus, address=address)
+    cmd = build_picotool_cmd(
+        uf2_path, bus=bus, address=address, usb_serial=usb_serial
+    )
     print(f"Running: {' '.join(cmd)}")
     res = subprocess.run(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
@@ -58,8 +65,9 @@ def flash_test_image(uf2_path, bus=None, address=None):
             print(output, end="", file=sys.stderr)
         raise RuntimeError(
             f"picotool failed (exit {res.returncode}). "
-            "If multiple BOOTSEL Picos are connected, pass "
-            "--bus and --address from `picotool info -ab`."
+            "If multiple BOOTSEL Picos are connected, pass --usb-serial "
+            "(from `picotool info -a`) or --bus/--address "
+            "(from `picotool info -ab`)."
             + (f"\npicotool output:\n{output}" if output else "")
         )
     if output:
@@ -96,10 +104,24 @@ def main():
         default=None,
         help="USB device address of the target Pico (companion to --bus).",
     )
+    p.add_argument(
+        "--usb-serial",
+        default=None,
+        help=(
+            "Pico board unique ID (flash serial). Preferred over "
+            "--bus/--address: stable across reboots and BOOTSEL toggles. "
+            "Discover with `picotool info -a`."
+        ),
+    )
     args = p.parse_args()
 
     try:
-        flash_test_image(args.uf2, bus=args.bus, address=args.address)
+        flash_test_image(
+            args.uf2,
+            bus=args.bus,
+            address=args.address,
+            usb_serial=args.usb_serial,
+        )
     except FileNotFoundError as e:
         print(
             f"{e}\nBuild the test image first with ./build.sh.",

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -16,13 +16,14 @@ from pathlib import Path
 
 def build_picotool_cmd(uf2_path, bus=None, address=None, usb_serial=None):
     """Return the argv for ``picotool load`` targeting BOOTSEL."""
-    cmd = ["picotool", "load", "-f", "-x", str(uf2_path)]
+    cmd = ["picotool", "load", "-f"]
     if usb_serial is not None:
         cmd += ["--ser", str(usb_serial)]
     if bus is not None:
         cmd += ["--bus", str(bus)]
     if address is not None:
         cmd += ["--address", str(address)]
+    cmd += ["-x", str(uf2_path)]
     return cmd
 
 

--- a/picohost/src/picohost/resolve.py
+++ b/picohost/src/picohost/resolve.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""`picohost-resolve`: map a Pico USB serial to its current /dev/ttyACMn.
+
+The serial number is the stable identifier; ``/dev/ttyACMn`` shuffles on
+replug/reboot. Use this helper in field debug sessions when you know
+the Pico by its role (e.g. from ``devices_info.json``) but need the
+current port to attach a serial client.
+"""
+import argparse
+import sys
+
+from .flash_picos import find_pico_ports
+
+
+def resolve_port(usb_serial):
+    """Return the ``/dev/ttyACMn`` currently bound to *usb_serial*.
+
+    Returns ``None`` if no attached CDC-mode Pico has that serial.
+    BOOTSEL-mode Picos are invisible here — they have no serial port.
+    """
+    for device, serial in find_pico_ports().items():
+        if serial == usb_serial:
+            return device
+    return None
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=(
+            "Resolve a Pico USB serial number to its current serial "
+            "port. With no argument, lists all attached CDC-mode Picos "
+            "as 'serial<TAB>port' lines."
+        ),
+    )
+    p.add_argument(
+        "usb_serial",
+        nargs="?",
+        default=None,
+        help="USB serial number to look up. If omitted, list all.",
+    )
+    args = p.parse_args()
+
+    if args.usb_serial is None:
+        for device, serial in sorted(find_pico_ports().items()):
+            print(f"{serial}\t{device}")
+        return
+
+    port = resolve_port(args.usb_serial)
+    if port is None:
+        print(
+            f"No Pico with USB serial {args.usb_serial!r} found.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(port)
+
+
+if __name__ == "__main__":
+    main()

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -67,6 +67,26 @@ class TestFlashAndDiscover:
         assert len(devices) == 1
         assert devices[0]["port"] == "/dev/ttyACM0"
 
+    def test_usb_serial_filter(self, _mock_flash):
+        uf2, flashed = _mock_flash
+        devices = flash_and_discover(uf2_path=uf2, usb_serial="SER_B")
+        assert len(devices) == 1
+        assert devices[0]["usb_serial"] == "SER_B"
+        assert devices[0]["port"] == "/dev/ttyACM1"
+        assert flashed == ["SER_B"]
+
+    def test_usb_serial_no_match_returns_empty(self, _mock_flash):
+        uf2, _ = _mock_flash
+        assert flash_and_discover(uf2_path=uf2, usb_serial="MISSING") == []
+
+    def test_port_and_usb_serial_must_both_match(self, _mock_flash):
+        uf2, _ = _mock_flash
+        # SER_A is on /dev/ttyACM0, so this combination is empty
+        devices = flash_and_discover(
+            uf2_path=uf2, port="/dev/ttyACM0", usb_serial="SER_B"
+        )
+        assert devices == []
+
     def test_missing_uf2_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="UF2 file not found"):
             flash_and_discover(uf2_path=tmp_path / "nonexistent.uf2")

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -16,15 +16,17 @@ class TestBuildPicotoolCmd:
     def test_with_bus_and_address(self):
         cmd = build_picotool_cmd("foo.uf2", bus=1, address=4)
         assert cmd == [
-            "picotool", "load", "-f", "-x", "foo.uf2",
+            "picotool", "load", "-f",
             "--bus", "1", "--address", "4",
+            "-x", "foo.uf2",
         ]
 
     def test_with_usb_serial(self):
         cmd = build_picotool_cmd("foo.uf2", usb_serial="E66160F423456789")
         assert cmd == [
-            "picotool", "load", "-f", "-x", "foo.uf2",
+            "picotool", "load", "-f",
             "--ser", "E66160F423456789",
+            "-x", "foo.uf2",
         ]
 
     def test_accepts_path(self):
@@ -67,7 +69,11 @@ class TestFlashTestImage:
         monkeypatch.setattr(subprocess, "run", fake_run)
         flash_test_image(uf2, bus=2, address=7)
 
-        assert captured["cmd"][-4:] == ["--bus", "2", "--address", "7"]
+        assert captured["cmd"] == [
+            "picotool", "load", "-f",
+            "--bus", "2", "--address", "7",
+            "-x", str(uf2),
+        ]
 
     def test_passes_usb_serial(self, monkeypatch, tmp_path):
         uf2 = tmp_path / "test.uf2"
@@ -82,7 +88,11 @@ class TestFlashTestImage:
         monkeypatch.setattr(subprocess, "run", fake_run)
         flash_test_image(uf2, usb_serial="E66160F4ABCDEF01")
 
-        assert captured["cmd"][-2:] == ["--ser", "E66160F4ABCDEF01"]
+        assert captured["cmd"] == [
+            "picotool", "load", "-f",
+            "--ser", "E66160F4ABCDEF01",
+            "-x", str(uf2),
+        ]
 
     def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
         uf2 = tmp_path / "test.uf2"

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -20,6 +20,13 @@ class TestBuildPicotoolCmd:
             "--bus", "1", "--address", "4",
         ]
 
+    def test_with_usb_serial(self):
+        cmd = build_picotool_cmd("foo.uf2", usb_serial="E66160F423456789")
+        assert cmd == [
+            "picotool", "load", "-f", "-x", "foo.uf2",
+            "--ser", "E66160F423456789",
+        ]
+
     def test_accepts_path(self):
         cmd = build_picotool_cmd(Path("foo.uf2"))
         assert cmd[-1] == "foo.uf2"
@@ -61,6 +68,21 @@ class TestFlashTestImage:
         flash_test_image(uf2, bus=2, address=7)
 
         assert captured["cmd"][-4:] == ["--bus", "2", "--address", "7"]
+
+    def test_passes_usb_serial(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok\n")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        flash_test_image(uf2, usb_serial="E66160F4ABCDEF01")
+
+        assert captured["cmd"][-2:] == ["--ser", "E66160F4ABCDEF01"]
 
     def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
         uf2 = tmp_path / "test.uf2"

--- a/picohost/tests/test_resolve.py
+++ b/picohost/tests/test_resolve.py
@@ -1,0 +1,55 @@
+"""Tests for picohost.resolve."""
+
+import pytest
+
+import picohost.resolve as resolve_mod
+from picohost.resolve import main, resolve_port
+
+
+@pytest.fixture
+def _mock_ports(monkeypatch):
+    monkeypatch.setattr(
+        resolve_mod,
+        "find_pico_ports",
+        lambda: {
+            "/dev/ttyACM0": "SER_A",
+            "/dev/ttyACM1": "SER_B",
+        },
+    )
+
+
+class TestResolvePort:
+    def test_hit(self, _mock_ports):
+        assert resolve_port("SER_B") == "/dev/ttyACM1"
+
+    def test_miss(self, _mock_ports):
+        assert resolve_port("MISSING") is None
+
+    def test_no_ports(self, monkeypatch):
+        monkeypatch.setattr(resolve_mod, "find_pico_ports", lambda: {})
+        assert resolve_port("SER_A") is None
+
+
+class TestMain:
+    def test_lookup_prints_port(self, _mock_ports, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["picohost-resolve", "SER_A"])
+        main()
+        assert capsys.readouterr().out.strip() == "/dev/ttyACM0"
+
+    def test_lookup_miss_exits_nonzero(
+        self, _mock_ports, monkeypatch, capsys
+    ):
+        monkeypatch.setattr("sys.argv", ["picohost-resolve", "NOPE"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert "NOPE" in capsys.readouterr().err
+
+    def test_list_all(self, _mock_ports, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["picohost-resolve"])
+        main()
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert lines == [
+            "SER_A\t/dev/ttyACM0",
+            "SER_B\t/dev/ttyACM1",
+        ]


### PR DESCRIPTION
## Summary

- Add `--usb-serial` to `flash-test` (forwards `picotool --ser`) and `flash-picos` (filters by serial value instead of port path). The board unique ID is stable across reboots and port renumbering; `/dev/ttyACMn` and USB bus/address are not.
- Add new `picohost-resolve` CLI: maps a USB serial → current `/dev/ttyACMn`, or lists all attached CDC Picos as tab-separated `serial<TAB>port` lines.

## Why

In the field, when an app stops working, the operator knows the Pico by its role (from `devices_info.json`) but not its current port. The existing CLIs forced two different unstable identifiers (`--bus`/`--address` for BOOTSEL, `--port` for CDC). USB serial is the one identifier that survives reboots, BOOTSEL toggles, and cable moves, and `picotool --ser` accepts it in both modes.

## Field debug recipe

```bash
PORT=$(picohost-resolve E66160F4ABCDEF01)
sudo systemctl stop pico-manager
# attach to $PORT with the app's picohost class
# if the firmware is wedged pre-CDC:
flash-test --usb-serial E66160F4ABCDEF01 --uf2 build/pico_test_blink.uf2
flash-picos --usb-serial E66160F4ABCDEF01 --no-redis
```

## Test plan

- [x] `pytest tests/test_flash_test.py tests/test_flash_picos.py tests/test_resolve.py` — 24 passing (4 new flag tests + 6 new resolver tests + 14 existing).
- [x] `flash-test --help`, `flash-picos --help`, `picohost-resolve --help` render correctly.
- [x] `picohost-resolve BOGUS_SERIAL` exits 1 with a stderr message.
- [ ] Field smoke test on a real Pico cluster (operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)