### PR TITLE
fix(picohost): retry flash step and settle between Picos for BOOTSEL re-enumeration races

### DIFF
--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -38,24 +38,61 @@ def find_pico_ports():
     return ports
 
 
-def flash_uf2(uf2_path, serial):
+_FLASH_MAX_ATTEMPTS = 3
+_FLASH_RETRY_BACKOFF_S = 2.0
+
+
+def flash_uf2(
+    uf2_path,
+    serial,
+    attempts=_FLASH_MAX_ATTEMPTS,
+    backoff=_FLASH_RETRY_BACKOFF_S,
+):
     """
     Flash the UF2 onto the Pico whose USB serial number is `serial`,
     using picotool's --ser selector.
+
+    ``picotool load -f`` reboots the target into BOOTSEL and must then
+    re-discover it as a BOOTSEL device before loading. On a busy USB
+    bus — e.g. several Picos behind a hub on a Raspberry Pi — that
+    re-enumeration can land outside picotool's internal discovery
+    window, so the load fails intermittently with "No accessible
+    RP-series devices in BOOTSEL mode were found".
+
+    We retry with linear backoff. On a retry the target is already
+    sitting in BOOTSEL (the earlier attempt's reset took effect), so
+    picotool only has to *find* it — which usually succeeds once the
+    bus has quieted, without another reset round-trip.
     """
     cmd = f"picotool load -f --ser {serial} -x {uf2_path}".split()
     print(f"Flashing {uf2_path} → serial={serial}")
-    res = subprocess.run(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        errors="replace",
+    res = None
+    for attempt in range(1, attempts + 1):
+        res = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            errors="replace",
+        )
+        if res.returncode == 0:
+            print(res.stdout, end="")
+            return
+        if attempt < attempts:
+            delay = backoff * attempt
+            logger.warning(
+                "picotool failed on serial=%s (attempt %d/%d); "
+                "retrying in %.1fs",
+                serial,
+                attempt,
+                attempts,
+                delay,
+            )
+            time.sleep(delay)
+    print(res.stdout, file=sys.stderr)
+    raise RuntimeError(
+        f"picotool failed on serial={serial} after {attempts} attempts"
     )
-    if res.returncode != 0:
-        print(res.stdout, file=sys.stderr)
-        raise RuntimeError(f"picotool failed on serial={serial}")
-    print(res.stdout, end="")
 
 
 def read_json_from_serial(port, baud, timeout):
@@ -78,6 +115,7 @@ def read_json_from_serial(port, baud, timeout):
 _REENUMERATE_TIMEOUT_S = 10.0
 _REENUMERATE_POLL_S = 0.2
 _UDEV_SETTLE_TIMEOUT_S = 3.0
+_INTER_DEVICE_SETTLE_S = 1.0
 
 
 def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
@@ -201,7 +239,13 @@ def flash_and_discover(
     logger.info(f"Found Picos on: {ports}")
     all_devices = []
 
-    for port_dev, port_serial in ports.items():
+    for idx, (port_dev, port_serial) in enumerate(ports.items()):
+        if idx > 0:
+            # Let the bus quiet after the previous Pico's post-flash
+            # re-enumeration before forcing the next one into BOOTSEL.
+            # Back-to-back resets on a shared hub disturb siblings and
+            # cause cascading "not found in BOOTSEL" failures.
+            time.sleep(_INTER_DEVICE_SETTLE_S)
         logger.info(f"Flashing Pico on port: {port_dev}")
         try:
             flash_uf2(uf2_path, port_serial)

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -1,10 +1,13 @@
 """Tests for picohost.flash_picos.flash_and_discover."""
 
+import types
+
 import pytest
 
 from picohost.flash_picos import (
     _resolve_post_flash_port,
     flash_and_discover,
+    flash_uf2,
 )
 
 
@@ -275,6 +278,63 @@ class TestFlashAndDiscover:
         assert len(devices) == 1
         assert devices[0]["usb_serial"] == "SER_B"
         assert devices[0]["port"] == "/dev/ttyACM1"
+
+
+class TestFlashUf2:
+    """picotool's ``-f`` reboots the target into BOOTSEL and must then
+    re-discover it before loading; on a busy hub that re-enumeration
+    can fall outside picotool's window and fail intermittently. The
+    flash step retries with backoff so a transient miss does not
+    abandon the device.
+    """
+
+    def _patch_run(self, monkeypatch, returncodes):
+        """Make subprocess.run return the given codes in sequence."""
+        import picohost.flash_picos as fp
+
+        calls = {"n": 0, "cmds": []}
+
+        def fake_run(cmd, **kwargs):
+            calls["cmds"].append(cmd)
+            rc = returncodes[calls["n"]]
+            calls["n"] += 1
+            return types.SimpleNamespace(returncode=rc, stdout="picotool out")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        return calls
+
+    def test_succeeds_on_first_attempt(self, monkeypatch):
+        calls = self._patch_run(monkeypatch, [0])
+        flash_uf2("x.uf2", "SER_A")
+        assert calls["n"] == 1
+
+    def test_retries_then_succeeds(self, monkeypatch):
+        calls = self._patch_run(monkeypatch, [1, 1, 0])
+        flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
+        assert calls["n"] == 3
+
+    def test_raises_after_exhausting_attempts(self, monkeypatch):
+        calls = self._patch_run(monkeypatch, [1, 1, 1])
+        with pytest.raises(RuntimeError, match="after 3 attempts"):
+            flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
+        assert calls["n"] == 3
+
+    def test_backoff_between_attempts(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        codes = iter([1, 0])
+        monkeypatch.setattr(
+            fp.subprocess,
+            "run",
+            lambda cmd, **kw: types.SimpleNamespace(
+                returncode=next(codes), stdout=""
+            ),
+        )
+        sleeps = []
+        monkeypatch.setattr(fp.time, "sleep", lambda s: sleeps.append(s))
+        flash_uf2("x.uf2", "SER_A", attempts=3, backoff=2.0)
+        assert sleeps == [2.0]
 
 
 class TestResolvePostFlashPort:

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -279,7 +279,7 @@ class TestFlashAndDiscover:
         assert devices[0]["usb_serial"] == "SER_B"
         assert devices[0]["port"] == "/dev/ttyACM1"
 
-    def test_inter_device_settle_delay_before_second_flash(
+    def test_inter_device_settle_delay_before_second_and_later_flash(
         self, monkeypatch, tmp_path
     ):
         import picohost.flash_picos as fp
@@ -293,6 +293,7 @@ class TestFlashAndDiscover:
             lambda: {
                 "/dev/ttyACM0": "SER_A",
                 "/dev/ttyACM1": "SER_B",
+                "/dev/ttyACM2": "SER_C",
             },
         )
 
@@ -308,6 +309,7 @@ class TestFlashAndDiscover:
             lambda serial: {
                 "SER_A": "/dev/ttyACM0",
                 "SER_B": "/dev/ttyACM1",
+                "SER_C": "/dev/ttyACM2",
             }[serial],
         )
         monkeypatch.setattr(
@@ -330,6 +332,9 @@ class TestFlashAndDiscover:
             ("sleep", fp._INTER_DEVICE_SETTLE_S),
             ("flash", "SER_B"),
             ("read", "/dev/ttyACM1"),
+            ("sleep", fp._INTER_DEVICE_SETTLE_S),
+            ("flash", "SER_C"),
+            ("read", "/dev/ttyACM2"),
         ]
 
 

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -298,7 +298,9 @@ class TestFlashAndDiscover:
 
         events = []
         monkeypatch.setattr(
-            fp, "flash_uf2", lambda path, serial: events.append(("flash", serial))
+            fp,
+            "flash_uf2",
+            lambda path, serial: events.append(("flash", serial)),
         )
         monkeypatch.setattr(
             fp,
@@ -311,8 +313,9 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "read_json_from_serial",
-            lambda port, baud, timeout: events.append(("read", port))
-            or {"app_id": 0},
+            lambda port, baud, timeout: (
+                events.append(("read", port)) or {"app_id": 0}
+            ),
         )
         monkeypatch.setattr(fp, "_udev_settle", lambda: None)
         monkeypatch.setattr(

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -279,6 +279,56 @@ class TestFlashAndDiscover:
         assert devices[0]["usb_serial"] == "SER_B"
         assert devices[0]["port"] == "/dev/ttyACM1"
 
+    def test_inter_device_settle_delay_before_second_flash(
+        self, monkeypatch, tmp_path
+    ):
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        monkeypatch.setattr(
+            fp,
+            "find_pico_ports",
+            lambda: {
+                "/dev/ttyACM0": "SER_A",
+                "/dev/ttyACM1": "SER_B",
+            },
+        )
+
+        events = []
+        monkeypatch.setattr(
+            fp, "flash_uf2", lambda path, serial: events.append(("flash", serial))
+        )
+        monkeypatch.setattr(
+            fp,
+            "_resolve_post_flash_port",
+            lambda serial: {
+                "SER_A": "/dev/ttyACM0",
+                "SER_B": "/dev/ttyACM1",
+            }[serial],
+        )
+        monkeypatch.setattr(
+            fp,
+            "read_json_from_serial",
+            lambda port, baud, timeout: events.append(("read", port))
+            or {"app_id": 0},
+        )
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
+        monkeypatch.setattr(
+            fp.time, "sleep", lambda s: events.append(("sleep", s))
+        )
+
+        flash_and_discover(uf2_path=uf2)
+
+        assert events == [
+            ("flash", "SER_A"),
+            ("read", "/dev/ttyACM0"),
+            ("sleep", fp._INTER_DEVICE_SETTLE_S),
+            ("flash", "SER_B"),
+            ("read", "/dev/ttyACM1"),
+        ]
+
 
 class TestFlashUf2:
     """picotool's ``-f`` reboots the target into BOOTSEL and must then

--- a/picohost/uv.lock
+++ b/picohost/uv.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
picotool load -f reboots a Pico into BOOTSEL and must re-discover it as
a BOOTSEL device before loading. With several Picos behind a hub on a
Pi, that re-enumeration can land outside picotool's discovery window,
failing intermittently with "No accessible RP-series devices in BOOTSEL
mode were found". The flash step had no retry and flashed back-to-back
with no settle, so a transient miss was a hard skip and one reset could
cascade into sibling failures.

- flash_uf2 retries with linear backoff (3 attempts). On a retry the
  target is already in BOOTSEL, so picotool only has to find it once the
  bus quiets — no second reset round-trip.
- Add a 1s settle between devices so one Pico's re-enumeration storm
  subsides before the next is forced into BOOTSEL.
- Tests cover first-try success, retry-then-succeed, attempt exhaustion,
  and backoff timing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
