### PR TITLE
ci: add advisory firmware↔emulator parity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,93 @@ jobs:
             exit 1
           fi
           echo "All apps have corresponding emulators."
+
+  emulator-staleness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      BEFORE_SHA: ${{ github.event.before }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so we can diff against the PR base / pushed range.
+          fetch-depth: 0
+      - name: Warn when firmware changed without emulator/conformance updates
+        # Advisory only: this step emits ::warning:: annotations and never
+        # exits non-zero, so it can never block a merge. Flip a warning to a
+        # gate later by adding `exit 1` after the echo.
+        run: |
+          # Compute the changed-file set for this PR or push. Guard the diffs
+          # with `|| true` so a missing base ref degrades to "no changes"
+          # rather than failing the (advisory) job under bash -e.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            changed=$(git diff --name-only "$BASE_SHA"...HEAD || true)
+          else
+            before="$BEFORE_SHA"
+            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              before=$(git rev-parse HEAD~1 2>/dev/null || echo "")
+            fi
+            if [ -n "$before" ]; then
+              changed=$(git diff --name-only "$before" HEAD || true)
+            else
+              changed=""
+            fi
+          fi
+
+          changed_has() {
+            printf '%s\n' "$changed" | grep -qxF "$1"
+          }
+
+          # Resolve the distinct emulator targets using the same app->emulator
+          # resolution as the emulator-coverage job, including the
+          # "// emulator: <name>" alias annotations in src/pico_multi.h.
+          apps=$(grep -oP '(?<=#define APP_)\w+' src/pico_multi.h | tr '[:upper:]' '[:lower:]')
+          targets=""
+          for app in $apps; do
+            alias=$(grep -iP "#define APP_${app}\b" src/pico_multi.h | grep -oP '//\s*emulator:\s*\K\w+' || true)
+            target=${alias:-$app}
+            case " $targets " in
+              *" $target "*) ;;
+              *) targets="$targets $target" ;;
+            esac
+          done
+
+          tests="picohost/tests/test_protocol_conformance.py picohost/tests/test_emulators.py"
+          warned=0
+          for target in $targets; do
+            # Firmware files for this target, plus documented shared deps.
+            fw="src/${target}.c src/${target}.h"
+            if [ "$target" = "tempctrl" ]; then
+              fw="$fw src/temp_simple.c src/temp_simple.h src/ds18b20.h"
+            fi
+            emu="picohost/src/picohost/emulators/${target}.py"
+
+            fw_changed=0
+            for f in $fw; do
+              if changed_has "$f"; then fw_changed=1; break; fi
+            done
+            if [ "$fw_changed" -eq 0 ]; then
+              continue
+            fi
+
+            if changed_has "$emu"; then
+              continue
+            fi
+
+            tests_changed=0
+            for f in $tests; do
+              if changed_has "$f"; then tests_changed=1; break; fi
+            done
+            if [ "$tests_changed" -eq 1 ]; then
+              continue
+            fi
+
+            echo "::warning::Firmware '${target}' changed but its emulator and conformance tests are untouched — verify parity."
+            warned=1
+          done
+
+          if [ "$warned" -eq 0 ]; then
+            echo "No firmware/emulator staleness detected."
+          fi

--- a/.github/workflows/claude-emulator-parity.yml
+++ b/.github/workflows/claude-emulator-parity.yml
@@ -27,6 +27,8 @@ jobs:
           fetch-depth: 1
 
       - name: Claude firmware/emulator parity review
+        if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        continue-on-error: true
         id: claude-emulator-parity
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-emulator-parity.yml
+++ b/.github/workflows/claude-emulator-parity.yml
@@ -1,0 +1,69 @@
+name: Claude Emulator Parity
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Only run when firmware or an emulator changes — the two sides of the
+    # equivalence contract.
+    paths:
+      - "src/**"
+      - "picohost/src/picohost/emulators/**"
+
+jobs:
+  emulator-parity:
+    # Advisory review: posts a PR comment, never blocks the merge.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude firmware/emulator parity review
+        id: claude-emulator-parity
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are reviewing a pull request for the EIGSEP Raspberry Pi Pico
+            firmware project. Your single job is to check whether each firmware
+            app and its Python emulator still behave equivalently.
+
+            Background: every firmware app (`src/<target>.c`) has a Python
+            emulator (`picohost/src/picohost/emulators/<target>.py`) that must
+            reproduce its behavioral contract. The written reference for that
+            contract lives in `picohost/tests/test_protocol_conformance.py`.
+            Several apps can share one emulator via a `// emulator: <name>`
+            annotation in `src/pico_multi.h` (e.g. APP_IMU_EL and APP_IMU_AZ
+            both map to the `imu` emulator).
+
+            Do the following:
+            1. Inspect this PR's diff to determine which emulator target(s) it
+               touches — on either the firmware side (`src/**`) or the emulator
+               side (`picohost/src/picohost/emulators/**`). Resolve any
+               `// emulator:` aliases in `src/pico_multi.h`.
+            2. For each touched target, read `src/<target>.c` (plus any shared
+               firmware deps it relies on — e.g. `tempctrl` also uses
+               `src/temp_simple.c` and `src/ds18b20.h`) and
+               `picohost/src/picohost/emulators/<target>.py` side by side.
+            3. Compare their behavioral contract: command handling, status
+               field names/values, defaults, clamps/validation, and edge
+               cases. Use `picohost/tests/test_protocol_conformance.py` as the
+               written reference for what parity means.
+            4. Post exactly ONE concise PR comment summarizing your findings:
+               - list concrete divergences, each with a `file:line` reference,
+                 OR
+               - state explicitly that no divergences were found.
+               When firmware behavior changed, also note whether
+               `picohost/tests/test_protocol_conformance.py` needs a matching
+               update, so the comment is actionable.
+
+            Keep the comment focused and short. Do not modify any files. This is
+            an advisory review — do not fail the build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ The boundary between `picohost` and the sister `eigsep_observing` repo is drawn 
 ## CI / Release
 
 - **CI**: GitHub Actions runs pytest across Python 3.9-3.12 on every push/PR, plus a check that every firmware app has a corresponding emulator
+- **Emulator parity (advisory, never blocks)**: two complementary checks verify that a firmware app and its emulator stay behaviorally equivalent. The `emulator-staleness` job in `ci.yml` emits a `::warning::` when a firmware target changes but its emulator and the conformance tests (`test_protocol_conformance.py`, `test_emulators.py`) are untouched. The `claude-emulator-parity.yml` workflow runs a Claude semantic review on PRs that touch `src/**` or `emulators/**`, posting one PR comment naming concrete divergences (or confirming none)
 - **Release**: release-please automates version bumps and changelogs
 - **Conventional commits**: Use conventional commit prefixes — `fix:`, `feat:`, `chore:`, `test:`, `ci:`, `docs:`, `refactor:`, etc. release-please uses these to determine version bumps and generate changelogs
 


### PR DESCRIPTION
## Summary

Implements the approved design in `docs/superpowers/specs/2026-06-02-firmware-emulator-equivalence-ci-design.md`: two complementary, **advisory (never-blocking)** checks that verify a firmware app and its Python emulator stay behaviorally equivalent.

- **`emulator-staleness` job** (`.github/workflows/ci.yml`, beside `emulator-coverage`): reuses the existing app→emulator `// emulator:` alias resolution to derive the distinct targets (`motor`, `tempctrl`, `potmon`, `imu`, `lidar`, `rfswitch`), then emits a `::warning::` when a target's firmware changed but its emulator **and** both conformance tests (`test_protocol_conformance.py`, `test_emulators.py`) were untouched. Handles `tempctrl`'s documented shared deps (`temp_simple.{c,h}`, `ds18b20.h`). Runs on PRs and pushes to `main`; never exits non-zero (flip to a gate later with one `exit 1`).
- **`claude-emulator-parity.yml`** (new): Claude semantic review on PRs touching `src/**` or `emulators/**`, skips dependabot, reads firmware and emulator side by side using `test_protocol_conformance.py` as the contract reference, and posts **one** PR comment naming concrete `file:line` divergences (or confirming none), flagging conformance-test updates when firmware behavior changed.
- **`CLAUDE.md`**: documents both checks under CI / Release.

## Test Plan

- [x] Both workflow files parse as valid YAML.
- [x] Staleness detection verified against 12 cases under `bash -eo pipefail` (GitHub Actions' shell): warns for `src/motor.c`-only (criterion 1), no warning when `motor.py` or a conformance test is also touched (criterion 2), alias resolution (`src/imu.c`→`imu`), shared-dep detection (`temp_simple.c`/`ds18b20.h`→`tempctrl`), multi-target, and `rc=0` in every case.
- [x] Real `git diff` end-to-end run on this branch yields no false positive (only non-firmware files changed).
- [x] Full pytest suite: 383 passed, no regression.
- [ ] After merge: confirm a PR editing `src/motor.c` alone surfaces the staleness warning and the Claude parity job posts a single comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)