### PR TITLE
feat(tempctrl): add runaway trip + sensor rate-sanity guards

### DIFF
--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -56,6 +56,7 @@ class TempControlState:
         self.stall_tripped = False
         self.stall_window_active = False
         self.stall_check_T = 0.0
+        self.stall_check_drive = 0.0
         self.stall_check_time = 0.0
         # Test hook: when True, skip the thermal-drift update even with the
         # drive engaged, so the stall guard can be exercised deterministically.
@@ -67,6 +68,31 @@ class TempControlState:
         # Conversion-cycle counter for the fresh-sample gate. PI fires
         # when this rolls over OP_TICKS_PER_CONVERSION.
         self._op_counter = 0
+        # Runaway guard mirror (see tempctrl_check_stall in tempctrl.c):
+        # consecutive wrong-direction windows.
+        self.runaway_strikes = 0
+        # Sensor sanity guard mirror (see tempctrl_update_sensor_drive).
+        # rate_ref_valid gates the first-sample seeding; sensor_rejects
+        # counts consecutive rejected samples and latches at MAX_REJECTS.
+        self.rate_ref_valid = False
+        self.sensor_rejects = 0
+        # Test hook: queued bogus sensor readings, one consumed per fresh
+        # conversion, standing in for a failing thermistor. A normal fresh
+        # tick (empty queue) reads the thermal-model T_now and always
+        # passes the rate guard. See inject_sensor_glitch.
+        self._glitch_queue = []
+
+    def inject_sensor_glitch(self, value, count=1):
+        """Queue ``count`` bogus raw sensor readings of ``value``.
+
+        Each is consumed on a subsequent fresh conversion and run through
+        the rate-of-change guard, mirroring a DS18B20 that answers on the
+        bus with garbage. A jump larger than ``MAX_RATE_C_PER_S * dt`` is
+        rejected (``T_now`` holds, ``sensor_rejects`` increments); after
+        ``MAX_REJECTS`` consecutive rejects the channel latches
+        ``internally_disabled``.
+        """
+        self._glitch_queue.extend([float(value)] * count)
 
 
 def _reset_controller_state(tc):
@@ -125,6 +151,14 @@ def tempctrl_pi_drive(tc, dt=DT_PER_PI_TICK_S):
 STALL_WINDOW_MS = 60000
 STALL_MIN_DELTA = 0.5
 
+# Mirrors TEMPCTRL_RUNAWAY_STRIKES / TEMPCTRL_MAX_RATE_C_PER_S /
+# TEMPCTRL_MAX_REJECTS in tempctrl.h. See the firmware comments for the
+# rationale (wrong-direction runaway trip; physically-impossible-jump
+# sensor rejection with a consecutive-reject latch).
+RUNAWAY_STRIKES = 2
+MAX_RATE_C_PER_S = 5.0
+MAX_REJECTS = 3
+
 
 class TempCtrlEmulator(PicoEmulator):
     """Emulates src/tempctrl.c firmware."""
@@ -179,6 +213,9 @@ class TempCtrlEmulator(PicoEmulator):
                 if new_enabled:
                     tc.stall_tripped = False
                     tc.stall_window_active = False
+                    tc.runaway_strikes = 0
+                    tc.sensor_rejects = 0
+                    tc.rate_ref_valid = False
                     self.watchdog_tripped = False
                 tc.enabled = new_enabled
 
@@ -245,13 +282,50 @@ class TempCtrlEmulator(PicoEmulator):
             and not self.watchdog_tripped
         )
 
+    def _read_sensor(self, tc):
+        """Mirror the sensor read + rate-of-change sanity guard in
+        tempctrl_update_sensor_drive. ``raw`` is the bogus queued reading
+        when a glitch is pending, else the thermal-model ``T_now`` (a
+        normal reading, which equals the current ``T_now`` and so always
+        passes). dt is one conversion (``DT_PER_PI_TICK_S``) because the
+        firmware advances its rate reference on every fresh sample.
+        """
+        if tc._sensor_error:
+            return
+        raw = tc._glitch_queue.pop(0) if tc._glitch_queue else tc.T_now
+        if not tc.rate_ref_valid:
+            tc.T_now = raw
+            tc.rate_ref_valid = True
+            tc.sensor_rejects = 0
+            return
+        rate = abs(raw - tc.T_now) / DT_PER_PI_TICK_S
+        if rate > MAX_RATE_C_PER_S:
+            # Reject: hold the last good T_now, count toward the latch.
+            if tc.sensor_rejects < MAX_REJECTS:
+                tc.sensor_rejects += 1
+        else:
+            tc.T_now = raw
+            tc.sensor_rejects = 0
+
     def _update_channel(self, tc):
         tc._op_counter += 1
         fresh = tc._op_counter % OP_TICKS_PER_CONVERSION == 0
 
-        # Mirror firmware tempctrl_update_sensor_drive: temp_sensor_has_error()
-        # is re-read every op tick, so a recovered sensor self-clears.
-        tc.internally_disabled = tc._sensor_error
+        # Sense first (mirrors firmware order: read + rate guard, then
+        # control on the filtered T_now). Only a fresh conversion produces
+        # a new sample.
+        if fresh:
+            self._read_sensor(tc)
+            # Mirror firmware: tempctrl_status sends
+            # temp_sensor_get_conversion_time(), updated on each decode.
+            tc.timestamp = self._ms_since_boot()
+
+        # internally_disabled is the hardware read error OR a latched
+        # sensor-sanity reject; re-derived every tick so a recovered sensor
+        # self-clears (matches firmware tempctrl_update_sensor_drive).
+        tc.internally_disabled = tc._sensor_error or (
+            tc.sensor_rejects >= MAX_REJECTS
+        )
 
         if self._drive_allowed(tc):
             if fresh:
@@ -260,6 +334,7 @@ class TempCtrlEmulator(PicoEmulator):
         else:
             _reset_controller_state(tc)
             tc.stall_window_active = False
+            tc.runaway_strikes = 0
 
         # Thermal model: drive set by PI is held between PI ticks (mirrors
         # continuous PWM), so the effect accumulates every op tick. When
@@ -269,11 +344,6 @@ class TempCtrlEmulator(PicoEmulator):
         if not tc.thermal_frozen:
             tc.T_now += tc.drive * THERMAL_DRIFT_PER_OP
 
-        # Mirror firmware: tempctrl_status sends temp_sensor_get_conversion_time()
-        # which updates when a new sample is decoded.
-        if fresh:
-            tc.timestamp = self._ms_since_boot()
-
     def _check_stall(self, tc):
         """Mirror tempctrl_check_stall() from tempctrl.c."""
         # `active` alone isn't sufficient: with cooling_enabled=False the PI
@@ -281,24 +351,45 @@ class TempCtrlEmulator(PicoEmulator):
         # drive=0, which is the configured refusal-to-cool, not a stall.
         if not tc.active or tc.drive == 0.0:
             tc.stall_window_active = False
+            tc.runaway_strikes = 0
             return
         now = time.time()
         if not tc.stall_window_active:
             tc.stall_check_T = tc.T_now
+            tc.stall_check_drive = tc.drive
             tc.stall_check_time = now
             tc.stall_window_active = True
             return
         elapsed_ms = (now - tc.stall_check_time) * 1000
         if elapsed_ms < STALL_WINDOW_MS:
             return
-        if abs(tc.T_now - tc.stall_check_T) < STALL_MIN_DELTA:
+        delta = tc.T_now - tc.stall_check_T
+        if abs(delta) < STALL_MIN_DELTA:
+            # No movement — sensor stuck or Peltier ineffective.
             tc.stall_tripped = True
             tc.active = False
             tc.drive = 0.0
             tc.stall_window_active = False
+            tc.runaway_strikes = 0
+            return
+        # Moved the wrong direction for the drive → runaway signature.
+        # Trip only after RUNAWAY_STRIKES consecutive wrong-direction
+        # windows (tolerates the startup/soak transient).
+        if delta * tc.stall_check_drive < 0.0:
+            tc.runaway_strikes += 1
+            if tc.runaway_strikes >= RUNAWAY_STRIKES:
+                tc.stall_tripped = True
+                tc.active = False
+                tc.drive = 0.0
+                tc.stall_window_active = False
+                tc.runaway_strikes = 0
+                return
         else:
-            tc.stall_check_T = tc.T_now
-            tc.stall_check_time = now
+            tc.runaway_strikes = 0
+        # Roll the window forward.
+        tc.stall_check_T = tc.T_now
+        tc.stall_check_drive = tc.drive
+        tc.stall_check_time = now
 
     def op(self):
         # Communication watchdog: trip the app-wide flag if no command has

--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -62,8 +62,9 @@ class TempControlState:
         # drive engaged, so the stall guard can be exercised deterministically.
         self.thermal_frozen = False
         # Mirrors temp_sensor_has_error()'s underlying state. op() re-reads
-        # this into internally_disabled every tick, so a recovered sensor
-        # self-clears (matches firmware tempctrl_update_sensor_drive).
+        # this into internally_disabled every tick, so a recovered bus fault
+        # self-clears (matches firmware tempctrl_update_sensor_drive). The
+        # rate-sanity latch (sensor_tripped) is sticky by contrast.
         self._sensor_error = False
         # Conversion-cycle counter for the fresh-sample gate. PI fires
         # when this rolls over OP_TICKS_PER_CONVERSION.
@@ -74,8 +75,16 @@ class TempControlState:
         # Sensor sanity guard mirror (see tempctrl_update_sensor_drive).
         # rate_ref_valid gates the first-sample seeding; sensor_rejects
         # counts consecutive rejected samples and latches at MAX_REJECTS.
+        # seed_pending marks a first (candidate) sample awaiting confirmation:
+        # the reference anchors only when two consecutive samples agree within
+        # the rate budget (two-to-anchor), so a lone transient cannot poison it.
+        # sensor_tripped latches once sensor_rejects reaches MAX_REJECTS and
+        # is cleared only by a *_enable=true host ack (like stall_tripped),
+        # so a sensor that produced a burst of garbage cannot silently
+        # re-enable drive when a later reading happens to look plausible.
         self.rate_ref_valid = False
         self.sensor_rejects = 0
+        self.sensor_tripped = False
         # Test hook: queued bogus sensor readings, one consumed per fresh
         # conversion, standing in for a failing thermistor. A normal fresh
         # tick (empty queue) reads the thermal-model T_now and always
@@ -215,6 +224,7 @@ class TempCtrlEmulator(PicoEmulator):
                     tc.stall_window_active = False
                     tc.runaway_strikes = 0
                     tc.sensor_rejects = 0
+                    tc.sensor_tripped = False
                     tc.rate_ref_valid = False
                     self.watchdog_tripped = False
                 tc.enabled = new_enabled
@@ -320,12 +330,14 @@ class TempCtrlEmulator(PicoEmulator):
             # temp_sensor_get_conversion_time(), updated on each decode.
             tc.timestamp = self._ms_since_boot()
 
-        # internally_disabled is the hardware read error OR a latched
-        # sensor-sanity reject; re-derived every tick so a recovered sensor
-        # self-clears (matches firmware tempctrl_update_sensor_drive).
-        tc.internally_disabled = tc._sensor_error or (
-            tc.sensor_rejects >= MAX_REJECTS
-        )
+        # internally_disabled is the hardware read error OR the latched
+        # sensor-sanity trip. The bus error self-clears when the sensor
+        # recovers; the rate-sanity latch is sticky once sensor_rejects hits
+        # MAX_REJECTS and only the enable ack clears it (matches firmware
+        # tempctrl_update_sensor_drive / tempctrl_apply_enable).
+        if tc.sensor_rejects >= MAX_REJECTS:
+            tc.sensor_tripped = True
+        tc.internally_disabled = tc._sensor_error or tc.sensor_tripped
 
         if self._drive_allowed(tc):
             if fresh:

--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -73,7 +73,7 @@ class TempControlState:
         # consecutive wrong-direction windows.
         self.runaway_strikes = 0
         # Sensor sanity guard mirror (see tempctrl_update_sensor_drive).
-        # rate_ref_valid gates the first-sample seeding; sensor_rejects
+        # rate_ref_valid gates control and the rate guard; sensor_rejects
         # counts consecutive rejected samples and latches at MAX_REJECTS.
         # seed_pending marks a first (candidate) sample awaiting confirmation:
         # the reference anchors only when two consecutive samples agree within
@@ -83,6 +83,7 @@ class TempControlState:
         # so a sensor that produced a burst of garbage cannot silently
         # re-enable drive when a later reading happens to look plausible.
         self.rate_ref_valid = False
+        self.seed_pending = False
         self.sensor_rejects = 0
         self.sensor_tripped = False
         # Test hook: queued bogus sensor readings, one consumed per fresh
@@ -226,6 +227,7 @@ class TempCtrlEmulator(PicoEmulator):
                     tc.sensor_rejects = 0
                     tc.sensor_tripped = False
                     tc.rate_ref_valid = False
+                    tc.seed_pending = False
                     self.watchdog_tripped = False
                 tc.enabled = new_enabled
 
@@ -299,14 +301,35 @@ class TempCtrlEmulator(PicoEmulator):
         normal reading, which equals the current ``T_now`` and so always
         passes). dt is one conversion (``DT_PER_PI_TICK_S``) because the
         firmware advances its rate reference on every fresh sample.
+
+        Two-to-anchor: until rate_ref_valid is set, the first sample is only a
+        candidate (held in T_now) and the reference anchors only when a second
+        sample confirms it within the rate budget. An unconfirmed candidate is
+        replaced and counts toward the latch, so a sensor that never produces
+        two consistent readings still latches.
         """
         if tc._sensor_error:
             return
         raw = tc._glitch_queue.pop(0) if tc._glitch_queue else tc.T_now
         if not tc.rate_ref_valid:
-            tc.T_now = raw
-            tc.rate_ref_valid = True
-            tc.sensor_rejects = 0
+            if not tc.seed_pending:
+                # First sample: hold as candidate, await confirmation.
+                tc.T_now = raw
+                tc.seed_pending = True
+                tc.sensor_rejects = 0
+                return
+            rate = abs(raw - tc.T_now) / DT_PER_PI_TICK_S
+            if rate > MAX_RATE_C_PER_S:
+                # Candidate unconfirmed: replace it, count toward the latch.
+                tc.T_now = raw
+                if tc.sensor_rejects < MAX_REJECTS:
+                    tc.sensor_rejects += 1
+            else:
+                # Two consecutive consistent samples: anchor the reference.
+                tc.T_now = raw
+                tc.rate_ref_valid = True
+                tc.seed_pending = False
+                tc.sensor_rejects = 0
             return
         rate = abs(raw - tc.T_now) / DT_PER_PI_TICK_S
         if rate > MAX_RATE_C_PER_S:
@@ -339,7 +362,10 @@ class TempCtrlEmulator(PicoEmulator):
             tc.sensor_tripped = True
         tc.internally_disabled = tc._sensor_error or tc.sensor_tripped
 
-        if self._drive_allowed(tc):
+        # rate_ref_valid gates control too: until the reference anchors T_now
+        # is only a candidate, so the channel stays idle (drive held at 0)
+        # rather than driving on an unconfirmed reading (matches firmware).
+        if self._drive_allowed(tc) and tc.rate_ref_valid:
             if fresh:
                 tempctrl_pi_drive(tc)
             self._check_stall(tc)

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -30,6 +30,18 @@ def _run_to_pi_tick(emu):
         emu.op()
 
 
+def _run_to_drive(emu):
+    """Advance to the first conversion that actually engages drive.
+
+    Two-to-anchor (tempctrl_update_sensor_drive): the first fresh
+    conversion only takes a candidate reference and control stays gated,
+    so drive engages on the second consistent conversion. Tests that need
+    a channel up and controlling step through both.
+    """
+    _run_to_pi_tick(emu)  # seed the candidate reference
+    _run_to_pi_tick(emu)  # confirm + anchor → control engages
+
+
 class TestMotorEmulator:
     def test_initial_state(self):
         emu = MotorEmulator()
@@ -418,7 +430,7 @@ class TestTempCtrlStallGuard:
         emu.lna.T_now = 25.0
         emu.lna.thermal_frozen = True
         emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
-        _run_to_pi_tick(emu)  # opens the stall window with active=True
+        _run_to_drive(emu)  # anchor, then open the stall window (active=True)
         assert emu.lna.active is True
         assert emu.lna.stall_window_active is True
         self._force_window_elapsed(emu.lna)
@@ -436,7 +448,7 @@ class TestTempCtrlStallGuard:
         emu = TempCtrlEmulator()
         emu.lna.T_now = 25.0
         emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         self._force_window_elapsed(emu.lna)
         emu.lna.T_now += 1.0  # well above STALL_MIN_DELTA
         emu.op()
@@ -455,7 +467,7 @@ class TestTempCtrlStallGuard:
                 "LNA_hysteresis": 0.5,
             }
         )
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         assert emu.lna.active is False
         assert emu.lna.stall_window_active is False
         self._force_window_elapsed(emu.lna)
@@ -468,7 +480,7 @@ class TestTempCtrlStallGuard:
         emu.lna.T_now = 25.0
         emu.lna.thermal_frozen = True
         emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         self._force_window_elapsed(emu.lna)
         emu.op()
         assert emu.lna.stall_tripped is True
@@ -483,7 +495,7 @@ class TestTempCtrlStallGuard:
         emu.lna.T_now = 25.0
         emu.lna.thermal_frozen = True
         emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         self._force_window_elapsed(emu.lna)
         emu.op()
         assert emu.lna.stall_tripped is True
@@ -504,7 +516,7 @@ class TestTempCtrlStallGuard:
                 "LOAD_enable": True,
             }
         )
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         self._force_window_elapsed(emu.load)
         emu.op()
         assert emu.load.stall_tripped is True
@@ -627,7 +639,7 @@ class TestTempCtrlCoolingGuard:
                 "LNA_cooling_enabled": False,
             }
         )
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         assert emu.lna.active is True
         assert emu.lna.drive == 0.0
         # Force-elapse the stall window and run another op cycle: with
@@ -658,7 +670,7 @@ class TestTempCtrlRunawayGuard:
         emu.lna.T_now = 30.0
         emu.lna.thermal_frozen = True  # drive T_now by hand
         emu.server({"LNA_temp_target": 20.0, "LNA_enable": True})
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         assert emu.lna.drive < 0.0
         assert emu.lna.stall_window_active is True
 
@@ -706,7 +718,7 @@ class TestTempCtrlRunawayGuard:
         emu.lna.T_now = 20.0
         emu.lna.thermal_frozen = True
         emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
-        _run_to_pi_tick(emu)
+        _run_to_drive(emu)
         assert emu.lna.drive > 0.0
         for _ in range(mod.RUNAWAY_STRIKES):
             self._force_window_elapsed(emu.lna)
@@ -746,9 +758,14 @@ class TestTempCtrlSensorSanity:
     """
 
     def _seed(self, emu):
-        """Run one good fresh conversion so the rate reference is valid."""
+        """Anchor the rate reference. Two-to-anchor needs two consistent
+        fresh conversions: the first is a candidate, the second confirms it.
+        """
         emu.lna.T_now = 25.0
         emu.lna.thermal_frozen = True
+        _run_to_pi_tick(emu)
+        assert emu.lna.seed_pending is True
+        assert emu.lna.rate_ref_valid is False
         _run_to_pi_tick(emu)
         assert emu.lna.rate_ref_valid is True
 

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -641,6 +641,170 @@ class TestTempCtrlCoolingGuard:
         assert emu.lna.enabled is True
 
 
+class TestTempCtrlRunawayGuard:
+    """Driving one direction while T_now moves the opposite direction trips
+    the channel (via stall_tripped) after RUNAWAY_STRIKES consecutive
+    wrong-direction windows — the thermal-runaway signature the no-movement
+    stall guard cannot catch (the temperature *is* moving).
+    """
+
+    def _force_window_elapsed(self, tc):
+        import picohost.emulators.tempctrl as mod
+
+        tc.stall_check_time = time.time() - (mod.STALL_WINDOW_MS / 1000 + 1)
+
+    def _setup_cooling(self, emu):
+        """Arm LNA cooling so drive saturates negative; open the window."""
+        emu.lna.T_now = 30.0
+        emu.lna.thermal_frozen = True  # drive T_now by hand
+        emu.server({"LNA_temp_target": 20.0, "LNA_enable": True})
+        _run_to_pi_tick(emu)
+        assert emu.lna.drive < 0.0
+        assert emu.lna.stall_window_active is True
+
+    def _wrong_way_window(self, emu):
+        """Force a completed window in which T_now moved *up* while the
+        drive is negative (cooling), then evaluate it with one op."""
+        self._force_window_elapsed(emu.lna)
+        emu.lna.T_now += 1.0
+        emu.op()
+
+    def test_runaway_trips_after_consecutive_wrong_windows(self):
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        self._setup_cooling(emu)
+        # All but the last wrong-direction window only accumulate strikes.
+        for i in range(mod.RUNAWAY_STRIKES - 1):
+            self._wrong_way_window(emu)
+            assert emu.lna.stall_tripped is False
+            assert emu.lna.runaway_strikes == i + 1
+        # The strike that reaches the threshold trips the channel.
+        self._wrong_way_window(emu)
+        assert emu.lna.stall_tripped is True
+        assert emu.lna.drive == 0.0
+        # Host intent preserved; trip flag is the runtime gate.
+        assert emu.lna.enabled is True
+
+    def test_correct_direction_window_resets_strikes(self):
+        emu = TempCtrlEmulator()
+        self._setup_cooling(emu)
+        self._wrong_way_window(emu)
+        assert emu.lna.runaway_strikes == 1
+        # A correct-direction window (cooling drive, T_now falls) clears it.
+        self._force_window_elapsed(emu.lna)
+        emu.lna.T_now -= 1.0
+        emu.op()
+        assert emu.lna.runaway_strikes == 0
+        assert emu.lna.stall_tripped is False
+
+    def test_runaway_trips_when_heating_drive_cools(self):
+        """Symmetric: heating drive (>0) while T_now falls also trips."""
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 20.0
+        emu.lna.thermal_frozen = True
+        emu.server({"LNA_temp_target": 30.0, "LNA_enable": True})
+        _run_to_pi_tick(emu)
+        assert emu.lna.drive > 0.0
+        for _ in range(mod.RUNAWAY_STRIKES):
+            self._force_window_elapsed(emu.lna)
+            emu.lna.T_now -= 1.0  # heating drive but cooling → wrong way
+            emu.op()
+        assert emu.lna.stall_tripped is True
+        assert emu.lna.drive == 0.0
+
+    def test_target_crossing_does_not_count_wrong_direction(self):
+        emu = TempCtrlEmulator()
+        self._setup_cooling(emu)
+        self._force_window_elapsed(emu.lna)
+        emu.lna.T_now = emu.lna.T_target - 1.0
+        emu.lna.thermal_frozen = False
+        _run_to_pi_tick(emu)
+        assert emu.lna.drive > 0.0
+        assert emu.lna.runaway_strikes == 0
+        assert emu.lna.stall_tripped is False
+
+    def test_enable_true_clears_runaway_trip(self):
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        self._setup_cooling(emu)
+        for _ in range(mod.RUNAWAY_STRIKES):
+            self._wrong_way_window(emu)
+        assert emu.lna.stall_tripped is True
+        emu.server({"LNA_enable": True})
+        assert emu.lna.stall_tripped is False
+        assert emu.lna.runaway_strikes == 0
+
+
+class TestTempCtrlSensorSanity:
+    """A fresh sample implying a physically impossible rate of change is
+    rejected (T_now holds); MAX_REJECTS consecutive rejects latch the
+    channel as a sensor fault (internally_disabled → status "error").
+    """
+
+    def _seed(self, emu):
+        """Run one good fresh conversion so the rate reference is valid."""
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        _run_to_pi_tick(emu)
+        assert emu.lna.rate_ref_valid is True
+
+    def test_single_glitch_absorbed(self):
+        emu = TempCtrlEmulator()
+        self._seed(emu)
+        emu.lna.inject_sensor_glitch(90.0)
+        _run_to_pi_tick(emu)
+        assert emu.lna.sensor_rejects == 1
+        assert emu.lna.internally_disabled is False
+        # Bogus value was not adopted — T_now holds the last good reading.
+        assert emu.lna.T_now == 25.0
+
+    def test_consecutive_glitches_latch_sensor_fault(self):
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        self._seed(emu)
+        emu.lna.inject_sensor_glitch(90.0, count=mod.MAX_REJECTS)
+        for _ in range(mod.MAX_REJECTS):
+            _run_to_pi_tick(emu)
+        assert emu.lna.sensor_rejects == mod.MAX_REJECTS
+        assert emu.lna.internally_disabled is True
+        assert emu.get_status()["LNA_status"] == "error"
+        # Never adopted a garbage value while latching.
+        assert emu.lna.T_now == 25.0
+
+    def test_good_sample_after_glitches_resets(self):
+        emu = TempCtrlEmulator()
+        self._seed(emu)
+        emu.lna.inject_sensor_glitch(90.0, count=2)
+        _run_to_pi_tick(emu)
+        _run_to_pi_tick(emu)
+        assert emu.lna.sensor_rejects == 2
+        assert emu.lna.internally_disabled is False
+        # A plausible reading (empty glitch queue → reads true T_now) clears
+        # the reject counter.
+        _run_to_pi_tick(emu)
+        assert emu.lna.sensor_rejects == 0
+        assert emu.lna.internally_disabled is False
+
+    def test_enable_true_clears_sensor_rejects_and_rate_reference(self):
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        self._seed(emu)
+        emu.lna.inject_sensor_glitch(90.0, count=mod.MAX_REJECTS)
+        for _ in range(mod.MAX_REJECTS):
+            _run_to_pi_tick(emu)
+        assert emu.lna.sensor_rejects == mod.MAX_REJECTS
+        assert emu.lna.rate_ref_valid is True
+        emu.server({"LNA_enable": True})
+        assert emu.lna.sensor_rejects == 0
+        assert emu.lna.rate_ref_valid is False
+
+
 class TestImuEmulator:
     def test_initial_state(self):
         emu = ImuEmulator(app_id=3)

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -803,6 +803,97 @@ class TestTempCtrlSensorSanity:
         emu.server({"LNA_enable": True})
         assert emu.lna.sensor_rejects == 0
         assert emu.lna.rate_ref_valid is False
+        assert emu.lna.seed_pending is False
+
+    def test_latched_fault_does_not_self_recover(self):
+        """A latched sensor fault is sticky: once tripped, plausible
+        readings alone must not silently re-enable the channel. Recovery
+        requires an explicit *_enable=true host ack (mirrors firmware
+        sensor_tripped). Auto-recovery would re-drive the Peltier on a
+        sensor that just produced a burst of garbage.
+        """
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        self._seed(emu)
+        emu.lna.inject_sensor_glitch(90.0, count=mod.MAX_REJECTS)
+        for _ in range(mod.MAX_REJECTS):
+            _run_to_pi_tick(emu)
+        assert emu.lna.internally_disabled is True
+        # Glitch queue is now empty, so subsequent fresh ticks read the true
+        # T_now and pass the rate guard — yet the latch must hold.
+        for _ in range(3):
+            _run_to_pi_tick(emu)
+        assert emu.lna.internally_disabled is True
+        assert emu.get_status()["LNA_status"] == "error"
+        # Only the host ack clears the latch and re-seeds the reference.
+        emu.server({"LNA_enable": True})
+        _run_to_pi_tick(emu)
+        assert emu.lna.internally_disabled is False
+
+    def test_seed_requires_two_samples(self):
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        # First fresh sample is only a candidate — the reference is not yet
+        # anchored, so there is nothing to rate-check the next sample against.
+        _run_to_pi_tick(emu)
+        assert emu.lna.seed_pending is True
+        assert emu.lna.rate_ref_valid is False
+        # A second consistent sample confirms and anchors the reference.
+        _run_to_pi_tick(emu)
+        assert emu.lna.rate_ref_valid is True
+        assert emu.lna.seed_pending is False
+
+    def test_bogus_seed_self_heals(self):
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        # First raw reading is a lone transient (e.g. the 85 C power-on
+        # default after a brownout); the true temperature is ~25. Two-to-anchor
+        # discards the transient and anchors on the consistent pair that
+        # follows, so the channel never latches.
+        emu.lna.inject_sensor_glitch(85.0)
+        emu.lna.inject_sensor_glitch(25.0, count=2)
+        for _ in range(3):
+            _run_to_pi_tick(emu)
+        assert emu.lna.rate_ref_valid is True
+        assert emu.lna.internally_disabled is False
+        assert emu.lna.sensor_rejects == 0
+        assert emu.lna.T_now == pytest.approx(25.0)
+
+    def test_persistent_disagreement_latches(self):
+        import picohost.emulators.tempctrl as mod
+
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.thermal_frozen = True
+        # A sensor that never produces two consecutive consistent readings
+        # never anchors; each failed confirmation counts toward the same latch.
+        for value in (85.0, 25.0, 85.0, 25.0):
+            emu.lna.inject_sensor_glitch(value)
+        for _ in range(4):
+            _run_to_pi_tick(emu)
+        assert emu.lna.rate_ref_valid is False
+        assert emu.lna.sensor_rejects == mod.MAX_REJECTS
+        assert emu.lna.internally_disabled is True
+        assert emu.get_status()["LNA_status"] == "error"
+
+    def test_no_drive_until_anchored(self):
+        emu = TempCtrlEmulator()
+        emu.lna.T_now = 25.0
+        emu.lna.T_target = 40.0
+        emu.lna.thermal_frozen = True
+        emu.lna.enabled = True
+        # Still seeding: the channel must stay idle even though it is enabled
+        # and far from target — driving on an unconfirmed reading is the bug.
+        _run_to_pi_tick(emu)
+        assert emu.lna.rate_ref_valid is False
+        assert emu.lna.drive == 0.0
+        # Anchored on the second consistent sample → control engages.
+        _run_to_pi_tick(emu)
+        assert emu.lna.rate_ref_valid is True
+        assert emu.lna.drive != 0.0
 
 
 class TestImuEmulator:

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -256,10 +256,10 @@ class TestTempCtrlProtocol:
         emu.server(
             {"LNA_enable": True, "LNA_temp_target": 50.0, "LNA_Ki": 0.1}
         )
-        # Need a full conversion cycle so PI fires at least once and drive
-        # leaves zero (matches firmware: PI only runs on the op tick a
-        # DS18B20 conversion completes).
-        for _ in range(OP_TICKS_PER_CONVERSION + 1):
+        # Two conversion cycles so PI fires and drive leaves zero. The first
+        # fresh conversion only seeds the candidate reference (two-to-anchor);
+        # control engages on the second, mirroring firmware.
+        for _ in range(2 * OP_TICKS_PER_CONVERSION):
             emu.op()
         assert emu.lna.drive != 0.0
         emu.inject_sensor_error("LNA")
@@ -334,7 +334,9 @@ class TestTempCtrlProtocol:
                 "LNA_hysteresis": 0.5,
             }
         )
-        for _ in range(OP_TICKS_PER_CONVERSION):
+        # Two conversions: the first seeds the candidate reference
+        # (two-to-anchor), the second anchors and runs the first PI step.
+        for _ in range(2 * OP_TICKS_PER_CONVERSION):
             emu.op()
         # With Kp=0.2 and T_delta=0.6, drive should be ~0.12 (12 % PWM),
         # not >=0.4 like the old baseline-kick law.

--- a/src/temp_simple.c
+++ b/src/temp_simple.c
@@ -3,6 +3,7 @@
 #include "onewire_library.pio.h"
 #include "ow_rom.h"
 #include <math.h>
+#include <stddef.h>
 
 void temp_sensor_init(TempSensor *sensor, uint gpio_pin, PIO pio, uint sm_offset) {
     sensor->gpio_pin = gpio_pin;
@@ -28,6 +29,24 @@ void temp_sensor_start_conversion(TempSensor *sensor) {
     }
 }
 
+// Dallas/Maxim 1-Wire CRC-8 (polynomial X^8 + X^5 + X^4 + 1, reflected 0x8C,
+// processed LSB-first). The DS18B20 stores the CRC of scratchpad bytes 0..7 in
+// byte 8, so a frame corrupted on the wire (marginal pull-up, line noise) is
+// caught here even though its decoded value may land inside the valid range.
+static uint8_t ow_crc8(const uint8_t *data, size_t len) {
+    uint8_t crc = 0;
+    for (size_t i = 0; i < len; i++) {
+        uint8_t byte = data[i];
+        for (int b = 0; b < 8; b++) {
+            uint8_t mix = (crc ^ byte) & 0x01;
+            crc >>= 1;
+            if (mix) crc ^= 0x8C;
+            byte >>= 1;
+        }
+    }
+    return crc;
+}
+
 bool temp_sensor_read(TempSensor *sensor) {
     // Check if enough time has passed since conversion start
     uint32_t now = to_ms_since_boot(get_absolute_time());
@@ -50,6 +69,23 @@ bool temp_sensor_read(TempSensor *sensor) {
         data[i] = ow_read(&sensor->ow);
     }
 
+    // An all-zero scratchpad has a valid (zero) CRC and decodes to a plausible
+    // 0.0 C, so a stuck-low bus would slip past the CRC check below. Reject it
+    // explicitly before trusting any byte.
+    bool all_zero = true;
+    for (int i = 0; i < 9; i++) {
+        if (data[i] != 0x00) { all_zero = false; break; }
+    }
+    if (all_zero) {
+        sensor->read_error = true;
+        return false;
+    }
+
+    // Reject frames corrupted in transit before trusting any byte.
+    if (ow_crc8(data, 8) != data[8]) {
+        sensor->read_error = true;
+        return false;
+    }
 
     // Convert to temperature
     int16_t raw_temp = (data[1] << 8) | data[0];

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -67,6 +67,10 @@ void init_single_tempctrl(TempControl *tempctrl,
     tempctrl->stall_window_active = false;
     tempctrl->stall_check_T = 0.0;
     tempctrl->stall_check_time = get_absolute_time();
+    tempctrl->runaway_strikes = 0;
+    tempctrl->rate_ref_valid = false;
+    tempctrl->rate_ref_ms = 0;
+    tempctrl->sensor_rejects = 0;
 }
 
 void tempctrl_init(uint8_t app_id) {
@@ -166,12 +170,15 @@ void tempctrl_status(uint8_t app_id) {
     const uint32_t time_lna = temp_sensor_get_conversion_time(&tempctrl_lna.temp_sensor);
     const uint32_t time_load = temp_sensor_get_conversion_time(&tempctrl_load.temp_sensor);
 
-    /* read_error is set/cleared on every temp_sensor_read() attempt, so
-       LNA_status / LOAD_status reflect the most recent attempt rather
-       than a stale timeout window. Matches the per-cycle status contract
-       enforced by eigsep_observing._avg_sensor_values. */
-    const char *status_lna = temp_sensor_has_error(&tempctrl_lna.temp_sensor) ? "error" : "update";
-    const char *status_load = temp_sensor_has_error(&tempctrl_load.temp_sensor) ? "error" : "update";
+    /* internally_disabled is recomputed every op tick from the hardware
+       read error OR a latched sensor-sanity reject (see
+       tempctrl_update_sensor_drive), so LNA_status / LOAD_status reflect the
+       most recent cycle and surface a garbage-but-valid sensor that the bus
+       error alone would miss. Matches the per-cycle status contract enforced
+       by eigsep_observing._avg_sensor_values and the emulator's status
+       derivation. */
+    const char *status_lna = tempctrl_lna.internally_disabled ? "error" : "update";
+    const char *status_load = tempctrl_load.internally_disabled ? "error" : "update";
 
     /* 34 KV pairs: 4 device-wide + 15 per channel * 2 channels. send_json
        silently truncates if the count argument disagrees with the actual
@@ -225,11 +232,39 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
     // it from accumulating ~15x per real sample (op() runs every ~50ms,
     // conversions complete every ~750ms).
     bool fresh = temp_sensor_read(&tempctrl->temp_sensor);
+    bool hw_error = temp_sensor_has_error(&tempctrl->temp_sensor);
 
-    // Update current temperatures
-    tempctrl->T_now = temp_sensor_get_temp(&tempctrl->temp_sensor);
+    // Sensor sanity guard: only consider a fresh, hardware-valid sample.
+    // Reject one whose implied rate of change is physically impossible
+    // (a failing thermistor returning garbage) and hold the last good
+    // T_now; latch the channel after TEMPCTRL_MAX_REJECTS consecutive
+    // rejects. rate_ref_ms advances on every fresh sample so the rate
+    // denominator stays ~one conversion; T_now is the value reference.
+    if (fresh && !hw_error) {
+        float raw = temp_sensor_get_temp(&tempctrl->temp_sensor);
+        uint32_t now_ms = to_ms_since_boot(get_absolute_time());
+        if (!tempctrl->rate_ref_valid) {
+            tempctrl->T_now = raw;
+            tempctrl->rate_ref_valid = true;
+            tempctrl->sensor_rejects = 0;
+        } else {
+            float dt = (float)(now_ms - tempctrl->rate_ref_ms) / 1000.0f;
+            if (dt > 0.0f &&
+                fabsf(raw - tempctrl->T_now) / dt > TEMPCTRL_MAX_RATE_C_PER_S) {
+                // Reject: hold T_now, count toward the latch ceiling.
+                if (tempctrl->sensor_rejects < TEMPCTRL_MAX_REJECTS) {
+                    tempctrl->sensor_rejects++;
+                }
+            } else {
+                tempctrl->T_now = raw;
+                tempctrl->sensor_rejects = 0;
+            }
+        }
+        tempctrl->rate_ref_ms = now_ms;
+    }
 
-    tempctrl->internally_disabled = temp_sensor_has_error(&tempctrl->temp_sensor) ? true : false;
+    tempctrl->internally_disabled =
+        hw_error || (tempctrl->sensor_rejects >= TEMPCTRL_MAX_REJECTS);
 
     if (tempctrl_drive_allowed(tempctrl)) {
         if (fresh) {
@@ -356,11 +391,13 @@ static void tempctrl_check_stall(TempControl *tempctrl) {
     // is the configured refusal-to-cool, not a stall.
     if (!tempctrl->active || tempctrl->drive == 0.0f) {
         tempctrl->stall_window_active = false;
+        tempctrl->runaway_strikes = 0;
         return;
     }
     absolute_time_t now = get_absolute_time();
     if (!tempctrl->stall_window_active) {
         tempctrl->stall_check_T = tempctrl->T_now;
+        tempctrl->stall_check_drive = tempctrl->drive;
         tempctrl->stall_check_time = now;
         tempctrl->stall_window_active = true;
         return;
@@ -369,7 +406,8 @@ static void tempctrl_check_stall(TempControl *tempctrl) {
     if (elapsed_us < (int64_t)TEMPCTRL_STALL_WINDOW_MS * 1000) {
         return;
     }
-    if (fabsf(tempctrl->T_now - tempctrl->stall_check_T) < TEMPCTRL_STALL_MIN_DELTA) {
+    float delta = tempctrl->T_now - tempctrl->stall_check_T;
+    if (fabsf(delta) < TEMPCTRL_STALL_MIN_DELTA) {
         // Drive engaged for a full window with no meaningful temperature
         // movement — sensor stuck or Peltier ineffective. Trip the channel;
         // `enabled` stays as the host set it, and the trip flag is the
@@ -380,11 +418,34 @@ static void tempctrl_check_stall(TempControl *tempctrl) {
         tempctrl->drive = 0.0;
         tempctrl_apply_drive(tempctrl);
         tempctrl->stall_window_active = false;
-    } else {
-        // Healthy: roll the window forward.
-        tempctrl->stall_check_T = tempctrl->T_now;
-        tempctrl->stall_check_time = now;
+        tempctrl->runaway_strikes = 0;
+        return;
     }
+    // Temperature moved. If it moved the *opposite* direction of the drive
+    // (delta * drive < 0) the channel is running away — mis-wired Peltier,
+    // lost hot-side dissipation, or swapped sensor. Score a strike; trip
+    // only after TEMPCTRL_RUNAWAY_STRIKES consecutive wrong-direction
+    // windows so a single startup/soak transient cannot false-trip a
+    // channel that is actually controlling.
+    if (delta * tempctrl->stall_check_drive < 0.0f) {
+        tempctrl->runaway_strikes++;
+        if (tempctrl->runaway_strikes >= TEMPCTRL_RUNAWAY_STRIKES) {
+            tempctrl->stall_tripped = true;
+            tempctrl->active = false;
+            tempctrl->drive = 0.0;
+            tempctrl_apply_drive(tempctrl);
+            tempctrl->stall_window_active = false;
+            tempctrl->runaway_strikes = 0;
+            return;
+        }
+    } else {
+        // Healthy progress in the driven direction — clear any strikes.
+        tempctrl->runaway_strikes = 0;
+    }
+    // Roll the window forward for the next evaluation.
+    tempctrl->stall_check_T = tempctrl->T_now;
+    tempctrl->stall_check_drive = tempctrl->drive;
+    tempctrl->stall_check_time = now;
 }
 
 static void tempctrl_apply_enable(TempControl *tempctrl, bool new_enabled) {
@@ -397,6 +458,9 @@ static void tempctrl_apply_enable(TempControl *tempctrl, bool new_enabled) {
     if (new_enabled) {
         tempctrl->stall_tripped = false;
         tempctrl->stall_window_active = false;
+        tempctrl->runaway_strikes = 0;
+        tempctrl->sensor_rejects = 0;
+        tempctrl->rate_ref_valid = false;
         watchdog_tripped = false;
     }
     tempctrl->enabled = new_enabled;

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -71,6 +71,7 @@ void init_single_tempctrl(TempControl *tempctrl,
     tempctrl->rate_ref_valid = false;
     tempctrl->rate_ref_ms = 0;
     tempctrl->sensor_rejects = 0;
+    tempctrl->sensor_tripped = false;
 }
 
 void tempctrl_init(uint8_t app_id) {
@@ -263,8 +264,15 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
         tempctrl->rate_ref_ms = now_ms;
     }
 
-    tempctrl->internally_disabled =
-        hw_error || (tempctrl->sensor_rejects >= TEMPCTRL_MAX_REJECTS);
+    // hw_error self-clears when the bus read recovers; the rate-sanity latch
+    // is sticky: once sensor_rejects reaches the ceiling, sensor_tripped stays
+    // set until the host acks with *_enable=true (see tempctrl_apply_enable).
+    // A later plausible sample resets sensor_rejects but must not re-enable a
+    // channel whose sensor just produced a burst of garbage.
+    if (tempctrl->sensor_rejects >= TEMPCTRL_MAX_REJECTS) {
+        tempctrl->sensor_tripped = true;
+    }
+    tempctrl->internally_disabled = hw_error || tempctrl->sensor_tripped;
 
     if (tempctrl_drive_allowed(tempctrl)) {
         if (fresh) {
@@ -275,8 +283,13 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
     } else {
         tempctrl_reset_controller_state(tempctrl);
         tempctrl_apply_drive(tempctrl);
-        // Not actively driving — no stall window pending.
+        // Not actively driving — no stall window pending, and any
+        // partial runaway strike count is stale once drive is gated
+        // (disable/error/watchdog). Clearing it here keeps the next
+        // wrong-direction window from tripping early and matches the
+        // emulator's not-drive-allowed branch.
         tempctrl->stall_window_active = false;
+        tempctrl->runaway_strikes = 0;
     }
 }
 
@@ -460,6 +473,7 @@ static void tempctrl_apply_enable(TempControl *tempctrl, bool new_enabled) {
         tempctrl->stall_window_active = false;
         tempctrl->runaway_strikes = 0;
         tempctrl->sensor_rejects = 0;
+        tempctrl->sensor_tripped = false;
         tempctrl->rate_ref_valid = false;
         watchdog_tripped = false;
     }

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -69,6 +69,7 @@ void init_single_tempctrl(TempControl *tempctrl,
     tempctrl->stall_check_time = get_absolute_time();
     tempctrl->runaway_strikes = 0;
     tempctrl->rate_ref_valid = false;
+    tempctrl->seed_pending = false;
     tempctrl->rate_ref_ms = 0;
     tempctrl->sensor_rejects = 0;
     tempctrl->sensor_tripped = false;
@@ -241,13 +242,40 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
     // T_now; latch the channel after TEMPCTRL_MAX_REJECTS consecutive
     // rejects. rate_ref_ms advances on every fresh sample so the rate
     // denominator stays ~one conversion; T_now is the value reference.
+    //
+    // Before the reference is anchored there is nothing to rate-check
+    // against, so the first sample is only a candidate (held in T_now,
+    // timestamp in rate_ref_ms): it becomes the trusted reference once a
+    // second sample confirms it within the rate budget. A candidate that
+    // fails confirmation is replaced and counts toward the same latch
+    // ceiling, so a sensor that can never produce two consistent readings
+    // still latches instead of seeding control from a lone transient.
     if (fresh && !hw_error) {
         float raw = temp_sensor_get_temp(&tempctrl->temp_sensor);
         uint32_t now_ms = to_ms_since_boot(get_absolute_time());
         if (!tempctrl->rate_ref_valid) {
-            tempctrl->T_now = raw;
-            tempctrl->rate_ref_valid = true;
-            tempctrl->sensor_rejects = 0;
+            if (!tempctrl->seed_pending) {
+                // First sample: hold as candidate, await confirmation.
+                tempctrl->T_now = raw;
+                tempctrl->seed_pending = true;
+                tempctrl->sensor_rejects = 0;
+            } else {
+                float dt = (float)(now_ms - tempctrl->rate_ref_ms) / 1000.0f;
+                if (dt > 0.0f &&
+                    fabsf(raw - tempctrl->T_now) / dt > TEMPCTRL_MAX_RATE_C_PER_S) {
+                    // Candidate unconfirmed: replace it, count toward the latch.
+                    tempctrl->T_now = raw;
+                    if (tempctrl->sensor_rejects < TEMPCTRL_MAX_REJECTS) {
+                        tempctrl->sensor_rejects++;
+                    }
+                } else {
+                    // Two consecutive consistent samples: anchor the reference.
+                    tempctrl->T_now = raw;
+                    tempctrl->rate_ref_valid = true;
+                    tempctrl->seed_pending = false;
+                    tempctrl->sensor_rejects = 0;
+                }
+            }
         } else {
             float dt = (float)(now_ms - tempctrl->rate_ref_ms) / 1000.0f;
             if (dt > 0.0f &&
@@ -274,7 +302,11 @@ void tempctrl_update_sensor_drive(TempControl *tempctrl) {
     }
     tempctrl->internally_disabled = hw_error || tempctrl->sensor_tripped;
 
-    if (tempctrl_drive_allowed(tempctrl)) {
+    // rate_ref_valid gates control as well as the guard: until the reference
+    // is anchored T_now is only a candidate, so the channel stays idle (the
+    // not-allowed branch holds drive at 0) rather than driving on an
+    // unconfirmed reading. Costs at most one extra conversion after enable.
+    if (tempctrl_drive_allowed(tempctrl) && tempctrl->rate_ref_valid) {
         if (fresh) {
             tempctrl_pi_drive(tempctrl);
         }
@@ -475,6 +507,7 @@ static void tempctrl_apply_enable(TempControl *tempctrl, bool new_enabled) {
         tempctrl->sensor_rejects = 0;
         tempctrl->sensor_tripped = false;
         tempctrl->rate_ref_valid = false;
+        tempctrl->seed_pending = false;
         watchdog_tripped = false;
     }
     tempctrl->enabled = new_enabled;

--- a/src/tempctrl.h
+++ b/src/tempctrl.h
@@ -107,10 +107,23 @@ typedef struct {
     // Sensor sanity guard state. rate_ref_ms advances on every fresh sample
     // (so the rate denominator is one conversion); T_now itself is the value
     // reference (held on reject). sensor_rejects counts consecutive rejected
-    // samples and latches the channel at TEMPCTRL_MAX_REJECTS.
+    // samples; when it reaches TEMPCTRL_MAX_REJECTS the channel latches via
+    // the sticky sensor_tripped flag. sensor_tripped is cleared only by an
+    // explicit *_enable=true host ack (like stall_tripped), so a sensor that
+    // produced a burst of garbage cannot silently re-enable drive when a
+    // later reading happens to fall back within the rate budget.
+    //
+    // Two-to-anchor seeding: until rate_ref_valid is set, the rate guard has no
+    // reference to check against, so the reference is only trusted once two
+    // consecutive samples agree within the rate budget. seed_pending marks that
+    // a first (candidate) sample has been taken and is awaiting confirmation;
+    // the candidate value lives in T_now and its timestamp in rate_ref_ms (both
+    // unused for control while unanchored). This stops a single transient (e.g.
+    // the 85 C power-on default after a brownout) from poisoning the anchor.
     bool rate_ref_valid;
     uint32_t rate_ref_ms;
     uint8_t sensor_rejects;
+    bool sensor_tripped;
 } TempControl;
 
 // Standard app interface functions

--- a/src/tempctrl.h
+++ b/src/tempctrl.h
@@ -121,6 +121,7 @@ typedef struct {
     // unused for control while unanchored). This stops a single transient (e.g.
     // the 85 C power-on default after a brownout) from poisoning the anchor.
     bool rate_ref_valid;
+    bool seed_pending;
     uint32_t rate_ref_ms;
     uint8_t sensor_rejects;
     bool sensor_tripped;

--- a/src/tempctrl.h
+++ b/src/tempctrl.h
@@ -34,6 +34,33 @@
 #define TEMPCTRL_STALL_WINDOW_MS   60000
 #define TEMPCTRL_STALL_MIN_DELTA   0.5f
 
+// Runaway guard: a channel that is actively driving but whose temperature
+// moves the *opposite* direction of the drive (cooling drive while T rises,
+// or heating drive while T falls) is mis-wired, has lost hot-side
+// dissipation, or has a swapped sensor — a thermal-runaway signature the
+// no-movement stall guard above cannot catch (the temperature is moving, so
+// |delta| stays above TEMPCTRL_STALL_MIN_DELTA). Evaluated on the same
+// stall window: a wrong-direction window scores a strike, and the channel
+// trips (via stall_tripped) after TEMPCTRL_RUNAWAY_STRIKES consecutive
+// strikes. Requiring consecutive windows tolerates the startup transient
+// where T_now lags the junction (heat already in the mass keeps the sensor
+// rising for a window after cooling engages) without false-tripping a
+// channel that is actually controlling.
+#define TEMPCTRL_RUNAWAY_STRIKES   2
+
+// Sensor sanity guard: a DS18B20 that still answers on the bus but returns
+// garbage (a failing thermistor seen cycling 0/40/90 C while the true temp
+// was ~20 C) passes temp_sensor_has_error(), so the raw read would drive the
+// Peltier full-scale on a physically impossible value. Reject any fresh
+// sample whose implied rate of change exceeds TEMPCTRL_MAX_RATE_C_PER_S
+// (well above any real thermal slew — a healthy half-power Peltier moves a
+// few C/min, ~0.1 C/s); hold the last good T_now instead. After
+// TEMPCTRL_MAX_REJECTS consecutive rejects the sensor is treated as failed
+// (internally_disabled), which gates drive and surfaces LNA/LOAD_status as
+// "error". A lone glitch is absorbed without disabling control.
+#define TEMPCTRL_MAX_RATE_C_PER_S  5.0f
+#define TEMPCTRL_MAX_REJECTS       3
+
 // Temperature control structure
 typedef struct {
     uint dir_pin1;
@@ -65,12 +92,25 @@ typedef struct {
     // cooling-mode thermal-runaway failure mode.
     bool cooling_enabled;
     // Stall guard: sticky fault tripped when an active drive fails to move
-    // T_now. Cleared by an explicit *_enable=true command from the host
-    // (mirrors the watchdog ack pattern).
+    // T_now, OR moves it the wrong direction for TEMPCTRL_RUNAWAY_STRIKES
+    // consecutive windows (the runaway signature). Cleared by an explicit
+    // *_enable=true command from the host (mirrors the watchdog ack pattern).
     bool stall_tripped;
     bool stall_window_active;
     float stall_check_T;
+    float stall_check_drive;
     absolute_time_t stall_check_time;
+    // Consecutive wrong-direction windows seen by the runaway guard; reset
+    // by a correct-direction (or no-) movement window, a trip, a disable,
+    // or an enable ack.
+    uint8_t runaway_strikes;
+    // Sensor sanity guard state. rate_ref_ms advances on every fresh sample
+    // (so the rate denominator is one conversion); T_now itself is the value
+    // reference (held on reject). sensor_rejects counts consecutive rejected
+    // samples and latches the channel at TEMPCTRL_MAX_REJECTS.
+    bool rate_ref_valid;
+    uint32_t rate_ref_ms;
+    uint8_t sensor_rejects;
 } TempControl;
 
 // Standard app interface functions


### PR DESCRIPTION
## Why

A field run of `tempctrl_manual` exposed two control-loop safety gaps. Both are fixed in firmware (mirrored in the emulator) because they must act locally, fast, and survive a panda/network loss — exactly like the existing watchdog and stall guards.

### 1. Runaway trip (wrong-direction movement)

The stall guard (`tempctrl_check_stall`) only trips on **no** movement (`|delta| < STALL_MIN_DELTA` over the window). A channel commanded to **cool** that instead **heats and runs away** — lost hot-side dissipation, mis-wired Peltier, or swapped sensor — keeps moving, so stall never fires. Observed on the LNA channel: negative drive, temperature climbing.

`tempctrl_check_stall` now also scores a *strike* when the temperature moves opposite the drive (`delta * drive < 0`) over a completed window, and trips (via the existing sticky `stall_tripped`) after `TEMPCTRL_RUNAWAY_STRIKES` (2) consecutive wrong-direction windows. The consecutive requirement tolerates the startup/soak transient where `T_now` lags the junction (heat already in the mass keeps the sensor rising for a window after cooling engages) without false-tripping a channel that is actually controlling.

### 2. Sensor rate-of-change sanity

A failing thermistor that still answers on the bus with **garbage** (observed cycling 0/40/90 °C while the true temp was ~20 °C) passes `temp_sensor_has_error()`, so the raw read drove the Peltier full-scale and thrashed its polarity — which pegged the PSU current limit.

`tempctrl_update_sensor_drive` now rejects any fresh sample whose implied rate exceeds `TEMPCTRL_MAX_RATE_C_PER_S` (5 °C/s — far above any real thermal slew; a healthy half-power Peltier moves a few °C/min), holding the last good `T_now`. After `TEMPCTRL_MAX_REJECTS` (3) consecutive rejects the channel latches `internally_disabled`, which gates drive. `LNA/LOAD_status` now derives from `internally_disabled` (matching the emulator) so a latched sensor surfaces as status `"error"` — a bus-error-only check would miss garbage-but-valid readings.

## Notes

- Both trips clear on the existing `*_enable=true` host ack.
- **No new status fields**, so the `eigsep_observing` `_PELTIER_SCHEMA` contract is unchanged. Richer stall-vs-runaway-vs-reject telemetry would need coordinated schema fields and is a possible follow-up.
- Companion to EIGSEP/eigsep_observing#140 (which wires the existing `cooling_enabled` asymmetric-clamp guard into config + the bring-up script).

## Test plan

- [x] `cd picohost && pytest tests/test_emulators.py -k TempCtrl` — 45 passed (new runaway + sensor-sanity classes + existing)
- [x] `pytest test_emulators.py test_protocol_conformance.py test_emulator_integration.py test_base.py test_dummy_devices.py` — 240 passed
- [x] `ruff check` / `ruff format --check` clean
- [x] Firmware builds clean for `pico2` (`make` exit 0, no warnings on tempctrl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)