### PR TITLE
fix(picohost): settle udev before opening post-flash serial port

### DIFF
--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -88,12 +88,30 @@ def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
     without ``udevadm`` (e.g. macOS).
     """
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["udevadm", "settle", f"--timeout={int(timeout)}"],
             check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout + 1,
         )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            if detail:
+                logger.warning(
+                    "udevadm settle failed with exit code %s: %s",
+                    result.returncode,
+                    detail,
+                )
+            else:
+                logger.warning(
+                    "udevadm settle failed with exit code %s",
+                    result.returncode,
+                )
     except FileNotFoundError:
         pass
+    except subprocess.TimeoutExpired:
+        logger.warning("udevadm settle timed out after %.1f seconds", timeout + 1)
 
 
 def _resolve_post_flash_port(

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -73,6 +73,27 @@ def read_json_from_serial(port, baud, timeout):
 
 _REENUMERATE_TIMEOUT_S = 10.0
 _REENUMERATE_POLL_S = 0.2
+_UDEV_SETTLE_TIMEOUT_S = 3.0
+
+
+def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
+    """Block until udev has drained its pending event queue.
+
+    After post-flash re-enumeration the new ``/dev/ttyACMn`` node is
+    created by devtmpfs with the driver-default mode before udev's
+    stock rules chgrp it to ``dialout``. ``list_ports.comports()`` sees
+    the device the instant the node exists, so opening it immediately
+    races against udev's permission pass and fails intermittently with
+    ``EACCES``. Settling here closes the window. No-op on systems
+    without ``udevadm`` (e.g. macOS).
+    """
+    try:
+        subprocess.run(
+            ["udevadm", "settle", f"--timeout={int(timeout)}"],
+            check=False,
+        )
+    except FileNotFoundError:
+        pass
 
 
 def _resolve_post_flash_port(
@@ -178,6 +199,8 @@ def flash_and_discover(
                 f"{_REENUMERATE_TIMEOUT_S}s; skipping"
             )
             continue
+
+        _udev_settle()
 
         try:
             data = read_json_from_serial(current_port, baud, timeout)

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -47,6 +47,7 @@ def _mock_flash(monkeypatch, tmp_path):
 
     # Skip the 2-second sleep
     monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+    monkeypatch.setattr(fp, "_udev_settle", lambda: None)
 
     return uf2, flashed
 
@@ -119,6 +120,7 @@ class TestFlashAndDiscover:
             ),
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
         assert flash_and_discover(uf2_path=uf2) == []
 
     def test_serial_read_failure_skips_device(self, monkeypatch, tmp_path):
@@ -142,7 +144,43 @@ class TestFlashAndDiscover:
             ),
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
         assert flash_and_discover(uf2_path=uf2) == []
+
+    def test_settles_udev_before_opening_post_flash_port(
+        self, monkeypatch, tmp_path
+    ):
+        """``udevadm settle`` must run between re-enumeration and the
+        serial open. The new ttyACM node exists with driver-default
+        permissions before udev applies the rule that chgrps it to
+        ``dialout``; opening immediately races against that and fails
+        intermittently with ``EACCES``. Settling closes the window.
+        """
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM0": "SER_A"}
+        )
+        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        events = []
+        monkeypatch.setattr(
+            fp, "_udev_settle", lambda: events.append("settle")
+        )
+
+        def fake_read(port, baud, timeout):
+            events.append(("read", port))
+            return {"app_id": 0}
+
+        monkeypatch.setattr(fp, "read_json_from_serial", fake_read)
+
+        devices = flash_and_discover(uf2_path=uf2)
+        assert len(devices) == 1
+        assert events == ["settle", ("read", "/dev/ttyACM0")]
 
     def test_resolves_current_port_after_reenumeration(
         self, monkeypatch, tmp_path
@@ -187,6 +225,7 @@ class TestFlashAndDiscover:
             lambda port, baud, timeout: serial_data[port],
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
 
         devices = flash_and_discover(uf2_path=uf2)
         by_serial = {d["usb_serial"]: d for d in devices}
@@ -230,6 +269,7 @@ class TestFlashAndDiscover:
             lambda port, baud, timeout: {"app_id": 5},
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
 
         devices = flash_and_discover(uf2_path=uf2)
         assert len(devices) == 1

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -45,7 +45,7 @@ def _mock_flash(monkeypatch, tmp_path):
         lambda port, baud, timeout: serial_data[port],
     )
 
-    # Skip the 2-second sleep
+    # Skip polling delays and udev settling in the test environment.
     monkeypatch.setattr(fp.time, "sleep", lambda _: None)
     monkeypatch.setattr(fp, "_udev_settle", lambda: None)
 


### PR DESCRIPTION
## Summary
- `flash-picos` intermittently failed with `[Errno 13] Permission denied` opening the post-flash `/dev/ttyACMn`. devtmpfs creates the node with the driver-default mode before udev's stock rules chgrp it to `dialout`, and `list_ports.comports()` returns the path the instant the node exists — so the open races against udev's permission pass.
- Call `udevadm settle --timeout=3` between `_resolve_post_flash_port` and `read_json_from_serial` to block until udev has drained pending events.
- No-op on systems without `udevadm` (e.g. macOS), so dev environments are unaffected.

## Test plan
- [x] \`pytest picohost/tests/test_flash_picos.py\` — 15 tests pass; new \`test_settles_udev_before_opening_post_flash_port\` asserts settle-then-read order.
- [ ] Run \`flash-picos\` repeatedly on the eigsep box and confirm the intermittent \`EACCES\` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)