### PR TITLE
feat(picohost): declare gpiozero runtime dependency

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -21,6 +21,12 @@ dependencies = [
   "numpy",
   "pyserial",
   "eigsep_redis>=2.3.0",
+  # Pi-side GPIO control. Pure-python; the pin factory backend (lgpio
+  # on the field image, via eigsep-field's [hardware.lgpio]) is
+  # supplied by the deployment, not declared here — PyPI lgpio ships
+  # no cp313 wheel, so declaring it would break eigsep-field's
+  # wheelhouse build. Tests use GPIOZERO_PIN_FACTORY=mock.
+  "gpiozero>=2",
 ]
 
 [project.scripts]

--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   # on the field image, via eigsep-field's [hardware.lgpio]) is
   # supplied by the deployment, not declared here — PyPI lgpio ships
   # no cp313 wheel, so declaring it would break eigsep-field's
-  # wheelhouse build. Tests use GPIOZERO_PIN_FACTORY=mock.
+  # wheelhouse build. For tests/dev on non-Pi systems, set GPIOZERO_PIN_FACTORY=mock.
   "gpiozero>=2",
 ]
 

--- a/picohost/uv.lock
+++ b/picohost/uv.lock
@@ -25,6 +25,18 @@ wheels = [
 ]
 
 [[package]]
+name = "colorzero"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/ca/688824a06e8c4d04c7d2fd2af2d8da27bed51af20ee5f094154e1d680334/colorzero-2.0.tar.gz", hash = "sha256:e7d5a5c26cd0dc37b164ebefc609f388de24f8593b659191e12d85f8f9d5eb58", size = 25382, upload-time = "2021-03-15T23:42:23.261Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/a6/ddd0f130e44a7593ac6c55aa93f6e256d2270fd88e9d1b64ab7f22ab8fde/colorzero-2.0-py2.py3-none-any.whl", hash = "sha256:0e60d743a6b8071498a56465f7719c96a5e92928f858bab1be2a0d606c9aa0f8", size = 26573, upload-time = "2021-03-15T23:42:21.757Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -178,6 +190,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[[package]]
+name = "gpiozero"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorzero" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/334b8db8a981eca9a0fb1e7e48e1997a5eaa8f40bb31c504299dcca0e6ff/gpiozero-2.0.1.tar.gz", hash = "sha256:d4ea1952689ec7e331f9d4ebc9adb15f1d01c2c9dcfabb72e752c9869ab7e97e", size = 136176, upload-time = "2024-02-15T11:07:02.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/eb/6518a1b00488d48995034226846653c382d676cf5f04be62b3c3fae2c6a1/gpiozero-2.0.1-py3-none-any.whl", hash = "sha256:8f621de357171d574c0b7ea0e358cb66e560818a47b0eeedf41ce1cdbd20c70b", size = 150818, upload-time = "2024-02-15T11:07:00.451Z" },
 ]
 
 [[package]]
@@ -351,6 +375,7 @@ version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },
+    { name = "gpiozero" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyserial" },
@@ -370,6 +395,7 @@ dev = [
 requires-dist = [
     { name = "eigsep-redis", specifier = ">=2.3.0" },
     { name = "fakeredis", marker = "extra == 'dev'" },
+    { name = "gpiozero", specifier = ">=2" },
     { name = "numpy" },
     { name = "pyserial" },
     { name = "pyserial-mock", marker = "extra == 'dev'", specifier = ">=1.0.0" },
@@ -495,6 +521,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
     { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `gpiozero>=2` to picohost's runtime dependencies (Pi-side GPIO control) and relocks `uv.lock`.
- The pin-factory backend (`lgpio`) is deliberately **not** declared: PyPI lgpio ships no cp313 wheel, so a hard dep would break eigsep-field's `--only-binary` wheelhouse build. The field image supplies it out-of-band via `[hardware.lgpio]` (same pattern as casperfpga) — see the companion eigsep-field PR.
- Tests/dev use `GPIOZERO_PIN_FACTORY=mock`, which needs no backend.

## Test Plan
- [x] `uv sync --frozen --extra dev && uv run pytest` — 397 passed (same as baseline)
- [x] `import gpiozero` + mock pin factory drives a pin in the synced env

🤖 Generated with [Claude Code](https://claude.com/claude-code)