### PR TITLE
fix(picohost): tolerate non-UTF-8 bytes in picotool output

### DIFF
--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -46,7 +46,11 @@ def flash_uf2(uf2_path, serial):
     cmd = f"picotool load -f --ser {serial} -x {uf2_path}".split()
     print(f"Flashing {uf2_path} → serial={serial}")
     res = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
     )
     if res.returncode != 0:
         print(res.stdout, file=sys.stderr)

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -58,7 +58,11 @@ def flash_test_image(uf2_path, bus=None, address=None, usb_serial=None):
     )
     print(f"Running: {' '.join(cmd)}")
     res = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
     )
     output = res.stdout or ""
     if res.returncode != 0:


### PR DESCRIPTION
## Summary
- picotool occasionally emits bytes that aren't valid UTF-8 (e.g. orphan continuation byte `0x98`), causing `subprocess.run(..., text=True)` to raise `UnicodeDecodeError` before the command's exit status can be inspected.
- Pass `errors="replace"` in `flash_picos.py` and `flash_test.py` so decoding is lossy but the wrapper keeps working and surfaces the underlying picotool exit status.

## Test plan
- [ ] `cd picohost && pytest`
- [ ] Reproduce on a host where picotool previously emitted invalid UTF-8 and confirm the flash CLIs no longer crash with `UnicodeDecodeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)