### PR TITLE
fix(potmon): discard first ADC sample after mux switch

### DIFF
--- a/src/potmon.c
+++ b/src/potmon.c
@@ -19,8 +19,11 @@ static void pot_sensor_init(PotSensor *pot, uint gpio_pin, uint adc_channel)
 /*helper func to read a value off of a pot sensor*/
 static void pot_sensor_read(PotSensor *pot)
 {
-    /*read a channel*/
     adc_select_input(pot->adc_channel);
+    /* Discard one sample to let the shared S/H cap settle after the
+       mux switch — otherwise a low-impedance neighbour channel bleeds
+       into a high-impedance/floating one (e.g. an unconnected pot). */
+    (void)adc_read();
     uint16_t raw = adc_read();
     pot->voltage = ((float)raw / (float)POTMON_ADC_MAX) * POTMON_VREF;
 }


### PR DESCRIPTION
## Summary
- Adds a throwaway `adc_read()` after `adc_select_input()` in `pot_sensor_read()` so the shared S/H capacitor settles before the real conversion.
- Fixes ghost readings on the EL channel that tracked AZ when only the AZ pot was wired (S/H charge sharing through the analog mux).

## Why
RP2350 has one SAR ADC + one S/H cap behind an analog mux. `adc_read()` does not delay after a channel switch, so a low-impedance neighbour (connected pot) bleeds into a high-impedance/floating channel. Observed on bench: ~0.6–1.2 V swing on unconnected EL across a full 3.3 V AZ swing. Discarding one sample lets the cap settle; cost is ~2 µs per read, negligible vs the 200 ms status cadence.

## Test plan
- [ ] Build with `./build.sh` and flash to a Pico running APP_POTMON.
- [ ] Bench test with only AZ pot wired: sweep AZ across full range, confirm EL voltage stays near 0 V (no correlated swing).
- [ ] Verify AZ voltage still tracks pot position normally.
- [ ] Sanity check both pots connected: AZ and EL track their respective pots independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)