### PR TITLE
feat(tempctrl): per-channel stall guard for stuck sensors

### DIFF
--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -611,6 +611,7 @@ class PicoPeltier(PicoDevice):
         "enabled",
         "active",
         "int_disabled",
+        "stall_tripped",
         "hysteresis",
         "clamp",
     )

--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -69,10 +69,10 @@ class TempCtrlEmulator(PicoEmulator):
         self._last_cmd_time = time.time()
 
     def server(self, cmd):
-        # Any valid command resets the watchdog timer and clears the trip flag.
-        # The host must explicitly re-enable peltiers after a trip.
+        # Any valid command refreshes the watchdog timer, but the trip flag
+        # is sticky: the host clears it by explicitly sending *_enable=true
+        # (see firmware tempctrl_apply_enable).
         self._last_cmd_time = time.time()
-        self.watchdog_tripped = False
 
         for prefix, tc in [("LNA", self.lna), ("LOAD", self.load)]:
             key = f"{prefix}_temp_target"
@@ -82,11 +82,13 @@ class TempCtrlEmulator(PicoEmulator):
             key = f"{prefix}_enable"
             if key in cmd:
                 new_enabled = bool(cmd[key])
-                # Rising edge clears the sticky stall trip — mirrors
-                # tempctrl_apply_enable() in tempctrl.c.
-                if new_enabled and not tc.enabled:
+                # *_enable=true is the host's ack of sticky trips: it clears
+                # this channel's stall flag and the app-wide watchdog flag.
+                # `enabled` is host intent only; firmware never mutates it.
+                if new_enabled:
                     tc.stall_tripped = False
                     tc.stall_window_active = False
+                    self.watchdog_tripped = False
                 tc.enabled = new_enabled
 
             key = f"{prefix}_hysteresis"
@@ -112,8 +114,16 @@ class TempCtrlEmulator(PicoEmulator):
         tc = self.lna if channel == "LNA" else self.load
         tc.internally_disabled = error
 
+    def _drive_allowed(self, tc):
+        return (
+            tc.enabled
+            and not tc.internally_disabled
+            and not tc.stall_tripped
+            and not self.watchdog_tripped
+        )
+
     def _update_channel(self, tc):
-        if tc.enabled and not tc.internally_disabled:
+        if self._drive_allowed(tc):
             tempctrl_hysteresis_drive(tc)
             if not tc.thermal_frozen:
                 tc.T_now += tc.drive * THERMAL_DRIFT_RATE
@@ -140,7 +150,6 @@ class TempCtrlEmulator(PicoEmulator):
             return
         if abs(tc.T_now - tc.stall_check_T) < STALL_MIN_DELTA:
             tc.stall_tripped = True
-            tc.enabled = False
             tc.active = False
             tc.drive = 0.0
             tc.stall_window_active = False
@@ -149,12 +158,12 @@ class TempCtrlEmulator(PicoEmulator):
             tc.stall_check_time = now
 
     def op(self):
-        # Communication watchdog: disable peltiers if no command within timeout
+        # Communication watchdog: trip the app-wide flag if no command has
+        # arrived within the timeout. `enabled` is host intent and stays
+        # untouched; the trip flag is the runtime gate.
         if self.watchdog_timeout_ms > 0 and not self.watchdog_tripped:
             elapsed_ms = (time.time() - self._last_cmd_time) * 1000
             if elapsed_ms > self.watchdog_timeout_ms:
-                self.lna.enabled = False
-                self.load.enabled = False
                 self.watchdog_tripped = True
 
         self._update_channel(self.lna)

--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -18,6 +18,14 @@ class TempControlState:
         self.active = False
         self.internally_disabled = False
         self.timestamp = 0.0
+        # Stall guard mirror (see tempctrl_check_stall in tempctrl.c).
+        self.stall_tripped = False
+        self.stall_window_active = False
+        self.stall_check_T = 0.0
+        self.stall_check_time = 0.0
+        # Test hook: when True, skip the thermal-drift update even with the
+        # drive engaged, so the stall guard can be exercised deterministically.
+        self.thermal_frozen = False
 
 
 def tempctrl_hysteresis_drive(tc):
@@ -36,6 +44,10 @@ def tempctrl_hysteresis_drive(tc):
 
 
 THERMAL_DRIFT_RATE = 0.05
+
+# Mirrors TEMPCTRL_STALL_WINDOW_MS / TEMPCTRL_STALL_MIN_DELTA in tempctrl.h.
+STALL_WINDOW_MS = 60000
+STALL_MIN_DELTA = 0.5
 
 
 class TempCtrlEmulator(PicoEmulator):
@@ -69,7 +81,13 @@ class TempCtrlEmulator(PicoEmulator):
 
             key = f"{prefix}_enable"
             if key in cmd:
-                tc.enabled = bool(cmd[key])
+                new_enabled = bool(cmd[key])
+                # Rising edge clears the sticky stall trip — mirrors
+                # tempctrl_apply_enable() in tempctrl.c.
+                if new_enabled and not tc.enabled:
+                    tc.stall_tripped = False
+                    tc.stall_window_active = False
+                tc.enabled = new_enabled
 
             key = f"{prefix}_hysteresis"
             if key in cmd:
@@ -97,10 +115,37 @@ class TempCtrlEmulator(PicoEmulator):
     def _update_channel(self, tc):
         if tc.enabled and not tc.internally_disabled:
             tempctrl_hysteresis_drive(tc)
-            tc.T_now += tc.drive * THERMAL_DRIFT_RATE
+            if not tc.thermal_frozen:
+                tc.T_now += tc.drive * THERMAL_DRIFT_RATE
+            self._check_stall(tc)
         else:
             tc.drive = 0.0
+            tc.stall_window_active = False
         tc.timestamp = time.time()
+
+    def _check_stall(self, tc):
+        """Mirror tempctrl_check_stall() from tempctrl.c."""
+        if not tc.active:
+            tc.stall_window_active = False
+            return
+        now = time.time()
+        if not tc.stall_window_active:
+            tc.stall_check_T = tc.T_now
+            tc.stall_check_time = now
+            tc.stall_window_active = True
+            return
+        elapsed_ms = (now - tc.stall_check_time) * 1000
+        if elapsed_ms < STALL_WINDOW_MS:
+            return
+        if abs(tc.T_now - tc.stall_check_T) < STALL_MIN_DELTA:
+            tc.stall_tripped = True
+            tc.enabled = False
+            tc.active = False
+            tc.drive = 0.0
+            tc.stall_window_active = False
+        else:
+            tc.stall_check_T = tc.T_now
+            tc.stall_check_time = now
 
     def op(self):
         # Communication watchdog: disable peltiers if no command within timeout
@@ -130,6 +175,7 @@ class TempCtrlEmulator(PicoEmulator):
             "LNA_enabled": self.lna.enabled,
             "LNA_active": self.lna.active,
             "LNA_int_disabled": self.lna.internally_disabled,
+            "LNA_stall_tripped": self.lna.stall_tripped,
             "LNA_hysteresis": self.lna.hysteresis,
             "LNA_clamp": self.lna.clamp,
             "LOAD_status": load_status,
@@ -140,6 +186,7 @@ class TempCtrlEmulator(PicoEmulator):
             "LOAD_enabled": self.load.enabled,
             "LOAD_active": self.load.active,
             "LOAD_int_disabled": self.load.internally_disabled,
+            "LOAD_stall_tripped": self.load.stall_tripped,
             "LOAD_hysteresis": self.load.hysteresis,
             "LOAD_clamp": self.load.clamp,
         }

--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -120,6 +120,7 @@ class TempCtrlEmulator(PicoEmulator):
             self._check_stall(tc)
         else:
             tc.drive = 0.0
+            tc.active = False
             tc.stall_window_active = False
         tc.timestamp = time.time()
 

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -788,6 +788,7 @@ class TestPicoPeltierRedisHandler:
         "LNA_enabled": True,
         "LNA_active": True,
         "LNA_int_disabled": False,
+        "LNA_stall_tripped": False,
         "LNA_hysteresis": 0.5,
         "LNA_clamp": 0.8,
         "LOAD_status": "error",
@@ -798,6 +799,7 @@ class TestPicoPeltierRedisHandler:
         "LOAD_enabled": True,
         "LOAD_active": False,
         "LOAD_int_disabled": True,
+        "LOAD_stall_tripped": False,
         "LOAD_hysteresis": 0.5,
         "LOAD_clamp": 0.8,
     }
@@ -815,6 +817,7 @@ class TestPicoPeltierRedisHandler:
         "enabled",
         "active",
         "int_disabled",
+        "stall_tripped",
         "hysteresis",
         "clamp",
     }

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -45,6 +45,7 @@ TEMPCTRL_FIELDS = {
     "LNA_enabled",
     "LNA_active",
     "LNA_int_disabled",
+    "LNA_stall_tripped",
     "LNA_hysteresis",
     "LNA_clamp",
     "LOAD_status",
@@ -55,6 +56,7 @@ TEMPCTRL_FIELDS = {
     "LOAD_enabled",
     "LOAD_active",
     "LOAD_int_disabled",
+    "LOAD_stall_tripped",
     "LOAD_hysteresis",
     "LOAD_clamp",
 }

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -425,7 +425,7 @@ class TestPeltierWatchdog:
             p.disconnect()
 
     def test_watchdog_trips_without_keepalive(self):
-        """Without keepalive, the watchdog trips and disables peltiers."""
+        """Without keepalive, the watchdog trip flag gates drive off."""
         p = DummyPicoPeltier("/dev/dummy", keepalive_interval=0)
         try:
             cadence = p.EMULATOR_CADENCE_MS

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -205,6 +205,7 @@ class TestTempCtrlEmulator:
             "LNA_enabled",
             "LNA_active",
             "LNA_int_disabled",
+            "LNA_stall_tripped",
             "LNA_hysteresis",
             "LNA_clamp",
             "LOAD_status",
@@ -215,6 +216,7 @@ class TestTempCtrlEmulator:
             "LOAD_enabled",
             "LOAD_active",
             "LOAD_int_disabled",
+            "LOAD_stall_tripped",
             "LOAD_hysteresis",
             "LOAD_clamp",
         }
@@ -267,6 +269,94 @@ class TestTempCtrlWatchdog:
         emu._last_cmd_time = time.time() - 999
         emu.op()
         assert emu.watchdog_tripped is False
+        assert emu.lna.enabled is True
+
+
+class TestTempCtrlStallGuard:
+    """The stall guard trips when drive is engaged but T_now refuses to move."""
+
+    def _force_window_elapsed(self, tc):
+        # Pretend the stall window opened before the threshold.
+        import picohost.emulators.tempctrl as mod
+
+        tc.stall_check_time = time.time() - (mod.STALL_WINDOW_MS / 1000 + 1)
+
+    def test_stall_trip_disables_channel(self):
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
+        emu.op()  # opens the stall window with active=True
+        assert emu.lna.active is True
+        assert emu.lna.stall_window_active is True
+        self._force_window_elapsed(emu.lna)
+        emu.op()
+        assert emu.lna.stall_tripped is True
+        assert emu.lna.enabled is False
+        assert emu.lna.drive == 0.0
+
+    def test_stall_does_not_trip_when_temperature_moves(self):
+        """Healthy drive rolls the window forward without tripping."""
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
+        emu.op()
+        self._force_window_elapsed(emu.lna)
+        emu.lna.T_now += 1.0  # well above STALL_MIN_DELTA
+        emu.op()
+        assert emu.lna.stall_tripped is False
+        assert emu.lna.enabled is True
+
+    def test_stall_does_not_trip_inside_hysteresis_band(self):
+        """active=False (within hysteresis band) means no stall window runs."""
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 30.0
+        emu.lna.thermal_frozen = True
+        emu.server(
+            {"LNA_temp_target": 30.0, "LNA_enable": True, "LNA_hysteresis": 0.5}
+        )
+        emu.op()
+        assert emu.lna.active is False
+        assert emu.lna.stall_window_active is False
+        self._force_window_elapsed(emu.lna)
+        emu.op()
+        assert emu.lna.stall_tripped is False
+
+    def test_re_enable_clears_stall_trip(self):
+        """Rising edge of enable acknowledges the trip and resets the window."""
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
+        emu.op()
+        self._force_window_elapsed(emu.lna)
+        emu.op()
+        assert emu.lna.stall_tripped is True
+        assert emu.lna.enabled is False
+        emu.server({"LNA_enable": True})
+        assert emu.lna.stall_tripped is False
+        assert emu.lna.enabled is True
+
+    def test_channels_trip_independently(self):
+        """A stalled LOAD does not knock out a healthy LNA."""
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.load.T_now = 25.0
+        emu.load.thermal_frozen = True
+        emu.server(
+            {
+                "LNA_temp_target": 30.0,
+                "LNA_enable": True,
+                "LOAD_temp_target": 30.0,
+                "LOAD_enable": True,
+            }
+        )
+        emu.op()
+        self._force_window_elapsed(emu.load)
+        emu.op()
+        assert emu.load.stall_tripped is True
+        assert emu.load.enabled is False
+        assert emu.lna.stall_tripped is False
         assert emu.lna.enabled is True
 
 

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -225,7 +225,11 @@ class TestTempCtrlEmulator:
 
 class TestTempCtrlWatchdog:
     def test_watchdog_trips_after_timeout(self):
-        """Watchdog disables peltiers when no command arrives within timeout."""
+        """Watchdog flag trips when no command arrives within timeout.
+
+        `enabled` is host intent and stays untouched; the trip flag is the
+        runtime gate that zeroes drive.
+        """
         emu = TempCtrlEmulator()
         emu.server({"LNA_enable": True, "LOAD_enable": True})
         assert emu.lna.enabled is True
@@ -234,19 +238,45 @@ class TestTempCtrlWatchdog:
         emu._last_cmd_time = time.time() - (emu.watchdog_timeout_ms / 1000 + 1)
         emu.op()
         assert emu.watchdog_tripped is True
-        assert emu.lna.enabled is False
-        assert emu.load.enabled is False
+        # Host intent is preserved.
+        assert emu.lna.enabled is True
+        assert emu.load.enabled is True
+        # Trip gates drive to zero on both channels.
+        assert emu.lna.drive == 0.0
+        assert emu.load.drive == 0.0
 
-    def test_server_resets_watchdog(self):
-        """Any command resets the watchdog timer and clears the trip flag."""
+    def test_keepalive_does_not_clear_watchdog_trip(self):
+        """A bare keepalive refreshes the timer but the trip flag is sticky."""
         emu = TempCtrlEmulator()
         # Trip the watchdog
         emu._last_cmd_time = time.time() - (emu.watchdog_timeout_ms / 1000 + 1)
         emu.op()
         assert emu.watchdog_tripped is True
-        # Any command clears the trip
+        # A non-enable command (e.g. keepalive) must not silently re-engage
+        # the peltiers — the host has to explicitly ack with *_enable=true.
+        emu.server({})
+        assert emu.watchdog_tripped is True
+        emu.server({"LNA_temp_target": 28.0})
+        assert emu.watchdog_tripped is True
+
+    def test_enable_true_clears_watchdog_trip(self):
+        """*_enable=true is the explicit ack that clears the watchdog flag."""
+        emu = TempCtrlEmulator()
+        emu._last_cmd_time = time.time() - (emu.watchdog_timeout_ms / 1000 + 1)
+        emu.op()
+        assert emu.watchdog_tripped is True
         emu.server({"LNA_enable": True})
         assert emu.watchdog_tripped is False
+
+    def test_enable_false_does_not_clear_watchdog_trip(self):
+        """Disabling a channel is not an ack — trip stays sticky."""
+        emu = TempCtrlEmulator()
+        emu.server({"LNA_enable": True})
+        emu._last_cmd_time = time.time() - (emu.watchdog_timeout_ms / 1000 + 1)
+        emu.op()
+        assert emu.watchdog_tripped is True
+        emu.server({"LNA_enable": False})
+        assert emu.watchdog_tripped is True
 
     def test_watchdog_does_not_trip_before_timeout(self):
         """Watchdog stays clear while commands arrive within timeout."""
@@ -281,7 +311,8 @@ class TestTempCtrlStallGuard:
 
         tc.stall_check_time = time.time() - (mod.STALL_WINDOW_MS / 1000 + 1)
 
-    def test_stall_trip_disables_channel(self):
+    def test_stall_trip_gates_drive(self):
+        """Stall trip zeroes drive while leaving host-intent `enabled` alone."""
         emu = TempCtrlEmulator()
         emu.lna.T_now = 25.0
         emu.lna.thermal_frozen = True
@@ -292,7 +323,11 @@ class TestTempCtrlStallGuard:
         self._force_window_elapsed(emu.lna)
         emu.op()
         assert emu.lna.stall_tripped is True
-        assert emu.lna.enabled is False
+        # Host intent preserved; trip flag is the runtime gate.
+        assert emu.lna.enabled is True
+        assert emu.lna.drive == 0.0
+        # Subsequent ops keep drive at zero — the gate stays closed.
+        emu.op()
         assert emu.lna.drive == 0.0
 
     def test_stall_does_not_trip_when_temperature_moves(self):
@@ -322,8 +357,8 @@ class TestTempCtrlStallGuard:
         emu.op()
         assert emu.lna.stall_tripped is False
 
-    def test_re_enable_clears_stall_trip(self):
-        """Rising edge of enable acknowledges the trip and resets the window."""
+    def test_enable_true_clears_stall_trip(self):
+        """An explicit *_enable=true is the host's ack of a stall trip."""
         emu = TempCtrlEmulator()
         emu.lna.T_now = 25.0
         emu.lna.thermal_frozen = True
@@ -332,10 +367,23 @@ class TestTempCtrlStallGuard:
         self._force_window_elapsed(emu.lna)
         emu.op()
         assert emu.lna.stall_tripped is True
-        assert emu.lna.enabled is False
+        assert emu.lna.enabled is True
         emu.server({"LNA_enable": True})
         assert emu.lna.stall_tripped is False
         assert emu.lna.enabled is True
+
+    def test_non_enable_command_does_not_clear_stall_trip(self):
+        """Setting a new temp target must not silently clear a stall trip."""
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
+        emu.op()
+        self._force_window_elapsed(emu.lna)
+        emu.op()
+        assert emu.lna.stall_tripped is True
+        emu.server({"LNA_temp_target": 28.0})
+        assert emu.lna.stall_tripped is True
 
     def test_channels_trip_independently(self):
         """A stalled LOAD does not knock out a healthy LNA."""
@@ -355,7 +403,10 @@ class TestTempCtrlStallGuard:
         self._force_window_elapsed(emu.load)
         emu.op()
         assert emu.load.stall_tripped is True
-        assert emu.load.enabled is False
+        # Host intent unchanged on the tripped channel.
+        assert emu.load.enabled is True
+        assert emu.load.drive == 0.0
+        # LNA is unaffected.
         assert emu.lna.stall_tripped is False
         assert emu.lna.enabled is True
 

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -25,6 +25,7 @@ static void tempctrl_drive_raw(TempControl *);
 static void tempctrl_hysteresis_drive(TempControl *);
 static void tempctrl_check_stall(TempControl *);
 static void tempctrl_apply_enable(TempControl *, bool);
+static bool tempctrl_drive_allowed(const TempControl *);
 
 void init_single_tempctrl(TempControl *tempctrl,
                           uint dir_pin1, uint dir_pin2, uint pwm_pin,
@@ -81,10 +82,12 @@ void tempctrl_server(uint8_t app_id, const char *json_str) {
         return;
     }
 
-    // Any valid command resets the watchdog timer and clears the trip flag.
-    // The host must explicitly re-enable peltiers after a trip.
+    // Any valid command refreshes the watchdog timer, but the trip flag
+    // is sticky: a keepalive that arrives after the timeout already fired
+    // must not silently re-engage the peltiers. The host clears
+    // watchdog_tripped by explicitly sending *_enable=true (see
+    // tempctrl_apply_enable), mirroring the stall-trip ack pattern.
     last_cmd_time = get_absolute_time();
-    watchdog_tripped = false;
 
     // Parse channel selection (default to both)
     item_json = cJSON_GetObjectItem(root, "LNA_temp_target");
@@ -170,7 +173,7 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
     // Handle sensor 1 error or drive Peltiers based on hysteresis control
     tempctrl->internally_disabled = temp_sensor_has_error(&tempctrl->temp_sensor) ? true : false;
 
-    if (tempctrl->enabled && !tempctrl->internally_disabled) {
+    if (tempctrl_drive_allowed(tempctrl)) {
         tempctrl_hysteresis_drive(tempctrl);
         tempctrl_check_stall(tempctrl);
     } else {
@@ -183,12 +186,13 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
 }
 
 void tempctrl_op(uint8_t app_id) {
-    // Communication watchdog: disable peltiers if no command received within timeout
+    // Communication watchdog: trip the (app-wide) flag if no command has
+    // arrived within the timeout. The flag is the runtime gate — `enabled`
+    // is host intent and stays untouched, so the host can see exactly which
+    // channels it had asked for vs. which are blocked by the trip.
     if (watchdog_timeout_ms > 0 && !watchdog_tripped) {
         int64_t elapsed_us = absolute_time_diff_us(last_cmd_time, get_absolute_time());
         if (elapsed_us > (int64_t)watchdog_timeout_ms * 1000) {
-            tempctrl_lna.enabled = false;
-            tempctrl_load.enabled = false;
             watchdog_tripped = true;
         }
     }
@@ -255,10 +259,11 @@ static void tempctrl_check_stall(TempControl *tempctrl) {
     }
     if (fabsf(tempctrl->T_now - tempctrl->stall_check_T) < TEMPCTRL_STALL_MIN_DELTA) {
         // Drive engaged for a full window with no meaningful temperature
-        // movement — sensor stuck or Peltier ineffective. Trip the channel
-        // and force the host to acknowledge by re-enabling it.
+        // movement — sensor stuck or Peltier ineffective. Trip the channel;
+        // `enabled` stays as the host set it, and the trip flag is the
+        // runtime gate. Host clears it via *_enable=true (see
+        // tempctrl_apply_enable).
         tempctrl->stall_tripped = true;
-        tempctrl->enabled = false;
         tempctrl->active = false;
         tempctrl->drive = 0.0;
         tempctrl_drive_raw(tempctrl);
@@ -271,11 +276,23 @@ static void tempctrl_check_stall(TempControl *tempctrl) {
 }
 
 static void tempctrl_apply_enable(TempControl *tempctrl, bool new_enabled) {
-    // Rising edge clears a sticky stall trip — the operator has acknowledged
-    // the fault by explicitly re-enabling the channel.
-    if (new_enabled && !tempctrl->enabled) {
+    // *_enable=true is the host's explicit ack of sticky trips: it clears
+    // this channel's stall flag and the app-wide watchdog flag. `enabled`
+    // itself is pure host intent — firmware never mutates it, so the host
+    // can always tell from status whether a channel is off because it was
+    // asked off (`enabled=false`) or because a trip is gating it
+    // (`enabled=true` with a trip flag set).
+    if (new_enabled) {
         tempctrl->stall_tripped = false;
         tempctrl->stall_window_active = false;
+        watchdog_tripped = false;
     }
     tempctrl->enabled = new_enabled;
+}
+
+static bool tempctrl_drive_allowed(const TempControl *tempctrl) {
+    return tempctrl->enabled
+        && !tempctrl->internally_disabled
+        && !tempctrl->stall_tripped
+        && !watchdog_tripped;
 }

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -23,6 +23,8 @@ static void init_single_tempctrl(TempControl *, uint, uint, uint, pwm_config *, 
 static void tempctrl_update_sensor_drive(TempControl *);
 static void tempctrl_drive_raw(TempControl *);
 static void tempctrl_hysteresis_drive(TempControl *);
+static void tempctrl_check_stall(TempControl *);
+static void tempctrl_apply_enable(TempControl *, bool);
 
 void init_single_tempctrl(TempControl *tempctrl,
                           uint dir_pin1, uint dir_pin2, uint pwm_pin,
@@ -54,6 +56,10 @@ void init_single_tempctrl(TempControl *tempctrl,
     tempctrl->internally_disabled = false;
     tempctrl->T_now = 0;
     tempctrl->drive = 0.0;
+    tempctrl->stall_tripped = false;
+    tempctrl->stall_window_active = false;
+    tempctrl->stall_check_T = 0.0;
+    tempctrl->stall_check_time = get_absolute_time();
 }
 
 void tempctrl_init(uint8_t app_id) {
@@ -84,7 +90,7 @@ void tempctrl_server(uint8_t app_id, const char *json_str) {
     item_json = cJSON_GetObjectItem(root, "LNA_temp_target");
     tempctrl_lna.T_target = item_json ? item_json->valuedouble : tempctrl_lna.T_target;
     item_json = cJSON_GetObjectItem(root, "LNA_enable");
-    if (item_json) tempctrl_lna.enabled = item_json->valueint ? true : false;
+    if (item_json) tempctrl_apply_enable(&tempctrl_lna, item_json->valueint ? true : false);
     item_json = cJSON_GetObjectItem(root, "LNA_hysteresis");
     tempctrl_lna.hysteresis = item_json ? item_json->valuedouble : tempctrl_lna.hysteresis;
     item_json = cJSON_GetObjectItem(root, "LNA_clamp");
@@ -92,7 +98,7 @@ void tempctrl_server(uint8_t app_id, const char *json_str) {
     item_json = cJSON_GetObjectItem(root, "LOAD_temp_target");
     tempctrl_load.T_target = item_json ? item_json->valuedouble : tempctrl_load.T_target;
     item_json = cJSON_GetObjectItem(root, "LOAD_enable");
-    if (item_json) tempctrl_load.enabled = item_json->valueint ? true : false;
+    if (item_json) tempctrl_apply_enable(&tempctrl_load, item_json->valueint ? true : false);
     item_json = cJSON_GetObjectItem(root, "LOAD_hysteresis");
     tempctrl_load.hysteresis = item_json ? item_json->valuedouble : tempctrl_load.hysteresis;
     item_json = cJSON_GetObjectItem(root, "LOAD_clamp");
@@ -119,7 +125,7 @@ void tempctrl_status(uint8_t app_id) {
     const char *status_lna = temp_sensor_has_error(&tempctrl_lna.temp_sensor) ? "error" : "update";
     const char *status_load = temp_sensor_has_error(&tempctrl_load.temp_sensor) ? "error" : "update";
 
-    send_json(24,
+    send_json(26,
         KV_STR, "sensor_name", "tempctrl",
         KV_INT, "app_id", app_id,
         KV_BOOL, "watchdog_tripped", watchdog_tripped,
@@ -132,6 +138,7 @@ void tempctrl_status(uint8_t app_id) {
         KV_BOOL, "LNA_enabled", tempctrl_lna.enabled,
         KV_BOOL, "LNA_active", tempctrl_lna.active,
         KV_BOOL, "LNA_int_disabled", tempctrl_lna.internally_disabled,
+        KV_BOOL, "LNA_stall_tripped", tempctrl_lna.stall_tripped,
         KV_FLOAT, "LNA_hysteresis", tempctrl_lna.hysteresis,
         KV_FLOAT, "LNA_clamp", tempctrl_lna.clamp,
         KV_STR, "LOAD_status", status_load,
@@ -142,6 +149,7 @@ void tempctrl_status(uint8_t app_id) {
         KV_BOOL, "LOAD_enabled", tempctrl_load.enabled,
         KV_BOOL, "LOAD_active", tempctrl_load.active,
         KV_BOOL, "LOAD_int_disabled", tempctrl_load.internally_disabled,
+        KV_BOOL, "LOAD_stall_tripped", tempctrl_load.stall_tripped,
         KV_FLOAT, "LOAD_hysteresis", tempctrl_load.hysteresis,
         KV_FLOAT, "LOAD_clamp", tempctrl_load.clamp
     );
@@ -164,9 +172,12 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
 
     if (tempctrl->enabled && !tempctrl->internally_disabled) {
         tempctrl_hysteresis_drive(tempctrl);
+        tempctrl_check_stall(tempctrl);
     } else {
         tempctrl->drive = 0.0;
         tempctrl_drive_raw(tempctrl);
+        // Not actively driving — no stall window pending.
+        tempctrl->stall_window_active = false;
     }
 }
 
@@ -205,7 +216,7 @@ static void tempctrl_drive_raw(TempControl *tempctrl) {
 static void tempctrl_hysteresis_drive(TempControl *tempctrl) {
     float T_delta = tempctrl->T_target - tempctrl->T_now;
     int sign = (T_delta >= 0) ? 1 : -1;
-    
+
     if (fabsf(T_delta) <= tempctrl->hysteresis) {
         // Within hysteresis band - turn off
         tempctrl->drive = 0.0;
@@ -221,4 +232,49 @@ static void tempctrl_hysteresis_drive(TempControl *tempctrl) {
         }
     }
     tempctrl_drive_raw(tempctrl);
+}
+
+static void tempctrl_check_stall(TempControl *tempctrl) {
+    // Only check while we're actively driving — in the hysteresis band the
+    // Peltier is off and T_now can legitimately sit nearly still.
+    if (!tempctrl->active) {
+        tempctrl->stall_window_active = false;
+        return;
+    }
+    absolute_time_t now = get_absolute_time();
+    if (!tempctrl->stall_window_active) {
+        tempctrl->stall_check_T = tempctrl->T_now;
+        tempctrl->stall_check_time = now;
+        tempctrl->stall_window_active = true;
+        return;
+    }
+    int64_t elapsed_us = absolute_time_diff_us(tempctrl->stall_check_time, now);
+    if (elapsed_us < (int64_t)TEMPCTRL_STALL_WINDOW_MS * 1000) {
+        return;
+    }
+    if (fabsf(tempctrl->T_now - tempctrl->stall_check_T) < TEMPCTRL_STALL_MIN_DELTA) {
+        // Drive engaged for a full window with no meaningful temperature
+        // movement — sensor stuck or Peltier ineffective. Trip the channel
+        // and force the host to acknowledge by re-enabling it.
+        tempctrl->stall_tripped = true;
+        tempctrl->enabled = false;
+        tempctrl->active = false;
+        tempctrl->drive = 0.0;
+        tempctrl_drive_raw(tempctrl);
+        tempctrl->stall_window_active = false;
+    } else {
+        // Healthy: roll the window forward.
+        tempctrl->stall_check_T = tempctrl->T_now;
+        tempctrl->stall_check_time = now;
+    }
+}
+
+static void tempctrl_apply_enable(TempControl *tempctrl, bool new_enabled) {
+    // Rising edge clears a sticky stall trip — the operator has acknowledged
+    // the fault by explicitly re-enabling the channel.
+    if (new_enabled && !tempctrl->enabled) {
+        tempctrl->stall_tripped = false;
+        tempctrl->stall_window_active = false;
+    }
+    tempctrl->enabled = new_enabled;
 }

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -175,6 +175,7 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
         tempctrl_check_stall(tempctrl);
     } else {
         tempctrl->drive = 0.0;
+        tempctrl->active = false;
         tempctrl_drive_raw(tempctrl);
         // Not actively driving — no stall window pending.
         tempctrl->stall_window_active = false;

--- a/src/tempctrl.h
+++ b/src/tempctrl.h
@@ -49,11 +49,15 @@ typedef struct {
     float hysteresis;
     float clamp;
     bool active;
+    // `enabled` is host intent only — firmware never mutates it. A channel
+    // drives only when enabled && none of the trip flags below are set; the
+    // host distinguishes "asked off" from "blocked by trip" by reading
+    // enabled together with the trip flags.
     bool enabled;
-    bool internally_disabled;
+    bool internally_disabled;  // sensor read error (auto-derived each cycle)
     // Stall guard: sticky fault tripped when an active drive fails to move
-    // T_now. Cleared on the rising edge of `enabled` (host must explicitly
-    // re-enable, mirroring the watchdog pattern).
+    // T_now. Cleared by an explicit *_enable=true command from the host
+    // (mirrors the watchdog ack pattern).
     bool stall_tripped;
     bool stall_window_active;
     float stall_check_T;

--- a/src/tempctrl.h
+++ b/src/tempctrl.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
+#include "pico/time.h"
 #include "hardware/gpio.h"
 #include "eigsep_command.h"
 #include "temp_simple.h"
@@ -23,6 +24,16 @@
 // PWM configuration
 #define PWM_WRAP            1000
 
+// Stall detection: if the channel is actively driving (drive!=0) but T_now
+// fails to move by at least TEMPCTRL_STALL_MIN_DELTA over a
+// TEMPCTRL_STALL_WINDOW_MS window, the sensor or Peltier is stuck and we
+// trip the channel. The threshold is far above the DS18B20 quantization
+// (1/16 = 0.0625 C) and a healthy half-power Peltier moves the load
+// several C/min, so a healthy run rolls the window forward long before
+// reaching the trip threshold.
+#define TEMPCTRL_STALL_WINDOW_MS   60000
+#define TEMPCTRL_STALL_MIN_DELTA   0.5f
+
 // Temperature control structure
 typedef struct {
     uint dir_pin1;
@@ -40,6 +51,13 @@ typedef struct {
     bool active;
     bool enabled;
     bool internally_disabled;
+    // Stall guard: sticky fault tripped when an active drive fails to move
+    // T_now. Cleared on the rising edge of `enabled` (host must explicitly
+    // re-enable, mirroring the watchdog pattern).
+    bool stall_tripped;
+    bool stall_window_active;
+    float stall_check_T;
+    absolute_time_t stall_check_time;
 } TempControl;
 
 // Standard app interface functions


### PR DESCRIPTION
## Summary
- **Stall guard:** trip the channel if drive is engaged for 60 s without `T_now` moving ≥ 0.5 °C — catches valid-but-stuck DS18B20 readings (e.g. a literal 0.00 °C) that the existing `read_error` / `internally_disabled` path can't see.
- **Decouple `enabled` from firmware state:** firmware no longer mutates `enabled`; it reflects only what the host asked for. The runtime gate is now `enabled && !internally_disabled && !stall_tripped && !watchdog_tripped` (centralized in `tempctrl_drive_allowed`). Host can now tell "asked off" from "blocked by trip" purely from status.
- **Sticky trip ack:** both `stall_tripped` and `watchdog_tripped` are cleared by the same explicit ack — a `*_enable=true` command from the host. **Behavior change:** a bare keepalive refreshes the watchdog timer but no longer clears an already-fired trip (previously any command silently cleared it).
- New per-channel `LNA_stall_tripped` / `LOAD_stall_tripped` fields in the status frame; `PicoPeltier._peltier_redis_handler` fans them into the per-stream Redis output.
- Schema bump on the eigsep_observing side is needed for the new field — see companion draft PR.

## Test plan
- [x] Firmware builds clean (no warnings)
- [x] Full picohost pytest suite passes (351 tests)
- [x] `TestTempCtrlStallGuard` covers: trip-gates-drive, healthy-roll, hysteresis-silence, enable-true ack, non-enable command does not ack, channel independence
- [x] `TestTempCtrlWatchdog` covers the new sticky semantics: keepalive does not clear trip, `*_enable=true` clears, `*_enable=false` does not clear
- [ ] Bench test: stall channel by disconnecting one DS18B20, confirm trip + clean re-enable on a real Pico
- [ ] Bench test: confirm keepalive no longer silently re-engages peltiers after a watchdog trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)