### PR TITLE
feat(flash_test): auto-discover all BOOTSEL Picos by default

### DIFF
--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -1,17 +1,67 @@
 #!/usr/bin/env python3
-"""`flash-test`: load the heartbeat test UF2 onto a Pico in BOOTSEL mode.
+"""`flash-test`: load the heartbeat test UF2 onto Pico(s) in BOOTSEL mode.
 
 `flash-picos` discovers Picos by enumerating CDC serial ports, which
 means a fresh / wiped Pico (USB PID 0x0003, mass-storage) is invisible
-to it. This CLI is a thin wrapper around ``picotool load`` that targets
-a BOOTSEL-mode Pico directly, so the test image can be installed,
-USB-CDC comes up, and the normal ``flash-picos`` workflow becomes
-available.
+to it. This CLI wraps ``picotool load`` to target BOOTSEL-mode Picos so
+the test image can be installed, USB-CDC comes up, and the normal
+``flash-picos`` workflow becomes available.
+
+By default all connected BOOTSEL Picos are flashed sequentially (mirroring
+``flash-picos``). Pass ``--bus/--address`` or ``--usb-serial`` to target
+a single device.
 """
 import argparse
 import subprocess
 import sys
 from pathlib import Path
+
+PICO_VID = "2e8a"
+PICO_PID_BOOTSEL = "0003"
+SYSFS_USB_DEVICES = Path("/sys/bus/usb/devices")
+
+
+def find_bootsel_devices(sysfs_root=None):
+    """Enumerate Picos currently in BOOTSEL mode by scanning Linux sysfs.
+
+    Returns a list of ``{"usb_serial", "bus", "address"}`` dicts, one per
+    attached Pico with VID:PID 2e8a:0003. BOOTSEL Picos are USB
+    mass-storage devices and don't appear in pyserial's port list, so
+    sysfs is the cheapest discovery path that avoids parsing picotool's
+    free-form output or pulling in libusb bindings.
+
+    Returns an empty list on systems without ``/sys/bus/usb/devices``
+    (e.g. macOS); the caller should fall back to ``picotool``'s default
+    selection.
+    """
+    if sysfs_root is None:
+        sysfs_root = SYSFS_USB_DEVICES
+    sysfs_root = Path(sysfs_root)
+    devices = []
+    if not sysfs_root.is_dir():
+        return devices
+    for entry in sorted(sysfs_root.iterdir()):
+        try:
+            vid = (entry / "idVendor").read_text().strip().lower()
+            pid = (entry / "idProduct").read_text().strip().lower()
+        except (OSError, ValueError):
+            continue
+        if vid != PICO_VID or pid != PICO_PID_BOOTSEL:
+            continue
+        try:
+            serial = (entry / "serial").read_text().strip() or None
+        except OSError:
+            serial = None
+        try:
+            bus = int((entry / "busnum").read_text().strip())
+            address = int((entry / "devnum").read_text().strip())
+        except (OSError, ValueError):
+            bus = None
+            address = None
+        devices.append(
+            {"usb_serial": serial, "bus": bus, "address": address}
+        )
+    return devices
 
 
 def build_picotool_cmd(uf2_path, bus=None, address=None, usb_serial=None):
@@ -75,11 +125,19 @@ def flash_test_image(uf2_path, bus=None, address=None, usb_serial=None):
         print(output, end="")
 
 
+_DONE_MSG = (
+    "\nFlash complete. Picos should now blink in a heartbeat pattern "
+    "and enumerate as /dev/ttyACM* (USB VID:PID 2e8a:0009).\nRun "
+    "`flash-picos --uf2 build/pico_multi.uf2` to install the "
+    "production image."
+)
+
+
 def main():
     p = argparse.ArgumentParser(
         description=(
-            "Flash a small heartbeat-LED test image onto a Pico in "
-            "BOOTSEL mode. After this, the Pico enumerates as USB-CDC "
+            "Flash a small heartbeat-LED test image onto every Pico in "
+            "BOOTSEL mode. After this, each Pico enumerates as USB-CDC "
             "and can be re-flashed with the production image using "
             "`flash-picos`."
         ),
@@ -95,8 +153,8 @@ def main():
         type=int,
         default=None,
         help=(
-            "USB bus number of the target Pico. Use only when more "
-            "than one BOOTSEL device is connected."
+            "USB bus number of a single target Pico. Skips auto-discovery; "
+            "use only to override which BOOTSEL device gets flashed."
         ),
     )
     p.add_argument(
@@ -109,20 +167,56 @@ def main():
         "--usb-serial",
         default=None,
         help=(
-            "Pico board unique ID (flash serial). Preferred over "
-            "--bus/--address: stable across reboots and BOOTSEL toggles. "
-            "Discover with `picotool info -a`."
+            "Pico board unique ID. Skips auto-discovery and flashes only "
+            "this device. Discover with `picotool info -a`."
         ),
     )
     args = p.parse_args()
 
+    targeted = (
+        args.bus is not None
+        or args.address is not None
+        or args.usb_serial is not None
+    )
+
     try:
-        flash_test_image(
-            args.uf2,
-            bus=args.bus,
-            address=args.address,
-            usb_serial=args.usb_serial,
-        )
+        if targeted or not SYSFS_USB_DEVICES.is_dir():
+            flash_test_image(
+                args.uf2,
+                bus=args.bus,
+                address=args.address,
+                usb_serial=args.usb_serial,
+            )
+        else:
+            devices = find_bootsel_devices()
+            if not devices:
+                print(
+                    "No Picos in BOOTSEL mode were found. Hold BOOTSEL "
+                    "while plugging the Pico in (or while pressing the "
+                    "RUN button) and re-run.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            print(f"Found {len(devices)} Pico(s) in BOOTSEL mode.")
+            failures = 0
+            for dev in devices:
+                serial = dev.get("usb_serial")
+                bus = dev.get("bus")
+                address = dev.get("address")
+                label = serial or f"bus {bus} address {address}"
+                print(f"\n→ Flashing Pico {label}")
+                try:
+                    if serial:
+                        flash_test_image(args.uf2, usb_serial=serial)
+                    else:
+                        flash_test_image(
+                            args.uf2, bus=bus, address=address
+                        )
+                except RuntimeError as e:
+                    print(str(e), file=sys.stderr)
+                    failures += 1
+            if failures:
+                sys.exit(1)
     except FileNotFoundError as e:
         print(
             f"{e}\nBuild the test image first with ./build.sh.",
@@ -133,12 +227,7 @@ def main():
         print(str(e), file=sys.stderr)
         sys.exit(1)
 
-    print(
-        "\nFlash complete. The Pico should now blink in a heartbeat "
-        "pattern and enumerate as /dev/ttyACM* (USB VID:PID "
-        "2e8a:0009).\nRun `flash-picos --uf2 build/pico_multi.uf2` to "
-        "install the production image."
-    )
+    print(_DONE_MSG)
 
 
 if __name__ == "__main__":

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -207,6 +207,15 @@ def main():
                 serial = dev.get("usb_serial")
                 bus = dev.get("bus")
                 address = dev.get("address")
+                has_bus_address = bus is not None and address is not None
+                if not serial and not has_bus_address:
+                    print(
+                        "Skipping BOOTSEL device with incomplete selector "
+                        f"(serial={serial}, bus={bus}, address={address}).",
+                        file=sys.stderr,
+                    )
+                    failures += 1
+                    continue
                 label = serial or f"bus {bus} address {address}"
                 print(f"\n→ Flashing Pico {label}")
                 try:

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -208,7 +208,7 @@ def main():
                 bus = dev.get("bus")
                 address = dev.get("address")
                 has_bus_address = bus is not None and address is not None
-                if not serial and not has_bus_address:
+                if serial is None and not has_bus_address:
                     print(
                         "Skipping BOOTSEL device with incomplete selector "
                         f"(serial={serial}, bus={bus}, address={address}).",
@@ -219,7 +219,7 @@ def main():
                 label = serial or f"bus {bus} address {address}"
                 print(f"\n→ Flashing Pico {label}")
                 try:
-                    if serial:
+                    if serial is not None:
                         flash_test_image(args.uf2, usb_serial=serial)
                     else:
                         flash_test_image(

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -172,6 +172,10 @@ def main():
         ),
     )
     args = p.parse_args()
+    if (args.bus is None) != (args.address is None):
+        p.error("--bus and --address must be provided together.")
+    if args.usb_serial is not None and args.bus is not None:
+        p.error("--usb-serial cannot be combined with --bus/--address.")
 
     targeted = (
         args.bus is not None

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -397,3 +397,40 @@ class TestMainAutoDiscover:
         assert calls == [
             {"bus": 1, "address": 7, "usb_serial": None},
         ]
+
+    def test_skips_device_with_incomplete_selector(
+        self, monkeypatch, tmp_path
+    ):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+        _make_usb_device(
+            sysfs, "1-1", "2e8a", "0003",
+            serial="AAA", bus=1, devnum=3,
+        )
+        dev = sysfs / "1-2"
+        dev.mkdir()
+        (dev / "idVendor").write_text("2e8a\n")
+        (dev / "idProduct").write_text("0003\n")
+        # no serial, no busnum/devnum -> incomplete selector
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+        calls = []
+
+        def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
+            calls.append({
+                "bus": bus, "address": address, "usb_serial": usb_serial,
+            })
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2)]
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+        assert calls == [
+            {"bus": None, "address": None, "usb_serial": "AAA"},
+        ]

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -193,6 +193,47 @@ class TestFindBootselDevices:
 
 
 class TestMainAutoDiscover:
+    def test_rejects_bus_without_address(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2), "--bus", "1"]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 2
+
+    def test_rejects_address_without_bus(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2), "--address", "7"]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 2
+
+    def test_rejects_usb_serial_with_bus_address(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "flash-test",
+                "--uf2",
+                str(uf2),
+                "--usb-serial",
+                "AAA",
+                "--bus",
+                "1",
+                "--address",
+                "7",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 2
+
     def test_flashes_each_bootsel_device(self, monkeypatch, tmp_path):
         uf2 = tmp_path / "test.uf2"
         uf2.write_bytes(b"\x00")

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -5,7 +5,28 @@ from pathlib import Path
 
 import pytest
 
-from picohost.flash_test import build_picotool_cmd, flash_test_image
+from picohost import flash_test as flash_test_mod
+from picohost.flash_test import (
+    build_picotool_cmd,
+    find_bootsel_devices,
+    flash_test_image,
+    main,
+)
+
+
+def _make_usb_device(root, name, vid, pid, *, serial=None, bus=None, devnum=None):
+    """Create a fake sysfs USB device directory for tests."""
+    dev = root / name
+    dev.mkdir()
+    (dev / "idVendor").write_text(vid + "\n")
+    (dev / "idProduct").write_text(pid + "\n")
+    if serial is not None:
+        (dev / "serial").write_text(serial + "\n")
+    if bus is not None:
+        (dev / "busnum").write_text(f"{bus}\n")
+    if devnum is not None:
+        (dev / "devnum").write_text(f"{devnum}\n")
+    return dev
 
 
 class TestBuildPicotoolCmd:
@@ -104,3 +125,234 @@ class TestFlashTestImage:
         monkeypatch.setattr(subprocess, "run", fake_run)
         with pytest.raises(RuntimeError, match="picotool failed"):
             flash_test_image(uf2)
+
+
+class TestFindBootselDevices:
+    def test_missing_sysfs_returns_empty(self, tmp_path):
+        assert find_bootsel_devices(tmp_path / "nope") == []
+
+    def test_skips_non_pico_devices(self, tmp_path):
+        _make_usb_device(
+            tmp_path, "1-1", "1234", "5678",
+            serial="other", bus=1, devnum=2,
+        )
+        assert find_bootsel_devices(tmp_path) == []
+
+    def test_skips_pico_in_cdc_mode(self, tmp_path):
+        _make_usb_device(
+            tmp_path, "1-2", "2e8a", "0009",
+            serial="CDCPICO", bus=1, devnum=3,
+        )
+        assert find_bootsel_devices(tmp_path) == []
+
+    def test_finds_bootsel_pico(self, tmp_path):
+        _make_usb_device(
+            tmp_path, "1-3", "2e8a", "0003",
+            serial="E66160F4ABCDEF01", bus=1, devnum=4,
+        )
+        assert find_bootsel_devices(tmp_path) == [
+            {"usb_serial": "E66160F4ABCDEF01", "bus": 1, "address": 4},
+        ]
+
+    def test_accepts_uppercase_vid_pid(self, tmp_path):
+        _make_usb_device(
+            tmp_path, "1-4", "2E8A", "0003",
+            serial="UPPER1", bus=2, devnum=5,
+        )
+        devs = find_bootsel_devices(tmp_path)
+        assert len(devs) == 1
+        assert devs[0]["usb_serial"] == "UPPER1"
+
+    def test_finds_multiple(self, tmp_path):
+        _make_usb_device(
+            tmp_path, "1-3", "2e8a", "0003",
+            serial="AAA", bus=1, devnum=3,
+        )
+        _make_usb_device(
+            tmp_path, "1-5", "2e8a", "0003",
+            serial="BBB", bus=1, devnum=6,
+        )
+        _make_usb_device(
+            tmp_path, "2-1", "2e8a", "0009",
+            serial="not-bootsel", bus=2, devnum=2,
+        )
+        devs = find_bootsel_devices(tmp_path)
+        serials = {d["usb_serial"] for d in devs}
+        assert serials == {"AAA", "BBB"}
+
+    def test_missing_optional_fields(self, tmp_path):
+        dev = tmp_path / "1-6"
+        dev.mkdir()
+        (dev / "idVendor").write_text("2e8a\n")
+        (dev / "idProduct").write_text("0003\n")
+        # no serial, no busnum, no devnum
+        devs = find_bootsel_devices(tmp_path)
+        assert devs == [
+            {"usb_serial": None, "bus": None, "address": None},
+        ]
+
+
+class TestMainAutoDiscover:
+    def test_flashes_each_bootsel_device(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+        _make_usb_device(
+            sysfs, "1-1", "2e8a", "0003",
+            serial="AAA", bus=1, devnum=3,
+        )
+        _make_usb_device(
+            sysfs, "1-2", "2e8a", "0003",
+            serial="BBB", bus=1, devnum=4,
+        )
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+
+        calls = []
+
+        def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
+            calls.append({
+                "uf2": str(uf2_path),
+                "bus": bus,
+                "address": address,
+                "usb_serial": usb_serial,
+            })
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2)]
+        )
+
+        main()
+
+        serials = sorted(c["usb_serial"] for c in calls)
+        assert serials == ["AAA", "BBB"]
+        for c in calls:
+            assert c["bus"] is None
+            assert c["address"] is None
+            assert c["uf2"] == str(uf2)
+
+    def test_no_devices_exits_error(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+        called = []
+
+        def fake_flash(*a, **kw):
+            called.append((a, kw))
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2)]
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+        assert called == []
+
+    def test_explicit_target_skips_discovery(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+        # Two BOOTSEL devices present, but user asked for one specifically.
+        _make_usb_device(
+            sysfs, "1-1", "2e8a", "0003",
+            serial="AAA", bus=1, devnum=3,
+        )
+        _make_usb_device(
+            sysfs, "1-2", "2e8a", "0003",
+            serial="BBB", bus=1, devnum=4,
+        )
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+
+        calls = []
+
+        def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
+            calls.append({
+                "bus": bus, "address": address, "usb_serial": usb_serial,
+            })
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["flash-test", "--uf2", str(uf2), "--usb-serial", "BBB"],
+        )
+
+        main()
+        assert calls == [
+            {"bus": None, "address": None, "usb_serial": "BBB"},
+        ]
+
+    def test_continues_on_individual_failure(self, monkeypatch, tmp_path):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+        _make_usb_device(
+            sysfs, "1-1", "2e8a", "0003",
+            serial="AAA", bus=1, devnum=3,
+        )
+        _make_usb_device(
+            sysfs, "1-2", "2e8a", "0003",
+            serial="BBB", bus=1, devnum=4,
+        )
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+
+        attempted = []
+
+        def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
+            attempted.append(usb_serial)
+            if usb_serial == "AAA":
+                raise RuntimeError("picotool failed")
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2)]
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+        assert sorted(attempted) == ["AAA", "BBB"]
+
+    def test_falls_back_to_bus_address_when_no_serial(
+        self, monkeypatch, tmp_path
+    ):
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+        dev = sysfs / "1-1"
+        dev.mkdir()
+        (dev / "idVendor").write_text("2e8a\n")
+        (dev / "idProduct").write_text("0003\n")
+        (dev / "busnum").write_text("1\n")
+        (dev / "devnum").write_text("7\n")
+        # no serial file
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+        calls = []
+
+        def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
+            calls.append({
+                "bus": bus, "address": address, "usb_serial": usb_serial,
+            })
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr(
+            "sys.argv", ["flash-test", "--uf2", str(uf2)]
+        )
+
+        main()
+        assert calls == [
+            {"bus": 1, "address": 7, "usb_serial": None},
+        ]


### PR DESCRIPTION
## Summary
- `flash-test` now scans `/sys/bus/usb/devices` for VID:PID `2e8a:0003` and flashes every BOOTSEL Pico it finds, mirroring `flash-picos`'s behavior for CDC devices.
- Single-device targeting via `--bus`/`--address` or `--usb-serial` still works as before.
- Non-Linux hosts fall back to picotool's own default selection.

## Test plan
- [ ] `cd picohost && pytest tests/test_flash_test.py`
- [ ] Plug in multiple Picos in BOOTSEL mode and confirm `flash-test` reaches all of them
- [ ] Confirm `--usb-serial` and `--bus/--address` still target a single device

🤖 Generated with [Claude Code](https://claude.com/claude-code)