### PR TITLE
feat(flash_picos): GPIO mass-BOOTSEL flash flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ coverage.xml
 
 # Claude Code
 .claude/
+docs/superpowers/
 
 # IDE
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,18 @@ The build produces `build/pico_multi.uf2` which can be flashed to the Pico by co
 # ships with Raspberry Pi OS)
 flash-picos --uf2 build/pico_multi.uf2
 
+# Hosts without the GPIO wiring: per-device USB reboot path
+flash-picos --uf2 build/pico_multi.uf2 --no-gpio
+
+# Target a single Pico (automatically uses the USB path)
+flash-picos --uf2 build/pico_multi.uf2 --usb-serial <ID>
+
 # Flash with custom parameters
 flash-picos --uf2 build/pico_multi.uf2 --baud 115200 --timeout 10
+
+# Drive the shared GPIO lines directly (all bussed Picos at once)
+pico-gpio bootsel   # everyone into BOOTSEL (2e8a:000f)
+pico-gpio reset     # mass reboot into current firmware
 
 # Monitor serial output (adjust /dev/ttyACM0 as needed)
 minicom -D /dev/ttyACM0 -b 115200

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,12 +180,16 @@ with MotorDevice() as motor:
 
 ### flash-picos
 
-CLI tool (installed as `flash-picos` entry point from picohost package) for flashing and configuring multiple Picos:
-- Uses `picotool` to flash via USB serial number
-- Reads JSON device info from each Pico after flashing
-- Updates `devices_info.json` with device configurations
-- Supports both BOOTSEL and CDC serial mode Picos
-- Automatically discovers connected Picos
+CLI tool (installed as `flash-picos` entry point from picohost package) for flashing and configuring multiple Picos. Two flash paths:
+- **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. One GPIO sequence (reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then one mass reset boots everything. Fails fast with a pointer to `--no-gpio` if no GPIO backend is available
+- **USB per-device (`--no-gpio`, or automatic with `--port`/`--usb-serial`)**: reboots each CDC Pico into BOOTSEL via `picotool reboot --bus/--address`, then loads — for hosts without the GPIO wiring
+- `picotool` targets devices by USB bus/address resolved from sysfs (never `--ser`, whose descriptor read corrupts under hub contention)
+- Reads JSON device info from each Pico after flashing and publishes the device list to Redis (optionally `--output-file`)
+- Automatically discovers connected Picos (CDC via pyserial, BOOTSEL via sysfs)
+
+### pico-gpio
+
+Standalone CLI over the same GPIO module: `pico-gpio bootsel` puts all bussed Picos into BOOTSEL, `pico-gpio reset` mass-reboots them.
 
 ### Python Host Library (picohost)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ The build produces `build/pico_multi.uf2` which can be flashed to the Pico by co
 ### Flashing and Development Commands
 
 ```bash
-# Flash multiple Picos at once
+# Flash all Picos at once (GPIO mass-BOOTSEL — default on the hub;
+# requires the bussed BOOTSEL/RUN wiring and the `pinctrl` CLI that
+# ships with Raspberry Pi OS)
 flash-picos --uf2 build/pico_multi.uf2
 
 # Flash with custom parameters
@@ -181,7 +183,7 @@ with MotorDevice() as motor:
 ### flash-picos
 
 CLI tool (installed as `flash-picos` entry point from picohost package) for flashing and configuring multiple Picos. Two flash paths:
-- **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. One GPIO sequence (reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then one mass reset boots everything. Fails fast with a pointer to `--no-gpio` if no GPIO backend is available
+- **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. The lines are driven through the `pinctrl` CLI (`pinctrl set 17/18 op dh|dl`), so there is no GPIO library or pin-factory backend to install. One GPIO sequence (`17 dh → 18 dh → 17 dl → 18 dl`, i.e. reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then one mass reset boots everything. Fails fast with a pointer to `--no-gpio` if `pinctrl` is not on PATH
 - **USB per-device (`--no-gpio`, or automatic with `--port`/`--usb-serial`)**: reboots each CDC Pico into BOOTSEL via `picotool reboot --bus/--address`, then loads — for hosts without the GPIO wiring
 - `picotool` targets devices by USB bus/address resolved from sysfs (never `--ser`, whose descriptor read corrupts under hub contention)
 - Reads JSON device info from each Pico after flashing and publishes the device list to Redis (optionally `--output-file`)

--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -35,6 +35,7 @@ flash-test = "picohost.flash_test:main"
 pico-manager = "picohost.manager:main"
 calibrate-pot = "picohost.calibrate_pot:main"
 picohost-resolve = "picohost.resolve:main"
+pico-gpio = "picohost.gpio:main"
 
 [project.optional-dependencies]
 dev = [

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # USB IDs for Raspberry Pi Pico
 PICO_VID = 0x2E8A
 PICO_PID_CDC = 0x0009  # CDC mode (serial)
-PICO_PID_BOOTSEL = 0x0003  # BOOTSEL mode
+PICO_PID_BOOTSEL = 0x000F  # RP2350 BOOTSEL mode (RP2040 was 0x0003)
 
 
 def redis_handler(writer):

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -505,6 +505,154 @@ def flash_and_discover(
     return all_devices
 
 
+def _load_bootsel_device(
+    dev,
+    uf2_path,
+    attempts=_FLASH_MAX_ATTEMPTS,
+    backoff=_FLASH_RETRY_BACKOFF_S,
+):
+    """Load *uf2_path* onto the BOOTSEL device *dev* (no execute).
+
+    Plain ``picotool load`` does not re-enumerate the device, so the
+    bus/address normally stay valid; between retries the address is
+    nonetheless re-resolved from sysfs (by serial, when the device has
+    one) in case the device dropped and re-enumerated meanwhile.
+
+    Returns True on success, False once *attempts* are exhausted.
+    """
+    bus, address = dev["bus"], dev["address"]
+    serial = dev["usb_serial"]
+    for attempt in range(1, attempts + 1):
+        res = _picotool_load(bus, address, uf2_path, execute=False)
+        if res.returncode == 0:
+            return True
+        logger.warning(
+            "picotool load failed on serial=%s (bus=%d address=%d) "
+            "(attempt %d/%d): %s",
+            serial,
+            bus,
+            address,
+            attempt,
+            attempts,
+            (res.stdout or "").strip(),
+        )
+        if attempt < attempts:
+            time.sleep(backoff * attempt)
+            if serial is not None:
+                for d in _find_bootsel_devices():
+                    if d["usb_serial"] == serial:
+                        bus, address = d["bus"], d["address"]
+                        break
+    return False
+
+
+def flash_and_discover_gpio(
+    uf2_path="build/pico_multi.uf2",
+    baud=115200,
+    timeout=10,
+):
+    """Mass-flash all Picos via the bussed GPIO BOOTSEL/RUN lines.
+
+    Unlike :func:`flash_and_discover`, this never reboots devices over
+    USB — the per-device ``picotool reboot`` round-trips are what fall
+    over on the observatory's contended hub. Three phases:
+
+    1. Snapshot CDC Picos (best effort, for a missing-device warning),
+       drive every Pico into BOOTSEL at once via the shared GPIO lines
+       (works even for wedged/bricked firmware), and wait for the
+       BOOTSEL set to settle in sysfs.
+    2. ``picotool load`` each device by bus/address — without ``-x``,
+       so nothing re-enumerates and the bus stays quiet while every
+       device is idle mass-storage.
+    3. One mass GPIO reset boots all Picos into the new firmware
+       simultaneously; then read each device's JSON over serial.
+
+    Returns the device info dicts (``app_id``, ``port``,
+    ``usb_serial``) for every Pico that flashed and re-enumerated.
+
+    Raises ``FileNotFoundError`` for a missing UF2 and ``RuntimeError``
+    when no Pico enters BOOTSEL (bad wiring, or no GPIO access).
+    """
+    from . import gpio  # deferred so --no-gpio paths never need gpiozero
+
+    uf2_path = Path(uf2_path)
+    if not uf2_path.is_file():
+        raise FileNotFoundError(f"UF2 file not found: {uf2_path}")
+
+    # Phase 1: everyone into BOOTSEL via the shared lines.
+    snapshot = find_pico_ports()
+    gpio.enter_bootsel()
+    bootsel_devices = _wait_for_stable_bootsel_set()
+    if not bootsel_devices:
+        raise RuntimeError(
+            "no Picos entered BOOTSEL after the mass GPIO entry; check "
+            "the BOOTSEL/RUN wiring or re-run with --no-gpio"
+        )
+    seen = {d["usb_serial"] for d in bootsel_devices}
+    missing = sorted(set(snapshot.values()) - seen)
+    if missing:
+        logger.warning(
+            "CDC Picos missing from the BOOTSEL set: %s",
+            ", ".join(missing),
+        )
+    logger.info(
+        "Flashing %d Pico(s) in BOOTSEL: %s",
+        len(bootsel_devices),
+        ", ".join(str(d["usb_serial"]) for d in bootsel_devices),
+    )
+
+    # Phase 2: load each device over a quiet bus (no -x: everything
+    # stays in BOOTSEL until the mass reset below).
+    flashed = []
+    for dev in bootsel_devices:
+        if _load_bootsel_device(dev, uf2_path):
+            flashed.append(dev)
+        else:
+            logger.error(
+                "giving up on serial=%s (bus=%d address=%d); it will "
+                "mass-reset with the others — re-run flash-picos to "
+                "retry it",
+                dev["usb_serial"],
+                dev["bus"],
+                dev["address"],
+            )
+
+    # Phase 3: one reset pulse boots the whole fleet, then read device
+    # info from each flashed Pico.
+    gpio.reset()
+    all_devices = []
+    for dev in flashed:
+        serial = dev["usb_serial"]
+        if serial is None:
+            logger.warning(
+                "flashed Pico at bus=%d address=%d has no USB serial; "
+                "cannot map it to a CDC port for the device-info read",
+                dev["bus"],
+                dev["address"],
+            )
+            continue
+        current_port = _resolve_post_flash_port(serial)
+        if current_port is None:
+            logger.error(
+                f"Pico serial={serial} did not re-enumerate within "
+                f"{_REENUMERATE_TIMEOUT_S}s after the mass reset; "
+                "skipping"
+            )
+            continue
+        _udev_settle()
+        try:
+            data = read_json_from_serial(current_port, baud, timeout)
+        except (RuntimeError, OSError) as e:
+            logger.error(f"Serial read failed on {current_port}: {e}")
+            continue
+        data["port"] = current_port
+        data["usb_serial"] = serial
+        all_devices.append(data)
+        logger.info(f"Read device info from {current_port}")
+
+    return all_devices
+
+
 def _publish_to_redis(devices, host, port):
     """Publish *devices* to Redis via :class:`PicoConfigStore`.
 
@@ -518,7 +666,7 @@ def _publish_to_redis(devices, host, port):
     return store
 
 
-def main():
+def main(argv=None):
     p = argparse.ArgumentParser(
         description=(
             "Flash all attached Picos, read JSON from each, and publish "
@@ -583,22 +731,59 @@ def main():
             "Not required — PicoManager reads from Redis directly."
         ),
     )
-    args = p.parse_args()
+    p.add_argument(
+        "--no-gpio",
+        action="store_true",
+        help=(
+            "Skip the GPIO mass-BOOTSEL flash flow and reboot each "
+            "Pico into BOOTSEL over USB instead. Required on hosts "
+            "without the bussed BOOTSEL/RUN wiring."
+        ),
+    )
+    args = p.parse_args(argv)
 
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
-    try:
-        all_devices = flash_and_discover(
-            uf2_path=args.uf2,
-            port=args.port,
-            usb_serial=args.usb_serial,
-            baud=args.baud,
-            timeout=args.timeout,
+    targeting = bool(args.port or args.usb_serial)
+    use_gpio = not args.no_gpio and not targeting
+    if targeting and not args.no_gpio:
+        logger.info(
+            "--port/--usb-serial target a single Pico; using the USB "
+            "per-device flash path (the GPIO mass reset cannot target "
+            "one Pico)"
         )
-    except FileNotFoundError as e:
+    if use_gpio:
+        from . import gpio  # deferred so --no-gpio never needs gpiozero
+
+        if not gpio.available():
+            print(
+                "GPIO backend unavailable (gpiozero could not load a "
+                "pin factory). On the Pi hub, install lgpio; elsewhere "
+                "re-run with --no-gpio to use the USB per-device flash "
+                "path.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    try:
+        if use_gpio:
+            all_devices = flash_and_discover_gpio(
+                uf2_path=args.uf2,
+                baud=args.baud,
+                timeout=args.timeout,
+            )
+        else:
+            all_devices = flash_and_discover(
+                uf2_path=args.uf2,
+                port=args.port,
+                usb_serial=args.usb_serial,
+                baud=args.baud,
+                timeout=args.timeout,
+            )
+    except (FileNotFoundError, RuntimeError) as e:
         print(str(e), file=sys.stderr)
         sys.exit(1)
 

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -129,9 +129,7 @@ def _find_bootsel_devices(sysfs_root=None):
             address = int((entry / "devnum").read_text().strip())
         except (OSError, ValueError):
             continue
-        devices.append(
-            {"usb_serial": serial, "bus": bus, "address": address}
-        )
+        devices.append({"usb_serial": serial, "bus": bus, "address": address})
     devices.sort(key=lambda d: (d["bus"], d["address"]))
     return devices
 
@@ -190,9 +188,7 @@ def _wait_for_stable_bootsel_set(
     stable_since = None
     while time.monotonic() < deadline:
         devices = _find_bootsel_devices()
-        keys = {
-            (d["usb_serial"], d["bus"], d["address"]) for d in devices
-        }
+        keys = {(d["usb_serial"], d["bus"], d["address"]) for d in devices}
         now = time.monotonic()
         if keys != last_keys:
             last_keys = keys
@@ -267,17 +263,21 @@ def flash_uf2(
         bus, address, in_bootsel = _resolve_bus_address(usb_serial)
         if bus is None:
             detail = (
-                f"serial={usb_serial} not visible as a "
-                f"Pico (2e8a) USB device"
+                f"serial={usb_serial} not visible as a Pico (2e8a) USB device"
             )
             logger.warning("%s (attempt %d/%d)", detail, attempt, attempts)
         else:
             if not in_bootsel:
                 rb = subprocess.run(
                     [
-                        "picotool", "reboot", "-u", "-f",
-                        "--bus", str(bus),
-                        "--address", str(address),
+                        "picotool",
+                        "reboot",
+                        "-u",
+                        "-f",
+                        "--bus",
+                        str(bus),
+                        "--address",
+                        str(address),
                     ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
@@ -512,8 +512,7 @@ def _read_fleet_cdc(expected, baud, timeout):
         ports = find_pico_ports()
     if len(ports) < expected:
         logger.warning(
-            "only %d of %d flashed Pico(s) re-enumerated as CDC within "
-            "%.0fs",
+            "only %d of %d flashed Pico(s) re-enumerated as CDC within %.0fs",
             len(ports),
             expected,
             _CDC_DISCOVER_TIMEOUT_S,

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -573,7 +573,7 @@ def flash_and_discover_gpio(
     Raises ``FileNotFoundError`` for a missing UF2 and ``RuntimeError``
     when no Pico enters BOOTSEL (bad wiring, or no GPIO access).
     """
-    from . import gpio  # deferred so --no-gpio paths never need gpiozero
+    from . import gpio  # deferred so --no-gpio paths never import gpio
 
     uf2_path = Path(uf2_path)
     if not uf2_path.is_file():
@@ -756,14 +756,14 @@ def main(argv=None):
             "one Pico)"
         )
     if use_gpio:
-        from . import gpio  # deferred so --no-gpio never needs gpiozero
+        from . import gpio  # deferred so --no-gpio paths never import gpio
 
         if not gpio.available():
             print(
-                "GPIO backend unavailable (gpiozero could not load a "
-                "pin factory). On the Pi hub, install lgpio; elsewhere "
-                "re-run with --no-gpio to use the USB per-device flash "
-                "path.",
+                "GPIO backend unavailable: the `pinctrl` CLI was not "
+                "found on PATH. Run on the Pi hub (pinctrl ships with "
+                "Raspberry Pi OS), or re-run with --no-gpio to use the "
+                "USB per-device flash path.",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -17,8 +17,10 @@ from .keys import PICO_CONFIG_KEY
 logger = logging.getLogger(__name__)
 
 PICO_VID = 0x2E8A  # Raspberry Pi Foundation USB vendor ID
-PICO_PID_BOOTSEL = 0x0003  # BOOTSEL-mode PID
+PICO_PID_BOOTSEL = 0x000F  # RP2350 BOOTSEL-mode PID (RP2040 was 0x0003)
 PICO_PID_CDC = 0x0009  # CDC serial mode PID
+
+SYSFS_USB_DEVICES = Path("/sys/bus/usb/devices")
 
 
 def find_pico_ports():
@@ -27,9 +29,9 @@ def find_pico_ports():
     ports whose USB VID/PID matches a Pico running CDC firmware
     (VID 0x2E8A, PID 0x0009).
 
-    BOOTSEL-mode Picos (PID 0x0003) are mass-storage devices and do
-    not appear in ``list_ports.comports()`` at all — use ``flash-test``
-    to install a CDC-capable image first.
+    BOOTSEL-mode Picos (PID 0x000F on RP2350) are mass-storage devices
+    and do not appear in ``list_ports.comports()`` at all — use
+    ``flash-test`` to install a CDC-capable image first.
     """
     ports = {}
     for info in list_ports.comports():
@@ -38,60 +40,134 @@ def find_pico_ports():
     return ports
 
 
+def _resolve_bus_address(usb_serial, sysfs_root=None):
+    """Return ``(bus, address, in_bootsel)`` for the Pico *usb_serial*.
+
+    Reads USB topology from Linux sysfs and matches the device — in
+    either CDC (``2e8a:0009``) or BOOTSEL (``2e8a:000f``) mode — whose
+    serial equals *usb_serial*. ``in_bootsel`` is ``True`` when the match
+    is a BOOTSEL device.
+
+    picotool's ``--ser`` selector is unreliable on a busy hub: matching
+    by serial forces a USB serial-string descriptor read that
+    intermittently fails under bus contention, so ``picotool load``
+    cannot find the device to flash. Selecting by ``--bus``/``--address``
+    needs no descriptor read and is reliable. Each flash re-enumerates
+    the Pico to a new USB address, so callers must re-resolve before
+    every attempt.
+
+    Matching BOOTSEL devices too lets a retry finish a load on a device a
+    prior attempt left in BOOTSEL (no reboot needed) rather than
+    stranding it: a BOOTSEL device is invisible to :func:`find_pico_ports`
+    and would otherwise need a separate ``flash-test`` pass to recover.
+
+    Returns ``(None, None, None)`` if no matching device is present
+    (e.g. the target is momentarily mid-reboot, or sysfs is absent).
+    """
+    if sysfs_root is None:
+        sysfs_root = SYSFS_USB_DEVICES
+    sysfs_root = Path(sysfs_root)
+    if not sysfs_root.is_dir():
+        return (None, None, None)
+    cdc_pid = f"{PICO_PID_CDC:04x}"
+    bootsel_pid = f"{PICO_PID_BOOTSEL:04x}"
+    for entry in sorted(sysfs_root.iterdir()):
+        try:
+            vid = (entry / "idVendor").read_text().strip().lower()
+            pid = (entry / "idProduct").read_text().strip().lower()
+        except (OSError, ValueError):
+            continue
+        if vid != "2e8a" or pid not in (cdc_pid, bootsel_pid):
+            continue
+        try:
+            serial = (entry / "serial").read_text().strip()
+        except OSError:
+            continue
+        if serial != usb_serial:
+            continue
+        try:
+            bus = int((entry / "busnum").read_text().strip())
+            address = int((entry / "devnum").read_text().strip())
+        except (OSError, ValueError):
+            return (None, None, None)
+        return (bus, address, pid == bootsel_pid)
+    return (None, None, None)
+
+
 _FLASH_MAX_ATTEMPTS = 3
 _FLASH_RETRY_BACKOFF_S = 2.0
 
 
 def flash_uf2(
     uf2_path,
-    serial,
+    usb_serial,
     attempts=_FLASH_MAX_ATTEMPTS,
     backoff=_FLASH_RETRY_BACKOFF_S,
 ):
-    """
-    Flash the UF2 onto the Pico whose USB serial number is `serial`,
-    using picotool's --ser selector.
+    """Flash the UF2 onto the Pico with USB serial *usb_serial*.
 
-    ``picotool load -f`` reboots the target into BOOTSEL and must then
-    re-discover it as a BOOTSEL device before loading. On a busy USB
-    bus — e.g. several Picos behind a hub on a Raspberry Pi — that
-    re-enumeration can land outside picotool's internal discovery
-    window, so the load fails intermittently with "No accessible
-    RP-series devices in BOOTSEL mode were found".
+    Selects the target by USB ``--bus``/``--address`` (resolved from
+    sysfs via :func:`_resolve_bus_address`) rather than picotool's
+    ``--ser``. On the observatory's deep USB hub, ``--ser`` matching
+    forces a serial-string descriptor read that intermittently fails, so
+    ``picotool load -f --ser`` cannot find the device to reboot into
+    BOOTSEL — the original cause of the "random which Pico flashes"
+    failures. ``--bus``/``--address`` needs no descriptor read.
 
-    We retry with linear backoff. On a retry the target is already
-    sitting in BOOTSEL (the earlier attempt's reset took effect), so
-    picotool only has to *find* it — which usually succeeds once the
-    bus has quieted, without another reset round-trip.
+    When the device is in CDC mode, ``picotool load -f`` reboots it into
+    BOOTSEL (RP2350 enumerates as ``2e8a:000f``), loads, and reboots back
+    to the app — re-enumerating to a *new* USB address each time. The
+    address is therefore re-resolved before every attempt. If a prior
+    attempt left the device in BOOTSEL, it is loaded directly (without
+    ``-f``); a target momentarily mid-reboot (no sysfs node) is treated
+    as a failed attempt and retried with linear backoff.
     """
-    cmd = f"picotool load -f --ser {serial} -x {uf2_path}".split()
-    print(f"Flashing {uf2_path} → serial={serial}")
-    res = None
+    print(f"Flashing {uf2_path} → serial={usb_serial}")
+    detail = ""
     for attempt in range(1, attempts + 1):
-        res = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            errors="replace",
-        )
-        if res.returncode == 0:
-            print(res.stdout, end="")
-            return
-        if attempt < attempts:
-            delay = backoff * attempt
+        bus, address, in_bootsel = _resolve_bus_address(usb_serial)
+        if bus is None:
+            detail = (
+                f"serial={usb_serial} not visible as a "
+                f"Pico (2e8a) USB device"
+            )
+            logger.warning("%s (attempt %d/%d)", detail, attempt, attempts)
+        else:
+            cmd = ["picotool", "load"]
+            if not in_bootsel:
+                cmd.append("-f")
+            cmd += [
+                "--bus", str(bus),
+                "--address", str(address),
+                "-x", str(uf2_path),
+            ]
+            res = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                errors="replace",
+            )
+            if res.returncode == 0:
+                print(res.stdout, end="")
+                return
+            detail = (res.stdout or "").strip()
             logger.warning(
-                "picotool failed on serial=%s (attempt %d/%d); "
-                "retrying in %.1fs",
-                serial,
+                "picotool failed on serial=%s (bus=%d address=%d "
+                "in_bootsel=%s) (attempt %d/%d)",
+                usb_serial,
+                bus,
+                address,
+                in_bootsel,
                 attempt,
                 attempts,
-                delay,
             )
-            time.sleep(delay)
-    print(res.stdout, file=sys.stderr)
+        if attempt < attempts:
+            time.sleep(backoff * attempt)
+    if detail:
+        print(detail, file=sys.stderr)
     raise RuntimeError(
-        f"picotool failed on serial={serial} after {attempts} attempts"
+        f"picotool failed on serial={usb_serial} after {attempts} attempts"
     )
 
 

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -337,6 +337,19 @@ _REENUMERATE_TIMEOUT_S = 10.0
 _REENUMERATE_POLL_S = 0.2
 _UDEV_SETTLE_TIMEOUT_S = 3.0
 _INTER_DEVICE_SETTLE_S = 1.0
+# After the GPIO mass reset the whole fleet re-enumerates at once; let
+# the bus settle before reading any device so a board's first status
+# lines aren't lost to enumeration churn.
+_POST_RESET_SETTLE_S = 2.0
+# The device-info readback (resolve CDC port + read one JSON line) can
+# flake when several Picos re-enumerate together — retry before giving
+# up, since the flash itself already succeeded.
+_READBACK_MAX_ATTEMPTS = 3
+_READBACK_RETRY_BACKOFF_S = 1.0
+# After the GPIO mass reset, wait for the whole flashed fleet to
+# re-enumerate as CDC before reading any of them.
+_CDC_DISCOVER_TIMEOUT_S = 15.0
+_CDC_DISCOVER_POLL_S = 0.3
 
 
 def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
@@ -403,6 +416,115 @@ def _resolve_post_flash_port(
                 return dev
         time.sleep(poll)
     return None
+
+
+def _read_cdc_port(
+    port,
+    usb_serial,
+    baud,
+    timeout,
+    attempts=_READBACK_MAX_ATTEMPTS,
+    backoff=_READBACK_RETRY_BACKOFF_S,
+):
+    """Read one device-info JSON line from CDC *port*, with retries.
+
+    Returns the device-info dict (with ``port``/``usb_serial`` added),
+    or ``None`` once *attempts* are exhausted. The read is retried
+    because, especially after the GPIO mass reset, several Picos
+    re-enumerate together: a board can be briefly busy or slow to start
+    emitting its 200 ms status, so a single timeout drops a Pico that in
+    fact flashed fine. On each retry the port is re-resolved from
+    *usb_serial* (when known) in case the kernel renamed it.
+    """
+    last_err = None
+    for attempt in range(1, attempts + 1):
+        if port is None:
+            last_err = (
+                f"no CDC port for serial={usb_serial} "
+                f"(did not re-enumerate within {_REENUMERATE_TIMEOUT_S}s)"
+            )
+        else:
+            _udev_settle()
+            try:
+                data = read_json_from_serial(port, baud, timeout)
+                data["port"] = port
+                data["usb_serial"] = usb_serial
+                return data
+            except (RuntimeError, OSError) as e:
+                last_err = str(e)
+        if attempt < attempts:
+            logger.warning(
+                "device-info read for serial=%s on %s failed (attempt "
+                "%d/%d): %s; retrying",
+                usb_serial,
+                port,
+                attempt,
+                attempts,
+                last_err,
+            )
+            time.sleep(backoff)
+            if usb_serial is not None:
+                port = _resolve_post_flash_port(usb_serial)
+    logger.error(
+        "could not read device info for serial=%s on %s after %d "
+        "attempts: %s (it flashed — re-run flash-picos, or check the "
+        "board's DIP/app if it never reports)",
+        usb_serial,
+        port,
+        attempts,
+        last_err,
+    )
+    return None
+
+
+def _read_device_info(
+    usb_serial,
+    baud,
+    timeout,
+    attempts=_READBACK_MAX_ATTEMPTS,
+    backoff=_READBACK_RETRY_BACKOFF_S,
+):
+    """Resolve the post-flash CDC port for *usb_serial* and read its JSON.
+
+    Used by the USB per-device path, which already knows each Pico by
+    its (stable) CDC serial.
+    """
+    port = _resolve_post_flash_port(usb_serial)
+    return _read_cdc_port(port, usb_serial, baud, timeout, attempts, backoff)
+
+
+def _read_fleet_cdc(expected, baud, timeout):
+    """Read device-info JSON from every Pico now in CDC mode.
+
+    Polls :func:`find_pico_ports` until at least *expected* Picos have
+    re-enumerated (or ``_CDC_DISCOVER_TIMEOUT_S`` elapses), then reads
+    each by its **CDC** serial. The GPIO mass-flash path uses this rather
+    than mapping the BOOTSEL-mode serial used for loading: a wiped or odd
+    board can present a different (or absent) serial in BOOTSEL, which
+    would leave it flashed but unreported. Keying off the CDC serial —
+    the same identity ``find_pico_ports`` and PicoManager use — reports
+    every Pico that actually booted into firmware.
+    """
+    deadline = time.monotonic() + _CDC_DISCOVER_TIMEOUT_S
+    ports = find_pico_ports()
+    while len(ports) < expected and time.monotonic() < deadline:
+        time.sleep(_CDC_DISCOVER_POLL_S)
+        ports = find_pico_ports()
+    if len(ports) < expected:
+        logger.warning(
+            "only %d of %d flashed Pico(s) re-enumerated as CDC within "
+            "%.0fs",
+            len(ports),
+            expected,
+            _CDC_DISCOVER_TIMEOUT_S,
+        )
+    all_devices = []
+    for port, serial in sorted(ports.items()):
+        data = _read_cdc_port(port, serial, baud, timeout)
+        if data is not None:
+            all_devices.append(data)
+            logger.info("Read device info from %s (serial=%s)", port, serial)
+    return all_devices
 
 
 def flash_and_discover(
@@ -475,32 +597,14 @@ def flash_and_discover(
             continue
 
         # picotool load reboots the Pico, which re-enumerates as a
-        # CDC device. The kernel may assign a different /dev/ttyACMn
-        # than it had pre-flash, so resolve the current path from
-        # the stable usb_serial before reading JSON — otherwise a
-        # different Pico that drifted into port_dev would have its
-        # status attributed to *this* device's usb_serial.
-        current_port = _resolve_post_flash_port(port_serial)
-        if current_port is None:
-            logger.error(
-                f"Pico serial={port_serial} (pre-flash port "
-                f"{port_dev}) did not re-enumerate within "
-                f"{_REENUMERATE_TIMEOUT_S}s; skipping"
-            )
-            continue
-
-        _udev_settle()
-
-        try:
-            data = read_json_from_serial(current_port, baud, timeout)
-        except (RuntimeError, OSError) as e:
-            logger.error(f"Serial read failed on {current_port}: {e}")
-            continue
-
-        data["port"] = current_port
-        data["usb_serial"] = port_serial
-        all_devices.append(data)
-        logger.info(f"Read device info from {current_port}")
+        # CDC device. _read_device_info resolves the current path from
+        # the stable usb_serial (the kernel may assign a different
+        # /dev/ttyACMn than it had pre-flash) and reads its JSON, with
+        # retries.
+        data = _read_device_info(port_serial, baud, timeout)
+        if data is not None:
+            all_devices.append(data)
+            logger.info(f"Read device info from {data['port']}")
 
     return all_devices
 
@@ -618,37 +722,30 @@ def flash_and_discover_gpio(
             )
 
     # Phase 3: one reset pulse boots the whole fleet, then read device
-    # info from each flashed Pico.
+    # info from every Pico now in CDC mode. Let the bus settle first —
+    # the whole fleet re-enumerates at once here, unlike the USB
+    # per-device path. The readback keys off the CDC serial, not the
+    # BOOTSEL-mode serial used for loading, so a board whose BOOTSEL
+    # serial differed or was absent is still reported.
     gpio.reset()
-    all_devices = []
-    for dev in flashed:
-        serial = dev["usb_serial"]
-        if serial is None:
-            logger.warning(
-                "flashed Pico at bus=%d address=%d has no USB serial; "
-                "cannot map it to a CDC port for the device-info read",
-                dev["bus"],
-                dev["address"],
-            )
-            continue
-        current_port = _resolve_post_flash_port(serial)
-        if current_port is None:
-            logger.error(
-                f"Pico serial={serial} did not re-enumerate within "
-                f"{_REENUMERATE_TIMEOUT_S}s after the mass reset; "
-                "skipping"
-            )
-            continue
-        _udev_settle()
-        try:
-            data = read_json_from_serial(current_port, baud, timeout)
-        except (RuntimeError, OSError) as e:
-            logger.error(f"Serial read failed on {current_port}: {e}")
-            continue
-        data["port"] = current_port
-        data["usb_serial"] = serial
-        all_devices.append(data)
-        logger.info(f"Read device info from {current_port}")
+    time.sleep(_POST_RESET_SETTLE_S)
+    all_devices = _read_fleet_cdc(len(flashed), baud, timeout)
+
+    # Surface any board that did not take the flash: after the reset it
+    # has no valid image and drops straight back into BOOTSEL.
+    stuck = _find_bootsel_devices()
+    if stuck:
+        logger.error(
+            "%d Pico(s) still in BOOTSEL after the mass reset — NOT "
+            "flashed: %s. Re-run flash-picos; if the same board fails "
+            "every time, check its USB cable/power and `picotool info`.",
+            len(stuck),
+            ", ".join(
+                f"bus={d['bus']} address={d['address']} "
+                f"serial={d['usb_serial']}"
+                for d in stuck
+            ),
+        )
 
     return all_devices
 

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -94,8 +94,143 @@ def _resolve_bus_address(usb_serial, sysfs_root=None):
     return (None, None, None)
 
 
+def _find_bootsel_devices(sysfs_root=None):
+    """List all Picos currently in BOOTSEL mode from Linux sysfs.
+
+    Returns a list of ``{"usb_serial", "bus", "address"}`` dicts (one
+    per ``2e8a:000f`` device), sorted by ``(bus, address)`` for a
+    deterministic flashing order. ``usb_serial`` is ``None`` for a
+    wiped board that enumerates without a serial descriptor — such a
+    device is still flashable by bus/address. Devices whose
+    bus/address cannot be read are skipped; the result is empty on
+    hosts without sysfs.
+    """
+    if sysfs_root is None:
+        sysfs_root = SYSFS_USB_DEVICES
+    sysfs_root = Path(sysfs_root)
+    if not sysfs_root.is_dir():
+        return []
+    bootsel_pid = f"{PICO_PID_BOOTSEL:04x}"
+    devices = []
+    for entry in sorted(sysfs_root.iterdir()):
+        try:
+            vid = (entry / "idVendor").read_text().strip().lower()
+            pid = (entry / "idProduct").read_text().strip().lower()
+        except (OSError, ValueError):
+            continue
+        if vid != "2e8a" or pid != bootsel_pid:
+            continue
+        try:
+            serial = (entry / "serial").read_text().strip()
+        except OSError:
+            serial = None
+        try:
+            bus = int((entry / "busnum").read_text().strip())
+            address = int((entry / "devnum").read_text().strip())
+        except (OSError, ValueError):
+            continue
+        devices.append(
+            {"usb_serial": serial, "bus": bus, "address": address}
+        )
+    devices.sort(key=lambda d: (d["bus"], d["address"]))
+    return devices
+
+
+_BOOTSEL_REENUM_TIMEOUT_S = 10.0
+_BOOTSEL_REENUM_POLL_S = 0.2
+
+
+def _wait_for_bootsel(
+    usb_serial,
+    timeout=_BOOTSEL_REENUM_TIMEOUT_S,
+    poll=_BOOTSEL_REENUM_POLL_S,
+):
+    """Poll sysfs until *usb_serial* re-enumerates in BOOTSEL.
+
+    Returns the BOOTSEL ``(bus, address)`` once the device appears as
+    ``2e8a:000f``, or ``(None, None)`` if it does not within *timeout*
+    (e.g. the reboot request was lost on the congested hub). The kernel's
+    sysfs serial is reliable; only picotool's *live* descriptor reads
+    corrupt under contention, which is why we re-find via sysfs rather
+    than letting ``picotool load -f`` track the device itself.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        bus, address, in_bootsel = _resolve_bus_address(usb_serial)
+        if in_bootsel:
+            return (bus, address)
+        time.sleep(poll)
+    return (None, None)
+
+
+_BOOTSEL_SET_TIMEOUT_S = 15.0
+_BOOTSEL_SET_STABLE_S = 2.0
+_BOOTSEL_SET_POLL_S = 0.3
+
+
+def _wait_for_stable_bootsel_set(
+    timeout=_BOOTSEL_SET_TIMEOUT_S,
+    stable=_BOOTSEL_SET_STABLE_S,
+    poll=_BOOTSEL_SET_POLL_S,
+):
+    """Poll sysfs until the set of BOOTSEL Picos stops changing.
+
+    After a mass BOOTSEL entry the devices enumerate one by one, so a
+    single scan would race the slower ones. The set counts as settled
+    when it is non-empty and unchanged for *stable* seconds; devices
+    are compared by ``(usb_serial, bus, address)``.
+
+    Returns the settled device list, or the last observation if the
+    set never settles within *timeout* (possibly empty) — the caller
+    decides whether a partial or empty set is an error.
+    """
+    deadline = time.monotonic() + timeout
+    last = []
+    last_keys = None
+    stable_since = None
+    while time.monotonic() < deadline:
+        devices = _find_bootsel_devices()
+        keys = {
+            (d["usb_serial"], d["bus"], d["address"]) for d in devices
+        }
+        now = time.monotonic()
+        if keys != last_keys:
+            last_keys = keys
+            last = devices
+            stable_since = now
+        elif keys and now - stable_since >= stable:
+            return devices
+        time.sleep(poll)
+    return last
+
+
 _FLASH_MAX_ATTEMPTS = 3
 _FLASH_RETRY_BACKOFF_S = 2.0
+
+
+def _picotool_load(bus, address, uf2_path, execute=True):
+    """Run ``picotool load`` against the device at *bus*/*address*.
+
+    *execute* appends ``-x`` (load then run). The GPIO mass-flash path
+    passes ``execute=False``: the device stays in BOOTSEL with no
+    re-enumeration (so bus/address remain valid for a retry) and a
+    single mass reset boots every Pico afterwards. ``-f`` is never
+    used — its reboot path re-acquires the device by a live USB
+    serial-descriptor read that corrupts under hub contention.
+
+    Returns the :class:`subprocess.CompletedProcess`.
+    """
+    cmd = ["picotool", "load", "--bus", str(bus), "--address", str(address)]
+    if execute:
+        cmd.append("-x")
+    cmd.append(str(uf2_path))
+    return subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",
+    )
 
 
 def flash_uf2(
@@ -106,21 +241,25 @@ def flash_uf2(
 ):
     """Flash the UF2 onto the Pico with USB serial *usb_serial*.
 
-    Selects the target by USB ``--bus``/``--address`` (resolved from
-    sysfs via :func:`_resolve_bus_address`) rather than picotool's
-    ``--ser``. On the observatory's deep USB hub, ``--ser`` matching
-    forces a serial-string descriptor read that intermittently fails, so
-    ``picotool load -f --ser`` cannot find the device to reboot into
-    BOOTSEL — the original cause of the "random which Pico flashes"
-    failures. ``--bus``/``--address`` needs no descriptor read.
+    Targets the device by USB ``--bus``/``--address`` (resolved from
+    sysfs) rather than picotool's ``--ser``. A CDC device is flashed in
+    two steps:
 
-    When the device is in CDC mode, ``picotool load -f`` reboots it into
-    BOOTSEL (RP2350 enumerates as ``2e8a:000f``), loads, and reboots back
-    to the app — re-enumerating to a *new* USB address each time. The
-    address is therefore re-resolved before every attempt. If a prior
-    attempt left the device in BOOTSEL, it is loaded directly (without
-    ``-f``); a target momentarily mid-reboot (no sysfs node) is treated
-    as a failed attempt and retried with linear backoff.
+    1. ``picotool reboot -u -f --bus B --address A`` resets it into
+       BOOTSEL (RP2350 enumerates as ``2e8a:000f``).
+    2. After it re-enumerates (a *new* address), ``picotool load
+       --bus B' --address A' -x`` loads and runs the image.
+
+    This deliberately avoids ``picotool load -f``: its ``-f`` reboot path
+    re-acquires the device by a *live* USB serial-string descriptor read,
+    which intermittently returns garbage under bus contention on the
+    observatory's deep hub (``Tracking device serial number ... for
+    reboot`` → ``no accessible RP-series devices in BOOTSEL``) — the
+    cause of the "random which Pico flashes" failures. ``reboot`` sends
+    the reset and exits (no tracking read); the device is then re-found
+    in BOOTSEL via sysfs, whose kernel-read serial is reliable. A device
+    already in BOOTSEL is loaded directly (no reboot). Each step retries
+    with linear backoff.
     """
     print(f"Flashing {uf2_path} → serial={usb_serial}")
     detail = ""
@@ -133,35 +272,41 @@ def flash_uf2(
             )
             logger.warning("%s (attempt %d/%d)", detail, attempt, attempts)
         else:
-            cmd = ["picotool", "load"]
             if not in_bootsel:
-                cmd.append("-f")
-            cmd += [
-                "--bus", str(bus),
-                "--address", str(address),
-                "-x", str(uf2_path),
-            ]
-            res = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                errors="replace",
-            )
-            if res.returncode == 0:
-                print(res.stdout, end="")
-                return
-            detail = (res.stdout or "").strip()
-            logger.warning(
-                "picotool failed on serial=%s (bus=%d address=%d "
-                "in_bootsel=%s) (attempt %d/%d)",
-                usb_serial,
-                bus,
-                address,
-                in_bootsel,
-                attempt,
-                attempts,
-            )
+                rb = subprocess.run(
+                    [
+                        "picotool", "reboot", "-u", "-f",
+                        "--bus", str(bus),
+                        "--address", str(address),
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    errors="replace",
+                )
+                bus, address = _wait_for_bootsel(usb_serial)
+                if bus is None:
+                    detail = (rb.stdout or "").strip() or (
+                        f"serial={usb_serial} did not reboot into BOOTSEL"
+                    )
+                    logger.warning(
+                        "%s (attempt %d/%d)", detail, attempt, attempts
+                    )
+            if bus is not None:
+                res = _picotool_load(bus, address, uf2_path, execute=True)
+                if res.returncode == 0:
+                    print(res.stdout, end="")
+                    return
+                detail = (res.stdout or "").strip()
+                logger.warning(
+                    "picotool load failed on serial=%s (bus=%d "
+                    "address=%d) (attempt %d/%d)",
+                    usb_serial,
+                    bus,
+                    address,
+                    attempt,
+                    attempts,
+                )
         if attempt < attempts:
             time.sleep(backoff * attempt)
     if detail:

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -2,7 +2,7 @@
 """`flash-test`: load the heartbeat test UF2 onto Pico(s) in BOOTSEL mode.
 
 `flash-picos` discovers Picos by enumerating CDC serial ports, which
-means a fresh / wiped Pico (USB PID 0x000f on RP2350, mass-storage) is invisible
+means a fresh / wiped Pico (USB PID 0x000f, mass-storage) is invisible
 to it. This CLI wraps ``picotool load`` to target BOOTSEL-mode Picos so
 the test image can be installed, USB-CDC comes up, and the normal
 ``flash-picos`` workflow becomes available.
@@ -222,10 +222,13 @@ def main():
                 label = serial or f"bus {bus} address {address}"
                 print(f"\n→ Flashing Pico {label}")
                 try:
-                    if serial is not None:
-                        flash_test_image(args.uf2, usb_serial=serial)
-                    else:
+                    # Prefer --bus/--address: --ser forces a serial-string
+                    # descriptor read that intermittently fails under bus
+                    # contention on the observatory's congested USB hub.
+                    if has_bus_address:
                         flash_test_image(args.uf2, bus=bus, address=address)
+                    else:
+                        flash_test_image(args.uf2, usb_serial=serial)
                 except RuntimeError as e:
                     print(str(e), file=sys.stderr)
                     failures += 1

--- a/picohost/src/picohost/flash_test.py
+++ b/picohost/src/picohost/flash_test.py
@@ -2,7 +2,7 @@
 """`flash-test`: load the heartbeat test UF2 onto Pico(s) in BOOTSEL mode.
 
 `flash-picos` discovers Picos by enumerating CDC serial ports, which
-means a fresh / wiped Pico (USB PID 0x0003, mass-storage) is invisible
+means a fresh / wiped Pico (USB PID 0x000f on RP2350, mass-storage) is invisible
 to it. This CLI wraps ``picotool load`` to target BOOTSEL-mode Picos so
 the test image can be installed, USB-CDC comes up, and the normal
 ``flash-picos`` workflow becomes available.
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 PICO_VID = "2e8a"
-PICO_PID_BOOTSEL = "0003"
+PICO_PID_BOOTSEL = "000f"  # RP2350 BOOTSEL PID (RP2040 was 0003)
 SYSFS_USB_DEVICES = Path("/sys/bus/usb/devices")
 
 
@@ -26,7 +26,7 @@ def find_bootsel_devices(sysfs_root=None):
     """Enumerate Picos currently in BOOTSEL mode by scanning Linux sysfs.
 
     Returns a list of ``{"usb_serial", "bus", "address"}`` dicts, one per
-    attached Pico with VID:PID 2e8a:0003. BOOTSEL Picos are USB
+    attached Pico with VID:PID 2e8a:000f. BOOTSEL Picos are USB
     mass-storage devices and don't appear in pyserial's port list, so
     sysfs is the cheapest discovery path that avoids parsing picotool's
     free-form output or pulling in libusb bindings.

--- a/picohost/src/picohost/gpio.py
+++ b/picohost/src/picohost/gpio.py
@@ -12,19 +12,22 @@ picos too), and one :func:`reset` pulse boots them all.
 
 BOOTSEL doubles as each pico's QSPI flash chip-select, so its line is
 only ever asserted while the picos are held in reset, and every
-operation switches the drivers off again — including on error —
-before releasing the pins to input (where the Pi's default pull-downs
-on BCM 17/18 keep the drivers off).
+operation releases both drivers again — including on error, releasing
+BOOTSEL before RUN — so a running pico never has its flash CS yanked
+low.
 
-The pin factory backend (lgpio on the field image) is supplied by the
-deployment; tests run against ``GPIOZERO_PIN_FACTORY=mock``.
+The lines are driven through the ``pinctrl`` CLI that ships with
+Raspberry Pi OS (``pinctrl set <gpio> op dh|dl`` sets a pin to output
+and drives it high/low in one call) — no GPIO library or pin-factory
+backend to install. This is the exact mechanism verified reliable on
+the hub.
 """
 
+import argparse
 import logging
+import shutil
+import subprocess
 import time
-from contextlib import contextmanager
-
-from gpiozero import Device, OutputDevice
 
 logger = logging.getLogger(__name__)
 
@@ -35,29 +38,52 @@ _SETTLE_S = 0.05  # RUN asserted before BOOTSEL joins it
 _RUN_PULSE_S = 0.1  # RUN+BOOTSEL held together before RUN releases
 _BOOTSEL_SAMPLE_S = 0.4  # BOOTSEL held after RUN release (bootrom samples)
 
+# Inverting drivers: a Pi pin driven HIGH grounds its bussed line
+# (assert); driven LOW switches the driver off and the line floats high
+# via the picos' pull-ups (release). These are the pinctrl drive tokens.
+_ASSERT = "dh"  # pinctrl drive-high
+_RELEASE = "dl"  # pinctrl drive-low
 
-@contextmanager
-def _line_driver(gpio):
-    """Yield an :class:`OutputDevice` driving the bussed line on *gpio*.
 
-    The hardware inverts: Pi pin HIGH grounds the line (``on()`` =
-    assert), Pi pin LOW releases it. Construction starts released
-    (``initial_value=False`` drives LOW), and the ``finally`` always
-    switches the driver off and re-muxes the pin to input before
-    close — on the kernel cdev backend a released output pin keeps
-    driving its last level, and as an input the Pi's default
-    pull-down holds the driver off.
+def _pinctrl(gpio, level):
+    """Drive *gpio* (BCM) to *level* (``_ASSERT``/``_RELEASE``).
+
+    Shells out to ``pinctrl set <gpio> op <dh|dl>``, which configures
+    the pin as an output and sets its level in one call. Raises
+    ``subprocess.CalledProcessError`` if pinctrl exits non-zero (e.g.
+    not installed, or insufficient permission) so a failed transition
+    is never silently ignored.
     """
-    dev = OutputDevice(gpio, active_high=True, initial_value=False)
+    subprocess.run(
+        ["pinctrl", "set", str(gpio), "op", level],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _release(gpio):
+    """Best-effort release of *gpio*; log and swallow failures.
+
+    Used on the cleanup path so a release error cannot mask the
+    original exception, and so one stuck line still lets the others be
+    released.
+    """
     try:
-        yield dev
-    finally:
-        try:
-            dev.off()
-            if dev.pin is not None:
-                dev.pin.function = "input"
-        finally:
-            dev.close()
+        _pinctrl(gpio, _RELEASE)
+    except Exception:
+        logger.warning("failed to release GPIO%d via pinctrl", gpio,
+                       exc_info=True)
+
+
+def _release_lines():
+    """Release BOOTSEL then RUN (best effort).
+
+    BOOTSEL (the shared QSPI flash CS) is released first so the picos
+    never exit reset with their flash CS still grounded.
+    """
+    _release(BOOTSEL_GPIO)
+    _release(RUN_GPIO)
 
 
 def enter_bootsel(
@@ -67,7 +93,9 @@ def enter_bootsel(
 ):
     """Put ALL bussed picos into BOOTSEL via the shared GPIO lines.
 
-    Sequence (inverted drivers; assert = Pi pin HIGH grounds the line):
+    Issues the verified-reliable ``pinctrl`` ordering
+    (``17 dh, 18 dh, 17 dl, 18 dl``); with the inverting drivers that
+    is:
 
     1. assert RUN — hold every pico in reset
     2. wait *settle*, then assert BOOTSEL (the shared QSPI-CS line is
@@ -77,47 +105,82 @@ def enter_bootsel(
     4. hold BOOTSEL low *bootsel_sample* while sampling completes
     5. release BOOTSEL
 
-    Lines are always released, even on exception. After this returns,
-    every pico re-enumerates as a ``2e8a:000f`` mass-storage device.
+    Both lines are always released, even on exception (BOOTSEL before
+    RUN). After this returns, every pico re-enumerates as a
+    ``2e8a:000f`` mass-storage device.
     """
     logger.info(
         "Mass BOOTSEL entry: BOOTSEL=GPIO%d RUN=GPIO%d",
         BOOTSEL_GPIO,
         RUN_GPIO,
     )
-    with _line_driver(RUN_GPIO) as run:
-        run.on()
+    try:
+        _pinctrl(RUN_GPIO, _ASSERT)
         time.sleep(settle)
-        with _line_driver(BOOTSEL_GPIO) as bootsel:
-            bootsel.on()
-            time.sleep(run_pulse)
-            run.off()  # picos boot, bootrom samples BOOTSEL
-            time.sleep(bootsel_sample)
-            bootsel.off()
+        _pinctrl(BOOTSEL_GPIO, _ASSERT)
+        time.sleep(run_pulse)
+        _pinctrl(RUN_GPIO, _RELEASE)  # picos boot, bootrom samples BOOTSEL
+        time.sleep(bootsel_sample)
+        _pinctrl(BOOTSEL_GPIO, _RELEASE)
+    except BaseException:
+        _release_lines()
+        raise
 
 
 def reset(run_pulse=_RUN_PULSE_S):
     """Pulse the shared RUN line low, then release it.
 
     All bussed picos reset and boot their current firmware
-    simultaneously.
+    simultaneously. BOOTSEL is never touched, and RUN is released even
+    if interrupted mid-pulse.
     """
     logger.info("Mass reset: RUN=GPIO%d", RUN_GPIO)
-    with _line_driver(RUN_GPIO) as run:
-        run.on()
+    try:
+        _pinctrl(RUN_GPIO, _ASSERT)
         time.sleep(run_pulse)
-        run.off()
+        _pinctrl(RUN_GPIO, _RELEASE)
+    except BaseException:
+        _release(RUN_GPIO)
+        raise
 
 
 def available():
-    """Return True if gpiozero can construct a usable pin factory.
+    """Return True if the ``pinctrl`` CLI is on PATH.
 
-    False on hosts without GPIO hardware/backends (gpiozero raises
-    ``BadPinFactory`` when no factory loads) — callers should fall back
-    to the USB flash path or tell the user to pass ``--no-gpio``.
+    False on hosts without it (e.g. a dev laptop) — callers should fall
+    back to the USB flash path or tell the user to pass ``--no-gpio``.
     """
-    try:
-        Device.ensure_pin_factory()
-    except Exception:
-        return False
-    return True
+    return shutil.which("pinctrl") is not None
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description=(
+            "Drive the bussed Pico BOOTSEL/RUN GPIO lines on the "
+            "observatory hub."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser(
+        "bootsel",
+        help="Put ALL bussed Picos into BOOTSEL (2e8a:000f).",
+    )
+    sub.add_parser(
+        "reset",
+        help="Reset (reboot) ALL bussed Picos into their firmware.",
+    )
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    if args.cmd == "bootsel":
+        enter_bootsel()
+    elif args.cmd == "reset":
+        reset()
+
+
+if __name__ == "__main__":
+    main()

--- a/picohost/src/picohost/gpio.py
+++ b/picohost/src/picohost/gpio.py
@@ -1,0 +1,123 @@
+"""Mass BOOTSEL entry and reset for the bussed observatory picos.
+
+All picos on the observatory hub share two control lines driven from
+Pi GPIOs (BCM numbering) through inverting drivers: every BOOTSEL pad
+is bussed to a driver on GPIO 18 and every RUN/RESET pad to one on
+GPIO 17. Driving a Pi pin HIGH pulls its bussed line to ground
+(assert); driving it LOW switches the driver off and the line floats
+high via the picos' pull-ups (release). One :func:`enter_bootsel`
+call therefore puts the whole fleet into BOOTSEL at once, with no
+dependency on working CDC firmware (it recovers wedged or bricked
+picos too), and one :func:`reset` pulse boots them all.
+
+BOOTSEL doubles as each pico's QSPI flash chip-select, so its line is
+only ever asserted while the picos are held in reset, and every
+operation switches the drivers off again — including on error —
+before releasing the pins to input (where the Pi's default pull-downs
+on BCM 17/18 keep the drivers off).
+
+The pin factory backend (lgpio on the field image) is supplied by the
+deployment; tests run against ``GPIOZERO_PIN_FACTORY=mock``.
+"""
+
+import logging
+import time
+from contextlib import contextmanager
+
+from gpiozero import Device, OutputDevice
+
+logger = logging.getLogger(__name__)
+
+BOOTSEL_GPIO = 18  # BCM; drives all picos' BOOTSEL/QSPI-CS pads low
+RUN_GPIO = 17  # BCM; drives all picos' RUN/RESET pads low
+
+_SETTLE_S = 0.05  # RUN asserted before BOOTSEL joins it
+_RUN_PULSE_S = 0.1  # RUN+BOOTSEL held together before RUN releases
+_BOOTSEL_SAMPLE_S = 0.4  # BOOTSEL held after RUN release (bootrom samples)
+
+
+@contextmanager
+def _line_driver(gpio):
+    """Yield an :class:`OutputDevice` driving the bussed line on *gpio*.
+
+    The hardware inverts: Pi pin HIGH grounds the line (``on()`` =
+    assert), Pi pin LOW releases it. Construction starts released
+    (``initial_value=False`` drives LOW), and the ``finally`` always
+    switches the driver off and re-muxes the pin to input before
+    close — on the kernel cdev backend a released output pin keeps
+    driving its last level, and as an input the Pi's default
+    pull-down holds the driver off.
+    """
+    dev = OutputDevice(gpio, active_high=True, initial_value=False)
+    try:
+        yield dev
+    finally:
+        try:
+            dev.off()
+            if dev.pin is not None:
+                dev.pin.function = "input"
+        finally:
+            dev.close()
+
+
+def enter_bootsel(
+    settle=_SETTLE_S,
+    run_pulse=_RUN_PULSE_S,
+    bootsel_sample=_BOOTSEL_SAMPLE_S,
+):
+    """Put ALL bussed picos into BOOTSEL via the shared GPIO lines.
+
+    Sequence (inverted drivers; assert = Pi pin HIGH grounds the line):
+
+    1. assert RUN — hold every pico in reset
+    2. wait *settle*, then assert BOOTSEL (the shared QSPI-CS line is
+       only pulled low while the picos are halted)
+    3. hold both *run_pulse*, then release RUN — the picos exit reset
+       and the bootrom samples BOOTSEL
+    4. hold BOOTSEL low *bootsel_sample* while sampling completes
+    5. release BOOTSEL
+
+    Lines are always released, even on exception. After this returns,
+    every pico re-enumerates as a ``2e8a:000f`` mass-storage device.
+    """
+    logger.info(
+        "Mass BOOTSEL entry: BOOTSEL=GPIO%d RUN=GPIO%d",
+        BOOTSEL_GPIO,
+        RUN_GPIO,
+    )
+    with _line_driver(RUN_GPIO) as run:
+        run.on()
+        time.sleep(settle)
+        with _line_driver(BOOTSEL_GPIO) as bootsel:
+            bootsel.on()
+            time.sleep(run_pulse)
+            run.off()  # picos boot, bootrom samples BOOTSEL
+            time.sleep(bootsel_sample)
+            bootsel.off()
+
+
+def reset(run_pulse=_RUN_PULSE_S):
+    """Pulse the shared RUN line low, then release it.
+
+    All bussed picos reset and boot their current firmware
+    simultaneously.
+    """
+    logger.info("Mass reset: RUN=GPIO%d", RUN_GPIO)
+    with _line_driver(RUN_GPIO) as run:
+        run.on()
+        time.sleep(run_pulse)
+        run.off()
+
+
+def available():
+    """Return True if gpiozero can construct a usable pin factory.
+
+    False on hosts without GPIO hardware/backends (gpiozero raises
+    ``BadPinFactory`` when no factory loads) — callers should fall back
+    to the USB flash path or tell the user to pass ``--no-gpio``.
+    """
+    try:
+        Device.ensure_pin_factory()
+    except Exception:
+        return False
+    return True

--- a/picohost/src/picohost/gpio.py
+++ b/picohost/src/picohost/gpio.py
@@ -72,8 +72,9 @@ def _release(gpio):
     try:
         _pinctrl(gpio, _RELEASE)
     except Exception:
-        logger.warning("failed to release GPIO%d via pinctrl", gpio,
-                       exc_info=True)
+        logger.warning(
+            "failed to release GPIO%d via pinctrl", gpio, exc_info=True
+        )
 
 
 def _release_lines():

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -868,3 +868,285 @@ class TestWaitForStableBootselSet:
             timeout=0.05, stable=10.0, poll=0.005
         )
         assert result == [d1]
+
+
+@pytest.fixture
+def _mock_gpio_flash(monkeypatch, tmp_path):
+    """Patch GPIO actions, sysfs scans, picotool, and serial reads so
+    flash_and_discover_gpio can run without hardware.
+
+    picotool invocations go through a fake subprocess.run so the tests
+    can assert on the *actual* argv (no reboot, no -x, no -f).
+    """
+    import picohost.flash_picos as fp
+    import picohost.gpio as gpio_mod
+
+    uf2 = tmp_path / "test.uf2"
+    uf2.write_bytes(b"\x00")
+
+    events = []
+    monkeypatch.setattr(
+        gpio_mod, "enter_bootsel", lambda: events.append("enter_bootsel")
+    )
+    monkeypatch.setattr(
+        gpio_mod, "reset", lambda: events.append("reset")
+    )
+
+    bootsel = [
+        {"usb_serial": "SER_A", "bus": 1, "address": 50},
+        {"usb_serial": "SER_B", "bus": 1, "address": 51},
+    ]
+    monkeypatch.setattr(
+        fp, "_wait_for_stable_bootsel_set", lambda: list(bootsel)
+    )
+    monkeypatch.setattr(fp, "_find_bootsel_devices", lambda: list(bootsel))
+    monkeypatch.setattr(
+        fp,
+        "find_pico_ports",
+        lambda: {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"},
+    )
+
+    cmds = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        events.append(("load", cmd[cmd.index("--address") + 1]))
+        return types.SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(fp.subprocess, "run", fake_run)
+
+    monkeypatch.setattr(
+        fp,
+        "_resolve_post_flash_port",
+        lambda s: {"SER_A": "/dev/ttyACM5", "SER_B": "/dev/ttyACM6"}[s],
+    )
+    monkeypatch.setattr(fp, "_udev_settle", lambda: None)
+    monkeypatch.setattr(
+        fp,
+        "read_json_from_serial",
+        lambda port, baud, timeout: {
+            "/dev/ttyACM5": {"app_id": 0},
+            "/dev/ttyACM6": {"app_id": 5},
+        }[port],
+    )
+    monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+    return types.SimpleNamespace(
+        uf2=uf2,
+        events=events,
+        cmds=cmds,
+        bootsel=bootsel,
+        fp=fp,
+        monkeypatch=monkeypatch,
+    )
+
+
+class TestFlashAndDiscoverGpio:
+    def test_happy_path_returns_device_list(self, _mock_gpio_flash):
+        m = _mock_gpio_flash
+        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        by_serial = {d["usb_serial"]: d for d in devices}
+        assert by_serial["SER_A"]["port"] == "/dev/ttyACM5"
+        assert by_serial["SER_A"]["app_id"] == 0
+        assert by_serial["SER_B"]["port"] == "/dev/ttyACM6"
+        assert by_serial["SER_B"]["app_id"] == 5
+
+    def test_never_invokes_picotool_reboot(self, _mock_gpio_flash):
+        # The whole point of the GPIO path: BOOTSEL entry happens on
+        # the shared GPIO lines, never via per-device USB reboots.
+        m = _mock_gpio_flash
+        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert m.cmds, "expected picotool load invocations"
+        assert all(c[:2] == ["picotool", "load"] for c in m.cmds)
+
+    def test_loads_omit_execute_and_force(self, _mock_gpio_flash):
+        # No -x: devices stay in BOOTSEL until the mass reset. No -f:
+        # its reboot path does the live serial-descriptor read that
+        # corrupts under hub contention.
+        m = _mock_gpio_flash
+        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        for cmd in m.cmds:
+            assert "-x" not in cmd
+            assert "-f" not in cmd
+
+    def test_phase_ordering(self, _mock_gpio_flash):
+        # enter_bootsel first, then all loads, then exactly one reset.
+        m = _mock_gpio_flash
+        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert m.events[0] == "enter_bootsel"
+        assert m.events.count("reset") == 1
+        load_idx = [
+            i for i, e in enumerate(m.events) if isinstance(e, tuple)
+        ]
+        assert load_idx, "expected load events"
+        assert m.events.index("reset") > max(load_idx)
+
+    def test_warns_on_snapshot_serial_missing_from_bootsel(
+        self, _mock_gpio_flash, caplog
+    ):
+        # SER_C was a live CDC Pico before the mass entry but never
+        # appeared in BOOTSEL — name it so the operator notices.
+        m = _mock_gpio_flash
+        m.monkeypatch.setattr(
+            m.fp,
+            "find_pico_ports",
+            lambda: {
+                "/dev/ttyACM0": "SER_A",
+                "/dev/ttyACM1": "SER_B",
+                "/dev/ttyACM2": "SER_C",
+            },
+        )
+        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert "SER_C" in caplog.text
+
+    def test_empty_bootsel_set_raises(self, _mock_gpio_flash):
+        m = _mock_gpio_flash
+        m.monkeypatch.setattr(
+            m.fp, "_wait_for_stable_bootsel_set", lambda: []
+        )
+        with pytest.raises(RuntimeError, match="no Picos entered BOOTSEL"):
+            m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+
+    def test_failed_load_excluded_but_reset_still_fires(
+        self, _mock_gpio_flash
+    ):
+        # SER_A's load never succeeds: it is excluded from the results,
+        # but the mass reset must still run (it cannot target — and the
+        # stragglers reboot into whatever firmware they have).
+        m = _mock_gpio_flash
+
+        def fake_run(cmd, **kw):
+            m.cmds.append(cmd)
+            address = cmd[cmd.index("--address") + 1]
+            m.events.append(("load", address))
+            rc = 1 if address == "50" else 0
+            return types.SimpleNamespace(returncode=rc, stdout="boom")
+
+        m.monkeypatch.setattr(m.fp.subprocess, "run", fake_run)
+        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert [d["usb_serial"] for d in devices] == ["SER_B"]
+        assert m.events.count("reset") == 1
+
+    def test_load_retry_reresolves_address(self, _mock_gpio_flash):
+        # A failed load retries against a freshly resolved address in
+        # case the device re-enumerated meanwhile.
+        m = _mock_gpio_flash
+        m.monkeypatch.setattr(
+            m.fp,
+            "_find_bootsel_devices",
+            lambda: [
+                {"usb_serial": "SER_A", "bus": 1, "address": 60},
+                {"usb_serial": "SER_B", "bus": 1, "address": 51},
+            ],
+        )
+        codes = iter([1, 0, 0])
+
+        def fake_run(cmd, **kw):
+            m.cmds.append(cmd)
+            return types.SimpleNamespace(
+                returncode=next(codes), stdout=""
+            )
+
+        m.monkeypatch.setattr(m.fp.subprocess, "run", fake_run)
+        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        ser_a_addrs = [
+            c[c.index("--address") + 1] for c in m.cmds[:2]
+        ]
+        assert ser_a_addrs == ["50", "60"]
+
+    def test_serialless_device_flashed_but_not_in_results(
+        self, _mock_gpio_flash
+    ):
+        m = _mock_gpio_flash
+        m.bootsel.append({"usb_serial": None, "bus": 1, "address": 52})
+        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        flashed_addrs = {c[c.index("--address") + 1] for c in m.cmds}
+        assert "52" in flashed_addrs
+        assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
+
+    def test_missing_uf2_raises_before_any_gpio_action(
+        self, _mock_gpio_flash, tmp_path
+    ):
+        m = _mock_gpio_flash
+        with pytest.raises(FileNotFoundError, match="UF2 file not found"):
+            m.fp.flash_and_discover_gpio(
+                uf2_path=tmp_path / "nonexistent.uf2"
+            )
+        assert m.events == []
+
+
+class TestMainRouting:
+    def _run_main(self, monkeypatch, argv, gpio_available=True):
+        import picohost.flash_picos as fp
+        import picohost.gpio as gpio_mod
+
+        calls = []
+        monkeypatch.setattr(
+            fp,
+            "flash_and_discover",
+            lambda **kw: calls.append(("usb", kw)) or [{"app_id": 0}],
+        )
+        monkeypatch.setattr(
+            fp,
+            "flash_and_discover_gpio",
+            lambda **kw: calls.append(("gpio", kw)) or [{"app_id": 0}],
+        )
+        monkeypatch.setattr(
+            gpio_mod, "available", lambda: gpio_available
+        )
+        fp.main(argv + ["--no-redis"])
+        return calls
+
+    def test_default_routes_to_gpio(self, monkeypatch):
+        calls = self._run_main(monkeypatch, ["--uf2", "x.uf2"])
+        assert [c[0] for c in calls] == ["gpio"]
+
+    def test_no_gpio_flag_routes_to_usb(self, monkeypatch):
+        calls = self._run_main(
+            monkeypatch, ["--uf2", "x.uf2", "--no-gpio"]
+        )
+        assert [c[0] for c in calls] == ["usb"]
+
+    def test_port_targeting_routes_to_usb(self, monkeypatch):
+        # GPIO mass reset cannot target a single Pico.
+        calls = self._run_main(
+            monkeypatch, ["--uf2", "x.uf2", "--port", "/dev/ttyACM0"]
+        )
+        assert [c[0] for c in calls] == ["usb"]
+        assert calls[0][1]["port"] == "/dev/ttyACM0"
+
+    def test_usb_serial_targeting_routes_to_usb(self, monkeypatch):
+        calls = self._run_main(
+            monkeypatch, ["--uf2", "x.uf2", "--usb-serial", "SER_A"]
+        )
+        assert [c[0] for c in calls] == ["usb"]
+        assert calls[0][1]["usb_serial"] == "SER_A"
+
+    def test_gpio_unavailable_fails_fast(self, monkeypatch, capsys):
+        # No silent fallback: tell the operator to fix the backend or
+        # pass --no-gpio explicitly.
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_main(
+                monkeypatch, ["--uf2", "x.uf2"], gpio_available=False
+            )
+        assert excinfo.value.code == 1
+        assert "--no-gpio" in capsys.readouterr().err
+
+    def test_gpio_flow_runtime_error_exits_nonzero(
+        self, monkeypatch, capsys
+    ):
+        import picohost.flash_picos as fp
+        import picohost.gpio as gpio_mod
+
+        monkeypatch.setattr(gpio_mod, "available", lambda: True)
+
+        def boom(**kw):
+            raise RuntimeError(
+                "no Picos entered BOOTSEL after mass GPIO entry"
+            )
+
+        monkeypatch.setattr(fp, "flash_and_discover_gpio", boom)
+        with pytest.raises(SystemExit) as excinfo:
+            fp.main(["--uf2", "x.uf2", "--no-redis"])
+        assert excinfo.value.code == 1
+        assert "BOOTSEL" in capsys.readouterr().err

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -360,6 +360,9 @@ class TestFlashUf2:
 
         monkeypatch.setattr(fp.subprocess, "run", fake_run)
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 35, False)
+        )
         return calls
 
     def test_succeeds_on_first_attempt(self, monkeypatch):
@@ -391,8 +394,103 @@ class TestFlashUf2:
         )
         sleeps = []
         monkeypatch.setattr(fp.time, "sleep", lambda s: sleeps.append(s))
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 35, False)
+        )
         flash_uf2("x.uf2", "SER_A", attempts=3, backoff=2.0)
         assert sleeps == [2.0]
+
+    def test_selects_cdc_by_bus_address_with_force(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (2, 9, False)
+        )
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A")
+        assert captured["cmd"] == [
+            "picotool", "load", "-f",
+            "--bus", "2", "--address", "9",
+            "-x", "x.uf2",
+        ]
+        assert "--ser" not in captured["cmd"]
+
+    def test_loads_bootsel_device_without_force(self, monkeypatch):
+        # A device already in BOOTSEL needs no reboot, so -f is omitted
+        # and picotool loads it straight away.
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (2, 9, True)
+        )
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A")
+        assert captured["cmd"] == [
+            "picotool", "load",
+            "--bus", "2", "--address", "9",
+            "-x", "x.uf2",
+        ]
+        assert "-f" not in captured["cmd"]
+
+    def test_reresolves_address_each_attempt(self, monkeypatch):
+        # Attempt 1 reboots the CDC device into BOOTSEL but the load
+        # fails; attempt 2 must re-resolve, find it now in BOOTSEL at a
+        # new address, and finish the load without -f.
+        import picohost.flash_picos as fp
+
+        addrs = iter([(1, 10, False), (1, 22, True)])
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: next(addrs)
+        )
+        codes = iter([1, 0])
+        seen = []
+
+        def fake_run(cmd, **kw):
+            seen.append(cmd)
+            return types.SimpleNamespace(returncode=next(codes), stdout="")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
+        assert seen[0][seen[0].index("--address") + 1] == "10"
+        assert "-f" in seen[0]
+        assert seen[1][seen[1].index("--address") + 1] == "22"
+        assert "-f" not in seen[1]
+
+    def test_unresolvable_attempt_skips_picotool_then_raises(
+        self, monkeypatch
+    ):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (None, None, None)
+        )
+        ran = []
+        monkeypatch.setattr(
+            fp.subprocess, "run", lambda *a, **k: ran.append(1)
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        with pytest.raises(RuntimeError, match="after 3 attempts"):
+            fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
+        assert ran == []
 
 
 class TestResolvePostFlashPort:
@@ -437,3 +535,82 @@ class TestResolvePostFlashPort:
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         assert _resolve_post_flash_port("SER_Z", timeout=1.0) == "/dev/ttyACM7"
         assert calls["n"] >= 3
+
+
+class TestResolveBusAddress:
+    def _make(
+        self, root, name, vid, pid, *, serial=None, bus=None, devnum=None
+    ):
+        dev = root / name
+        dev.mkdir()
+        (dev / "idVendor").write_text(vid + "\n")
+        (dev / "idProduct").write_text(pid + "\n")
+        if serial is not None:
+            (dev / "serial").write_text(serial + "\n")
+        if bus is not None:
+            (dev / "busnum").write_text(f"{bus}\n")
+        if devnum is not None:
+            (dev / "devnum").write_text(f"{devnum}\n")
+        return dev
+
+    def test_resolves_cdc_device(self, tmp_path):
+        from picohost.flash_picos import _resolve_bus_address
+
+        self._make(
+            tmp_path, "1-3", "2e8a", "0009",
+            serial="SER_A", bus=1, devnum=35,
+        )
+        assert _resolve_bus_address("SER_A", sysfs_root=tmp_path) == (
+            1,
+            35,
+            False,
+        )
+
+    def test_resolves_bootsel_device_flagged_in_bootsel(self, tmp_path):
+        # A device a prior attempt left stranded in BOOTSEL (000f) must
+        # still be found, flagged in_bootsel, so a retry can finish the
+        # load without another reboot rather than abandoning it.
+        from picohost.flash_picos import _resolve_bus_address
+
+        self._make(
+            tmp_path, "1-3", "2e8a", "000f",
+            serial="SER_A", bus=1, devnum=40,
+        )
+        assert _resolve_bus_address("SER_A", sysfs_root=tmp_path) == (
+            1,
+            40,
+            True,
+        )
+
+    def test_returns_none_when_serial_absent(self, tmp_path):
+        from picohost.flash_picos import _resolve_bus_address
+
+        self._make(
+            tmp_path, "1-3", "2e8a", "0009",
+            serial="SER_A", bus=1, devnum=35,
+        )
+        assert _resolve_bus_address("MISSING", sysfs_root=tmp_path) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_ignores_non_pico_with_matching_serial(self, tmp_path):
+        from picohost.flash_picos import _resolve_bus_address
+
+        self._make(
+            tmp_path, "1-4", "1234", "5678",
+            serial="SER_A", bus=1, devnum=41,
+        )
+        assert _resolve_bus_address("SER_A", sysfs_root=tmp_path) == (
+            None,
+            None,
+            None,
+        )
+
+    def test_returns_none_when_sysfs_missing(self, tmp_path):
+        from picohost.flash_picos import _resolve_bus_address
+
+        assert _resolve_bus_address(
+            "SER_A", sysfs_root=tmp_path / "nope"
+        ) == (None, None, None)

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -364,10 +364,26 @@ class TestFlashUf2:
 
         fp.flash_uf2("x.uf2", "SER_A")
         assert cmds == [
-            ["picotool", "reboot", "-u", "-f",
-             "--bus", "1", "--address", "104"],
-            ["picotool", "load",
-             "--bus", "1", "--address", "107", "-x", "x.uf2"],
+            [
+                "picotool",
+                "reboot",
+                "-u",
+                "-f",
+                "--bus",
+                "1",
+                "--address",
+                "104",
+            ],
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "107",
+                "-x",
+                "x.uf2",
+            ],
         ]
         assert "--ser" not in cmds[0] and "--ser" not in cmds[1]
         assert "-f" not in cmds[1]
@@ -395,8 +411,16 @@ class TestFlashUf2:
 
         fp.flash_uf2("x.uf2", "SER_A")
         assert cmds == [
-            ["picotool", "load",
-             "--bus", "1", "--address", "50", "-x", "x.uf2"],
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "50",
+                "-x",
+                "x.uf2",
+            ],
         ]
 
     def test_retries_load_then_succeeds(self, monkeypatch):
@@ -417,10 +441,26 @@ class TestFlashUf2:
 
         fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
         assert [c for c in cmds if c[1] == "load"] == [
-            ["picotool", "load",
-             "--bus", "1", "--address", "50", "-x", "x.uf2"],
-            ["picotool", "load",
-             "--bus", "1", "--address", "50", "-x", "x.uf2"],
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "50",
+                "-x",
+                "x.uf2",
+            ],
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "50",
+                "-x",
+                "x.uf2",
+            ],
         ]
 
     def test_raises_after_exhausting_attempts(self, monkeypatch):
@@ -482,12 +522,36 @@ class TestFlashUf2:
 
         fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
         assert cmds == [
-            ["picotool", "reboot", "-u", "-f",
-             "--bus", "1", "--address", "104"],
-            ["picotool", "load",
-             "--bus", "1", "--address", "107", "-x", "x.uf2"],
-            ["picotool", "load",
-             "--bus", "1", "--address", "107", "-x", "x.uf2"],
+            [
+                "picotool",
+                "reboot",
+                "-u",
+                "-f",
+                "--bus",
+                "1",
+                "--address",
+                "104",
+            ],
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "107",
+                "-x",
+                "x.uf2",
+            ],
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "107",
+                "-x",
+                "x.uf2",
+            ],
         ]
 
     def test_reboot_not_entering_bootsel_retries_then_raises(
@@ -500,9 +564,7 @@ class TestFlashUf2:
         monkeypatch.setattr(
             fp, "_resolve_bus_address", lambda s: (1, 104, False)
         )
-        monkeypatch.setattr(
-            fp, "_wait_for_bootsel", lambda s: (None, None)
-        )
+        monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s: (None, None))
         cmds = []
 
         def fake_run(cmd, **kw):
@@ -560,9 +622,7 @@ class TestWaitForBootsel:
         import picohost.flash_picos as fp
 
         seq = iter([(1, 104, False), (1, 104, False), (1, 107, True)])
-        monkeypatch.setattr(
-            fp, "_resolve_bus_address", lambda s: next(seq)
-        )
+        monkeypatch.setattr(fp, "_resolve_bus_address", lambda s: next(seq))
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         assert fp._wait_for_bootsel("SER_A", timeout=1.0) == (1, 107)
 
@@ -706,8 +766,10 @@ class TestReadDeviceInfo:
             # SER_B's port flakes once, then yields JSON.
             if port == "/dev/ttyACM6" and attempts[port] == 1:
                 raise RuntimeError("Timed out waiting for JSON")
-            return {"/dev/ttyACM5": {"app_id": 0},
-                    "/dev/ttyACM6": {"app_id": 5}}[port]
+            return {
+                "/dev/ttyACM5": {"app_id": 0},
+                "/dev/ttyACM6": {"app_id": 5},
+            }[port]
 
         m.monkeypatch.setattr(m.fp, "read_json_from_serial", flaky_read)
 
@@ -736,8 +798,13 @@ class TestResolveBusAddress:
         from picohost.flash_picos import _resolve_bus_address
 
         self._make(
-            tmp_path, "1-3", "2e8a", "0009",
-            serial="SER_A", bus=1, devnum=35,
+            tmp_path,
+            "1-3",
+            "2e8a",
+            "0009",
+            serial="SER_A",
+            bus=1,
+            devnum=35,
         )
         assert _resolve_bus_address("SER_A", sysfs_root=tmp_path) == (
             1,
@@ -752,8 +819,13 @@ class TestResolveBusAddress:
         from picohost.flash_picos import _resolve_bus_address
 
         self._make(
-            tmp_path, "1-3", "2e8a", "000f",
-            serial="SER_A", bus=1, devnum=40,
+            tmp_path,
+            "1-3",
+            "2e8a",
+            "000f",
+            serial="SER_A",
+            bus=1,
+            devnum=40,
         )
         assert _resolve_bus_address("SER_A", sysfs_root=tmp_path) == (
             1,
@@ -765,8 +837,13 @@ class TestResolveBusAddress:
         from picohost.flash_picos import _resolve_bus_address
 
         self._make(
-            tmp_path, "1-3", "2e8a", "0009",
-            serial="SER_A", bus=1, devnum=35,
+            tmp_path,
+            "1-3",
+            "2e8a",
+            "0009",
+            serial="SER_A",
+            bus=1,
+            devnum=35,
         )
         assert _resolve_bus_address("MISSING", sysfs_root=tmp_path) == (
             None,
@@ -778,8 +855,13 @@ class TestResolveBusAddress:
         from picohost.flash_picos import _resolve_bus_address
 
         self._make(
-            tmp_path, "1-4", "1234", "5678",
-            serial="SER_A", bus=1, devnum=41,
+            tmp_path,
+            "1-4",
+            "1234",
+            "5678",
+            serial="SER_A",
+            bus=1,
+            devnum=41,
         )
         assert _resolve_bus_address("SER_A", sysfs_root=tmp_path) == (
             None,
@@ -790,14 +872,14 @@ class TestResolveBusAddress:
     def test_returns_none_when_sysfs_missing(self, tmp_path):
         from picohost.flash_picos import _resolve_bus_address
 
-        assert _resolve_bus_address(
-            "SER_A", sysfs_root=tmp_path / "nope"
-        ) == (None, None, None)
+        assert _resolve_bus_address("SER_A", sysfs_root=tmp_path / "nope") == (
+            None,
+            None,
+            None,
+        )
 
 
-def _make_usb_dev(
-    root, name, vid, pid, *, serial=None, bus=None, devnum=None
-):
+def _make_usb_dev(root, name, vid, pid, *, serial=None, bus=None, devnum=None):
     """Create a fake sysfs USB device directory under *root*."""
     dev = root / name
     dev.mkdir()
@@ -833,9 +915,14 @@ class TestPicotoolLoad:
         captured = self._capture_run(monkeypatch)
         _picotool_load(2, 9, "x.uf2", execute=True)
         assert captured["cmd"] == [
-            "picotool", "load",
-            "--bus", "2", "--address", "9",
-            "-x", "x.uf2",
+            "picotool",
+            "load",
+            "--bus",
+            "2",
+            "--address",
+            "9",
+            "-x",
+            "x.uf2",
         ]
 
     def test_no_execute_omits_x(self, monkeypatch):
@@ -849,8 +936,12 @@ class TestPicotoolLoad:
         captured = self._capture_run(monkeypatch)
         _picotool_load(1, 42, "y.uf2", execute=False)
         assert captured["cmd"] == [
-            "picotool", "load",
-            "--bus", "1", "--address", "42",
+            "picotool",
+            "load",
+            "--bus",
+            "1",
+            "--address",
+            "42",
             "y.uf2",
         ]
         assert "-x" not in captured["cmd"]
@@ -870,21 +961,41 @@ class TestFindBootselDevices:
         from picohost.flash_picos import _find_bootsel_devices
 
         _make_usb_dev(
-            tmp_path, "1-4", "2e8a", "000f",
-            serial="SER_B", bus=1, devnum=51,
+            tmp_path,
+            "1-4",
+            "2e8a",
+            "000f",
+            serial="SER_B",
+            bus=1,
+            devnum=51,
         )
         _make_usb_dev(
-            tmp_path, "1-3", "2e8a", "000f",
-            serial="SER_A", bus=1, devnum=50,
+            tmp_path,
+            "1-3",
+            "2e8a",
+            "000f",
+            serial="SER_A",
+            bus=1,
+            devnum=50,
         )
         # CDC pico and non-pico devices must be ignored.
         _make_usb_dev(
-            tmp_path, "1-5", "2e8a", "0009",
-            serial="SER_C", bus=1, devnum=52,
+            tmp_path,
+            "1-5",
+            "2e8a",
+            "0009",
+            serial="SER_C",
+            bus=1,
+            devnum=52,
         )
         _make_usb_dev(
-            tmp_path, "1-6", "1234", "5678",
-            serial="SER_D", bus=1, devnum=53,
+            tmp_path,
+            "1-6",
+            "1234",
+            "5678",
+            serial="SER_D",
+            bus=1,
+            devnum=53,
         )
         assert _find_bootsel_devices(sysfs_root=tmp_path) == [
             {"usb_serial": "SER_A", "bus": 1, "address": 50},
@@ -1108,9 +1219,7 @@ class TestFlashAndDiscoverGpio:
         m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         assert m.events[0] == "enter_bootsel"
         assert m.events.count("reset") == 1
-        load_idx = [
-            i for i, e in enumerate(m.events) if isinstance(e, tuple)
-        ]
+        load_idx = [i for i, e in enumerate(m.events) if isinstance(e, tuple)]
         assert load_idx, "expected load events"
         assert m.events.index("reset") > max(load_idx)
 
@@ -1126,9 +1235,7 @@ class TestFlashAndDiscoverGpio:
 
     def test_empty_bootsel_set_raises(self, _mock_gpio_flash):
         m = _mock_gpio_flash
-        m.monkeypatch.setattr(
-            m.fp, "_wait_for_stable_bootsel_set", lambda: []
-        )
+        m.monkeypatch.setattr(m.fp, "_wait_for_stable_bootsel_set", lambda: [])
         with pytest.raises(RuntimeError, match="no Picos entered BOOTSEL"):
             m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
 
@@ -1183,15 +1290,11 @@ class TestFlashAndDiscoverGpio:
 
         def fake_run(cmd, **kw):
             m.cmds.append(cmd)
-            return types.SimpleNamespace(
-                returncode=next(codes), stdout=""
-            )
+            return types.SimpleNamespace(returncode=next(codes), stdout="")
 
         m.monkeypatch.setattr(m.fp.subprocess, "run", fake_run)
         m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        ser_a_addrs = [
-            c[c.index("--address") + 1] for c in m.cmds[:2]
-        ]
+        ser_a_addrs = [c[c.index("--address") + 1] for c in m.cmds[:2]]
         assert ser_a_addrs == ["50", "60"]
 
     def test_serialless_bootsel_device_reported_via_cdc(
@@ -1230,9 +1333,7 @@ class TestFlashAndDiscoverGpio:
     ):
         m = _mock_gpio_flash
         with pytest.raises(FileNotFoundError, match="UF2 file not found"):
-            m.fp.flash_and_discover_gpio(
-                uf2_path=tmp_path / "nonexistent.uf2"
-            )
+            m.fp.flash_and_discover_gpio(uf2_path=tmp_path / "nonexistent.uf2")
         assert m.events == []
 
 
@@ -1252,9 +1353,7 @@ class TestMainRouting:
             "flash_and_discover_gpio",
             lambda **kw: calls.append(("gpio", kw)) or [{"app_id": 0}],
         )
-        monkeypatch.setattr(
-            gpio_mod, "available", lambda: gpio_available
-        )
+        monkeypatch.setattr(gpio_mod, "available", lambda: gpio_available)
         fp.main(argv + ["--no-redis"])
         return calls
 
@@ -1263,9 +1362,7 @@ class TestMainRouting:
         assert [c[0] for c in calls] == ["gpio"]
 
     def test_no_gpio_flag_routes_to_usb(self, monkeypatch):
-        calls = self._run_main(
-            monkeypatch, ["--uf2", "x.uf2", "--no-gpio"]
-        )
+        calls = self._run_main(monkeypatch, ["--uf2", "x.uf2", "--no-gpio"])
         assert [c[0] for c in calls] == ["usb"]
 
     def test_port_targeting_routes_to_usb(self, monkeypatch):
@@ -1293,9 +1390,7 @@ class TestMainRouting:
         assert excinfo.value.code == 1
         assert "--no-gpio" in capsys.readouterr().err
 
-    def test_gpio_flow_runtime_error_exits_nonzero(
-        self, monkeypatch, capsys
-    ):
+    def test_gpio_flow_runtime_error_exits_nonzero(self, monkeypatch, capsys):
         import picohost.flash_picos as fp
         import picohost.gpio as gpio_mod
 

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -7,7 +7,6 @@ import pytest
 from picohost.flash_picos import (
     _resolve_post_flash_port,
     flash_and_discover,
-    flash_uf2,
 )
 
 
@@ -339,51 +338,114 @@ class TestFlashAndDiscover:
 
 
 class TestFlashUf2:
-    """picotool's ``-f`` reboots the target into BOOTSEL and must then
-    re-discover it before loading; on a busy hub that re-enumeration
-    can fall outside picotool's window and fail intermittently. The
-    flash step retries with backoff so a transient miss does not
-    abandon the device.
+    """flash_uf2 reboots a CDC Pico into BOOTSEL with ``picotool reboot``
+    — which, unlike ``load -f``, does not re-acquire the device by a live
+    serial-descriptor read (that read corrupts under bus contention on
+    the deep hub) — waits for it to re-enumerate in BOOTSEL via sysfs,
+    then loads it by ``--bus/--address`` without ``-f``. Retries with
+    backoff.
     """
 
-    def _patch_run(self, monkeypatch, returncodes):
-        """Make subprocess.run return the given codes in sequence."""
+    def test_cdc_device_rebooted_then_loaded(self, monkeypatch):
         import picohost.flash_picos as fp
 
-        calls = {"n": 0, "cmds": []}
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 104, False)
+        )
+        monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s: (1, 107))
+        cmds = []
 
-        def fake_run(cmd, **kwargs):
-            calls["cmds"].append(cmd)
-            rc = returncodes[calls["n"]]
-            calls["n"] += 1
-            return types.SimpleNamespace(returncode=rc, stdout="picotool out")
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return types.SimpleNamespace(returncode=0, stdout="")
 
         monkeypatch.setattr(fp.subprocess, "run", fake_run)
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A")
+        assert cmds == [
+            ["picotool", "reboot", "-u", "-f",
+             "--bus", "1", "--address", "104"],
+            ["picotool", "load",
+             "--bus", "1", "--address", "107", "-x", "x.uf2"],
+        ]
+        assert "--ser" not in cmds[0] and "--ser" not in cmds[1]
+        assert "-f" not in cmds[1]
+
+    def test_bootsel_device_loaded_directly(self, monkeypatch):
+        # A device already in BOOTSEL is loaded straight away — no reboot.
+        import picohost.flash_picos as fp
+
         monkeypatch.setattr(
-            fp, "_resolve_bus_address", lambda s: (1, 35, False)
+            fp, "_resolve_bus_address", lambda s: (1, 50, True)
         )
-        return calls
+        monkeypatch.setattr(
+            fp,
+            "_wait_for_bootsel",
+            lambda s: pytest.fail("must not reboot a BOOTSEL device"),
+        )
+        cmds = []
 
-    def test_succeeds_on_first_attempt(self, monkeypatch):
-        calls = self._patch_run(monkeypatch, [0])
-        flash_uf2("x.uf2", "SER_A")
-        assert calls["n"] == 1
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return types.SimpleNamespace(returncode=0, stdout="")
 
-    def test_retries_then_succeeds(self, monkeypatch):
-        calls = self._patch_run(monkeypatch, [1, 1, 0])
-        flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
-        assert calls["n"] == 3
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A")
+        assert cmds == [
+            ["picotool", "load",
+             "--bus", "1", "--address", "50", "-x", "x.uf2"],
+        ]
+
+    def test_retries_load_then_succeeds(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 50, True)
+        )
+        codes = iter([1, 0])
+        cmds = []
+
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return types.SimpleNamespace(returncode=next(codes), stdout="")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
+        assert [c for c in cmds if c[1] == "load"] == [
+            ["picotool", "load",
+             "--bus", "1", "--address", "50", "-x", "x.uf2"],
+            ["picotool", "load",
+             "--bus", "1", "--address", "50", "-x", "x.uf2"],
+        ]
 
     def test_raises_after_exhausting_attempts(self, monkeypatch):
-        calls = self._patch_run(monkeypatch, [1, 1, 1])
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 50, True)
+        )
+        monkeypatch.setattr(
+            fp.subprocess,
+            "run",
+            lambda cmd, **kw: types.SimpleNamespace(
+                returncode=1, stdout="boom"
+            ),
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         with pytest.raises(RuntimeError, match="after 3 attempts"):
-            flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
-        assert calls["n"] == 3
+            fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
 
     def test_backoff_between_attempts(self, monkeypatch):
         import picohost.flash_picos as fp
 
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 50, True)
+        )
         codes = iter([1, 0])
         monkeypatch.setattr(
             fp.subprocess,
@@ -394,85 +456,66 @@ class TestFlashUf2:
         )
         sleeps = []
         monkeypatch.setattr(fp.time, "sleep", lambda s: sleeps.append(s))
-        monkeypatch.setattr(
-            fp, "_resolve_bus_address", lambda s: (1, 35, False)
-        )
-        flash_uf2("x.uf2", "SER_A", attempts=3, backoff=2.0)
+        fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=2.0)
         assert sleeps == [2.0]
 
-    def test_selects_cdc_by_bus_address_with_force(self, monkeypatch):
+    def test_recovers_bootsel_device_on_retry(self, monkeypatch):
+        # Attempt 1: reboot CDC->BOOTSEL, load fails. Attempt 2: device
+        # is now already in BOOTSEL, so it loads directly (no reboot).
         import picohost.flash_picos as fp
 
+        resolves = iter([(1, 104, False), (1, 107, True)])
         monkeypatch.setattr(
-            fp, "_resolve_bus_address", lambda s: (2, 9, False)
+            fp, "_resolve_bus_address", lambda s: next(resolves)
         )
-        captured = {}
-
-        def fake_run(cmd, **kw):
-            captured["cmd"] = cmd
-            return types.SimpleNamespace(returncode=0, stdout="")
-
-        monkeypatch.setattr(fp.subprocess, "run", fake_run)
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-
-        fp.flash_uf2("x.uf2", "SER_A")
-        assert captured["cmd"] == [
-            "picotool", "load", "-f",
-            "--bus", "2", "--address", "9",
-            "-x", "x.uf2",
-        ]
-        assert "--ser" not in captured["cmd"]
-
-    def test_loads_bootsel_device_without_force(self, monkeypatch):
-        # A device already in BOOTSEL needs no reboot, so -f is omitted
-        # and picotool loads it straight away.
-        import picohost.flash_picos as fp
-
-        monkeypatch.setattr(
-            fp, "_resolve_bus_address", lambda s: (2, 9, True)
-        )
-        captured = {}
-
-        def fake_run(cmd, **kw):
-            captured["cmd"] = cmd
-            return types.SimpleNamespace(returncode=0, stdout="")
-
-        monkeypatch.setattr(fp.subprocess, "run", fake_run)
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-
-        fp.flash_uf2("x.uf2", "SER_A")
-        assert captured["cmd"] == [
-            "picotool", "load",
-            "--bus", "2", "--address", "9",
-            "-x", "x.uf2",
-        ]
-        assert "-f" not in captured["cmd"]
-
-    def test_reresolves_address_each_attempt(self, monkeypatch):
-        # Attempt 1 reboots the CDC device into BOOTSEL but the load
-        # fails; attempt 2 must re-resolve, find it now in BOOTSEL at a
-        # new address, and finish the load without -f.
-        import picohost.flash_picos as fp
-
-        addrs = iter([(1, 10, False), (1, 22, True)])
-        monkeypatch.setattr(
-            fp, "_resolve_bus_address", lambda s: next(addrs)
-        )
+        monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s: (1, 107))
         codes = iter([1, 0])
-        seen = []
+        cmds = []
 
         def fake_run(cmd, **kw):
-            seen.append(cmd)
-            return types.SimpleNamespace(returncode=next(codes), stdout="")
+            cmds.append(cmd)
+            rc = next(codes) if cmd[1] == "load" else 0
+            return types.SimpleNamespace(returncode=rc, stdout="")
 
         monkeypatch.setattr(fp.subprocess, "run", fake_run)
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
 
         fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
-        assert seen[0][seen[0].index("--address") + 1] == "10"
-        assert "-f" in seen[0]
-        assert seen[1][seen[1].index("--address") + 1] == "22"
-        assert "-f" not in seen[1]
+        assert cmds == [
+            ["picotool", "reboot", "-u", "-f",
+             "--bus", "1", "--address", "104"],
+            ["picotool", "load",
+             "--bus", "1", "--address", "107", "-x", "x.uf2"],
+            ["picotool", "load",
+             "--bus", "1", "--address", "107", "-x", "x.uf2"],
+        ]
+
+    def test_reboot_not_entering_bootsel_retries_then_raises(
+        self, monkeypatch
+    ):
+        # The reboot request is lost on the congested hub: the device
+        # never enters BOOTSEL, so no load is attempted and it retries.
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 104, False)
+        )
+        monkeypatch.setattr(
+            fp, "_wait_for_bootsel", lambda s: (None, None)
+        )
+        cmds = []
+
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return types.SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        with pytest.raises(RuntimeError, match="after 2 attempts"):
+            fp.flash_uf2("x.uf2", "SER_A", attempts=2, backoff=0.0)
+        assert all(c[1] == "reboot" for c in cmds)
+        assert len(cmds) == 2
 
     def test_unresolvable_attempt_skips_picotool_then_raises(
         self, monkeypatch
@@ -491,6 +534,37 @@ class TestFlashUf2:
         with pytest.raises(RuntimeError, match="after 3 attempts"):
             fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
         assert ran == []
+
+
+class TestWaitForBootsel:
+    def test_returns_address_when_in_bootsel(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 107, True)
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        assert fp._wait_for_bootsel("SER_A", timeout=0.1) == (1, 107)
+
+    def test_returns_none_on_timeout(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        # Never enters BOOTSEL (stays CDC) -> times out.
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 104, False)
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        assert fp._wait_for_bootsel("SER_A", timeout=0.05) == (None, None)
+
+    def test_waits_through_cdc_then_bootsel(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        seq = iter([(1, 104, False), (1, 104, False), (1, 107, True)])
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: next(seq)
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        assert fp._wait_for_bootsel("SER_A", timeout=1.0) == (1, 107)
 
 
 class TestResolvePostFlashPort:
@@ -614,3 +688,183 @@ class TestResolveBusAddress:
         assert _resolve_bus_address(
             "SER_A", sysfs_root=tmp_path / "nope"
         ) == (None, None, None)
+
+
+def _make_usb_dev(
+    root, name, vid, pid, *, serial=None, bus=None, devnum=None
+):
+    """Create a fake sysfs USB device directory under *root*."""
+    dev = root / name
+    dev.mkdir()
+    (dev / "idVendor").write_text(vid + "\n")
+    (dev / "idProduct").write_text(pid + "\n")
+    if serial is not None:
+        (dev / "serial").write_text(serial + "\n")
+    if bus is not None:
+        (dev / "busnum").write_text(f"{bus}\n")
+    if devnum is not None:
+        (dev / "devnum").write_text(f"{devnum}\n")
+    return dev
+
+
+class TestPicotoolLoad:
+    def _capture_run(self, monkeypatch, returncode=0):
+        import picohost.flash_picos as fp
+
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(
+                returncode=returncode, stdout="picotool out"
+            )
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        return captured
+
+    def test_execute_appends_x(self, monkeypatch):
+        from picohost.flash_picos import _picotool_load
+
+        captured = self._capture_run(monkeypatch)
+        _picotool_load(2, 9, "x.uf2", execute=True)
+        assert captured["cmd"] == [
+            "picotool", "load",
+            "--bus", "2", "--address", "9",
+            "-x", "x.uf2",
+        ]
+
+    def test_no_execute_omits_x(self, monkeypatch):
+        # The GPIO mass-flash path loads without -x: the device stays in
+        # BOOTSEL (no re-enumeration) and a single mass reset at the end
+        # boots every pico. -f must never appear either — its reboot
+        # path does the live serial-descriptor read that corrupts under
+        # hub contention.
+        from picohost.flash_picos import _picotool_load
+
+        captured = self._capture_run(monkeypatch)
+        _picotool_load(1, 42, "y.uf2", execute=False)
+        assert captured["cmd"] == [
+            "picotool", "load",
+            "--bus", "1", "--address", "42",
+            "y.uf2",
+        ]
+        assert "-x" not in captured["cmd"]
+        assert "-f" not in captured["cmd"]
+
+    def test_returns_completed_process(self, monkeypatch):
+        from picohost.flash_picos import _picotool_load
+
+        self._capture_run(monkeypatch, returncode=1)
+        res = _picotool_load(1, 42, "y.uf2", execute=False)
+        assert res.returncode == 1
+        assert res.stdout == "picotool out"
+
+
+class TestFindBootselDevices:
+    def test_finds_all_bootsel_devices_sorted(self, tmp_path):
+        from picohost.flash_picos import _find_bootsel_devices
+
+        _make_usb_dev(
+            tmp_path, "1-4", "2e8a", "000f",
+            serial="SER_B", bus=1, devnum=51,
+        )
+        _make_usb_dev(
+            tmp_path, "1-3", "2e8a", "000f",
+            serial="SER_A", bus=1, devnum=50,
+        )
+        # CDC pico and non-pico devices must be ignored.
+        _make_usb_dev(
+            tmp_path, "1-5", "2e8a", "0009",
+            serial="SER_C", bus=1, devnum=52,
+        )
+        _make_usb_dev(
+            tmp_path, "1-6", "1234", "5678",
+            serial="SER_D", bus=1, devnum=53,
+        )
+        assert _find_bootsel_devices(sysfs_root=tmp_path) == [
+            {"usb_serial": "SER_A", "bus": 1, "address": 50},
+            {"usb_serial": "SER_B", "bus": 1, "address": 51},
+        ]
+
+    def test_serial_optional(self, tmp_path):
+        # A wiped board can enumerate in BOOTSEL without a serial; it
+        # must still be flashable (keyed by bus/address).
+        from picohost.flash_picos import _find_bootsel_devices
+
+        _make_usb_dev(tmp_path, "1-3", "2e8a", "000f", bus=1, devnum=50)
+        assert _find_bootsel_devices(sysfs_root=tmp_path) == [
+            {"usb_serial": None, "bus": 1, "address": 50},
+        ]
+
+    def test_skips_device_missing_busnum(self, tmp_path):
+        from picohost.flash_picos import _find_bootsel_devices
+
+        _make_usb_dev(tmp_path, "1-3", "2e8a", "000f", serial="SER_A")
+        assert _find_bootsel_devices(sysfs_root=tmp_path) == []
+
+    def test_empty_when_sysfs_missing(self, tmp_path):
+        from picohost.flash_picos import _find_bootsel_devices
+
+        assert _find_bootsel_devices(sysfs_root=tmp_path / "nope") == []
+
+
+class TestWaitForStableBootselSet:
+    def _scanner(self, monkeypatch, frames):
+        """Patch _find_bootsel_devices to step through *frames*, then
+        repeat the last frame forever."""
+        import picohost.flash_picos as fp
+
+        calls = {"n": 0}
+
+        def fake_find():
+            idx = min(calls["n"], len(frames) - 1)
+            calls["n"] += 1
+            return frames[idx]
+
+        monkeypatch.setattr(fp, "_find_bootsel_devices", fake_find)
+        return calls
+
+    def test_returns_after_set_stabilizes(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        d1 = {"usb_serial": "SER_A", "bus": 1, "address": 50}
+        d2 = {"usb_serial": "SER_B", "bus": 1, "address": 51}
+        self._scanner(monkeypatch, [[], [d1], [d1, d2]])
+        result = fp._wait_for_stable_bootsel_set(
+            timeout=5.0, stable=0.05, poll=0.005
+        )
+        assert result == [d1, d2]
+
+    def test_waits_through_growing_set(self, monkeypatch):
+        # Devices enumerate one by one; the wait must not latch onto
+        # the first non-empty set it sees.
+        import picohost.flash_picos as fp
+
+        d1 = {"usb_serial": "SER_A", "bus": 1, "address": 50}
+        d2 = {"usb_serial": "SER_B", "bus": 1, "address": 51}
+        self._scanner(monkeypatch, [[d1], [d1], [d1], [d1, d2]])
+        result = fp._wait_for_stable_bootsel_set(
+            timeout=5.0, stable=0.3, poll=0.005
+        )
+        assert result == [d1, d2]
+
+    def test_empty_on_timeout_when_nothing_appears(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        self._scanner(monkeypatch, [[]])
+        result = fp._wait_for_stable_bootsel_set(
+            timeout=0.05, stable=0.5, poll=0.005
+        )
+        assert result == []
+
+    def test_returns_last_seen_on_timeout(self, monkeypatch):
+        # The set never stabilizes within the timeout; the last
+        # observation is returned so the caller can proceed/warn.
+        import picohost.flash_picos as fp
+
+        d1 = {"usb_serial": "SER_A", "bus": 1, "address": 50}
+        self._scanner(monkeypatch, [[d1]])
+        result = fp._wait_for_stable_bootsel_set(
+            timeout=0.05, stable=10.0, poll=0.005
+        )
+        assert result == [d1]

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -611,6 +611,111 @@ class TestResolvePostFlashPort:
         assert calls["n"] >= 3
 
 
+class TestReadDeviceInfo:
+    """The post-flash device-info readback retries before giving up.
+
+    After the GPIO mass reset the whole fleet re-enumerates at once, so
+    a board that flashed fine can briefly fail to yield its JSON — a
+    single timeout must not drop it.
+    """
+
+    def _patch_common(self, monkeypatch, fp):
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+    def test_retries_then_succeeds(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        self._patch_common(monkeypatch, fp)
+        monkeypatch.setattr(
+            fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
+        )
+
+        attempts = {"n": 0}
+
+        def fake_read(port, baud, timeout):
+            attempts["n"] += 1
+            if attempts["n"] == 1:  # first read flakes
+                raise RuntimeError("Timed out waiting for JSON")
+            return {"app_id": 3}
+
+        monkeypatch.setattr(fp, "read_json_from_serial", fake_read)
+
+        data = fp._read_device_info("SER_A", 115200, 1)
+        assert data == {
+            "app_id": 3,
+            "port": "/dev/ttyACM0",
+            "usb_serial": "SER_A",
+        }
+        assert attempts["n"] == 2
+
+    def test_returns_none_after_exhausting_attempts(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        self._patch_common(monkeypatch, fp)
+        monkeypatch.setattr(
+            fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
+        )
+
+        calls = {"n": 0}
+
+        def always_timeout(port, baud, timeout):
+            calls["n"] += 1
+            raise RuntimeError("Timed out waiting for JSON")
+
+        monkeypatch.setattr(fp, "read_json_from_serial", always_timeout)
+
+        data = fp._read_device_info("SER_A", 115200, 1, attempts=3)
+        assert data is None
+        assert calls["n"] == 3
+
+    def test_reresolves_port_each_attempt(self, monkeypatch):
+        """The port may rename across re-enumeration; resolve it fresh
+        on every attempt rather than reusing a stale path."""
+        import picohost.flash_picos as fp
+
+        self._patch_common(monkeypatch, fp)
+
+        ports = iter(["/dev/ttyACM0", "/dev/ttyACM4"])
+        monkeypatch.setattr(
+            fp, "_resolve_post_flash_port", lambda s: next(ports)
+        )
+
+        seen = []
+
+        def fake_read(port, baud, timeout):
+            seen.append(port)
+            if len(seen) == 1:
+                raise RuntimeError("Timed out waiting for JSON")
+            return {"app_id": 0}
+
+        monkeypatch.setattr(fp, "read_json_from_serial", fake_read)
+
+        data = fp._read_device_info("SER_A", 115200, 1)
+        assert seen == ["/dev/ttyACM0", "/dev/ttyACM4"]
+        assert data["port"] == "/dev/ttyACM4"
+
+    def test_gpio_flow_recovers_flaky_readback(self, _mock_gpio_flash):
+        """End-to-end: a board whose first read times out is still
+        published once the retry succeeds."""
+        m = _mock_gpio_flash
+        attempts = {"/dev/ttyACM5": 0, "/dev/ttyACM6": 0}
+
+        def flaky_read(port, baud, timeout):
+            attempts[port] += 1
+            # SER_B's port flakes once, then yields JSON.
+            if port == "/dev/ttyACM6" and attempts[port] == 1:
+                raise RuntimeError("Timed out waiting for JSON")
+            return {"/dev/ttyACM5": {"app_id": 0},
+                    "/dev/ttyACM6": {"app_id": 5}}[port]
+
+        m.monkeypatch.setattr(m.fp, "read_json_from_serial", flaky_read)
+
+        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+
+        assert sorted(d["usb_serial"] for d in devices) == ["SER_A", "SER_B"]
+
+
 class TestResolveBusAddress:
     def _make(
         self, root, name, vid, pid, *, serial=None, bus=None, devnum=None
@@ -875,8 +980,17 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
     """Patch GPIO actions, sysfs scans, picotool, and serial reads so
     flash_and_discover_gpio can run without hardware.
 
-    picotool invocations go through a fake subprocess.run so the tests
-    can assert on the *actual* argv (no reboot, no -x, no -f).
+    ``find_pico_ports`` and ``_find_bootsel_devices`` are time-dependent:
+    they return the pre-entry view until ``gpio.reset()`` fires, then the
+    post-reset view (the flashed fleet back in CDC under their real CDC
+    serials, and whatever is still stuck in BOOTSEL). picotool goes
+    through a fake subprocess.run so tests can assert the actual argv
+    (no reboot, no -x, no -f).
+
+    Tests tweak behaviour by mutating the exposed dicts/lists in place:
+    ``bootsel`` (BOOTSEL set), ``pre_cdc`` (CDC before entry), ``post_cdc``
+    (CDC after reset), ``reads`` (port → JSON), ``stuck`` (still in
+    BOOTSEL after reset).
     """
     import picohost.flash_picos as fp
     import picohost.gpio as gpio_mod
@@ -884,27 +998,45 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
     uf2 = tmp_path / "test.uf2"
     uf2.write_bytes(b"\x00")
 
+    state = {"reset_done": False}
     events = []
     monkeypatch.setattr(
         gpio_mod, "enter_bootsel", lambda: events.append("enter_bootsel")
     )
-    monkeypatch.setattr(
-        gpio_mod, "reset", lambda: events.append("reset")
-    )
+
+    def fake_reset():
+        events.append("reset")
+        state["reset_done"] = True
+
+    monkeypatch.setattr(gpio_mod, "reset", fake_reset)
 
     bootsel = [
         {"usb_serial": "SER_A", "bus": 1, "address": 50},
         {"usb_serial": "SER_B", "bus": 1, "address": 51},
     ]
+    # CDC view before the mass entry (only used for the missing-from-
+    # BOOTSEL warning).
+    pre_cdc = {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"}
+    # CDC view after the mass reset: the flashed fleet, at new /dev nodes
+    # and under their real CDC serials.
+    post_cdc = {"/dev/ttyACM5": "SER_A", "/dev/ttyACM6": "SER_B"}
+    reads = {"/dev/ttyACM5": {"app_id": 0}, "/dev/ttyACM6": {"app_id": 5}}
+    # Boards still in BOOTSEL after the reset (default: none).
+    stuck = []
+
     monkeypatch.setattr(
         fp, "_wait_for_stable_bootsel_set", lambda: list(bootsel)
     )
-    monkeypatch.setattr(fp, "_find_bootsel_devices", lambda: list(bootsel))
-    monkeypatch.setattr(
-        fp,
-        "find_pico_ports",
-        lambda: {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"},
-    )
+
+    def fake_find_bootsel():
+        return list(stuck) if state["reset_done"] else list(bootsel)
+
+    monkeypatch.setattr(fp, "_find_bootsel_devices", fake_find_bootsel)
+
+    def fake_find_pico_ports():
+        return dict(post_cdc) if state["reset_done"] else dict(pre_cdc)
+
+    monkeypatch.setattr(fp, "find_pico_ports", fake_find_pico_ports)
 
     cmds = []
 
@@ -918,16 +1050,13 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
     monkeypatch.setattr(
         fp,
         "_resolve_post_flash_port",
-        lambda s: {"SER_A": "/dev/ttyACM5", "SER_B": "/dev/ttyACM6"}[s],
+        lambda s: {v: k for k, v in post_cdc.items()}.get(s),
     )
     monkeypatch.setattr(fp, "_udev_settle", lambda: None)
     monkeypatch.setattr(
         fp,
         "read_json_from_serial",
-        lambda port, baud, timeout: {
-            "/dev/ttyACM5": {"app_id": 0},
-            "/dev/ttyACM6": {"app_id": 5},
-        }[port],
+        lambda port, baud, timeout: reads[port],
     )
     monkeypatch.setattr(fp.time, "sleep", lambda _: None)
 
@@ -936,6 +1065,10 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
         events=events,
         cmds=cmds,
         bootsel=bootsel,
+        pre_cdc=pre_cdc,
+        post_cdc=post_cdc,
+        reads=reads,
+        stuck=stuck,
         fp=fp,
         monkeypatch=monkeypatch,
     )
@@ -987,15 +1120,7 @@ class TestFlashAndDiscoverGpio:
         # SER_C was a live CDC Pico before the mass entry but never
         # appeared in BOOTSEL — name it so the operator notices.
         m = _mock_gpio_flash
-        m.monkeypatch.setattr(
-            m.fp,
-            "find_pico_ports",
-            lambda: {
-                "/dev/ttyACM0": "SER_A",
-                "/dev/ttyACM1": "SER_B",
-                "/dev/ttyACM2": "SER_C",
-            },
-        )
+        m.pre_cdc["/dev/ttyACM2"] = "SER_C"
         m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         assert "SER_C" in caplog.text
 
@@ -1010,10 +1135,14 @@ class TestFlashAndDiscoverGpio:
     def test_failed_load_excluded_but_reset_still_fires(
         self, _mock_gpio_flash
     ):
-        # SER_A's load never succeeds: it is excluded from the results,
-        # but the mass reset must still run (it cannot target — and the
-        # stragglers reboot into whatever firmware they have).
+        # SER_A's load never succeeds: it never reaches CDC (stuck in
+        # BOOTSEL) so it is absent from the results, but the mass reset
+        # must still run (it cannot target — and the stragglers reboot
+        # into whatever firmware they have).
         m = _mock_gpio_flash
+        del m.post_cdc["/dev/ttyACM5"]  # SER_A doesn't come back to CDC
+        m.reads.pop("/dev/ttyACM5", None)
+        m.stuck.append({"usb_serial": "SER_A", "bus": 1, "address": 50})
 
         def fake_run(cmd, **kw):
             m.cmds.append(cmd)
@@ -1026,6 +1155,17 @@ class TestFlashAndDiscoverGpio:
         devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         assert [d["usb_serial"] for d in devices] == ["SER_B"]
         assert m.events.count("reset") == 1
+
+    def test_stuck_in_bootsel_after_reset_is_logged(
+        self, _mock_gpio_flash, caplog
+    ):
+        # A board still in BOOTSEL after the mass reset never took the
+        # flash — surface it by serial/bus/address for the operator.
+        m = _mock_gpio_flash
+        m.stuck.append({"usb_serial": "SER_B", "bus": 1, "address": 51})
+        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert "still in BOOTSEL" in caplog.text
+        assert "SER_B" in caplog.text
 
     def test_load_retry_reresolves_address(self, _mock_gpio_flash):
         # A failed load retries against a freshly resolved address in
@@ -1054,14 +1194,35 @@ class TestFlashAndDiscoverGpio:
         ]
         assert ser_a_addrs == ["50", "60"]
 
-    def test_serialless_device_flashed_but_not_in_results(
+    def test_serialless_bootsel_device_reported_via_cdc(
         self, _mock_gpio_flash
     ):
+        # A board with no serial in BOOTSEL still flashes (by bus/
+        # address) and, once it reboots into CDC under its real serial,
+        # is reported — the readback keys off the CDC serial, not the
+        # BOOTSEL one.
         m = _mock_gpio_flash
         m.bootsel.append({"usb_serial": None, "bus": 1, "address": 52})
+        m.post_cdc["/dev/ttyACM7"] = "SER_C"
+        m.reads["/dev/ttyACM7"] = {"app_id": 6}
         devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         flashed_addrs = {c[c.index("--address") + 1] for c in m.cmds}
         assert "52" in flashed_addrs
+        assert {d["usb_serial"] for d in devices} == {
+            "SER_A",
+            "SER_B",
+            "SER_C",
+        }
+
+    def test_reports_board_with_mismatched_bootsel_serial(
+        self, _mock_gpio_flash
+    ):
+        # The serial a board presents in BOOTSEL can differ from its CDC
+        # serial; keying the readback off the CDC serial still reports it.
+        m = _mock_gpio_flash
+        m.pre_cdc.clear()  # boards were already in BOOTSEL, not prior CDC
+        m.bootsel[0]["usb_serial"] = "BOOTSEL_ONLY"  # SER_A in BOOTSEL
+        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
 
     def test_missing_uf2_raises_before_any_gpio_action(

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -339,12 +339,41 @@ class TestMainAutoDiscover:
 
         main()
 
-        serials = sorted(c["usb_serial"] for c in calls)
-        assert serials == ["AAA", "BBB"]
+        # Both devices expose bus/address, so we flash by those (not
+        # --ser), which is reliable on the congested hub.
+        addrs = sorted((c["bus"], c["address"]) for c in calls)
+        assert addrs == [(1, 3), (1, 4)]
         for c in calls:
-            assert c["bus"] is None
-            assert c["address"] is None
+            assert c["usb_serial"] is None
             assert c["uf2"] == str(uf2)
+
+    def test_prefers_bus_address_over_serial(self, monkeypatch, tmp_path):
+        # A discovered BOOTSEL device with BOTH serial and bus/address is
+        # flashed by bus/address: --ser forces a serial-string descriptor
+        # read that intermittently fails on the congested hub.
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        sysfs = tmp_path / "sysfs"
+        sysfs.mkdir()
+        _make_usb_device(
+            sysfs, "1-1", "2e8a", "000f", serial="AAA", bus=1, devnum=9
+        )
+
+        monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)
+        calls = []
+
+        def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
+            calls.append(
+                {"bus": bus, "address": address, "usb_serial": usb_serial}
+            )
+
+        monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
+        monkeypatch.setattr("sys.argv", ["flash-test", "--uf2", str(uf2)])
+
+        main()
+        assert calls == [
+            {"bus": 1, "address": 9, "usb_serial": None},
+        ]
 
     def test_no_devices_exits_error(self, monkeypatch, tmp_path):
         uf2 = tmp_path / "test.uf2"
@@ -444,8 +473,9 @@ class TestMainAutoDiscover:
         attempted = []
 
         def fake_flash(uf2_path, bus=None, address=None, usb_serial=None):
-            attempted.append(usb_serial)
-            if usb_serial == "AAA":
+            # Flashed by bus/address now, so key the failure on address.
+            attempted.append(address)
+            if address == 3:
                 raise RuntimeError("picotool failed")
 
         monkeypatch.setattr(flash_test_mod, "flash_test_image", fake_flash)
@@ -454,7 +484,7 @@ class TestMainAutoDiscover:
         with pytest.raises(SystemExit) as exc_info:
             main()
         assert exc_info.value.code == 1
-        assert sorted(attempted) == ["AAA", "BBB"]
+        assert sorted(attempted) == [3, 4]
 
     def test_falls_back_to_bus_address_when_no_serial(
         self, monkeypatch, tmp_path
@@ -532,5 +562,5 @@ class TestMainAutoDiscover:
             main()
         assert exc_info.value.code == 1
         assert calls == [
-            {"bus": None, "address": None, "usb_serial": "AAA"},
+            {"bus": 1, "address": 3, "usb_serial": None},
         ]

--- a/picohost/tests/test_flash_test.py
+++ b/picohost/tests/test_flash_test.py
@@ -186,7 +186,7 @@ class TestFindBootselDevices:
             tmp_path,
             "1-3",
             "2e8a",
-            "0003",
+            "000f",
             serial="E66160F4ABCDEF01",
             bus=1,
             devnum=4,
@@ -200,7 +200,7 @@ class TestFindBootselDevices:
             tmp_path,
             "1-4",
             "2E8A",
-            "0003",
+            "000f",
             serial="UPPER1",
             bus=2,
             devnum=5,
@@ -214,7 +214,7 @@ class TestFindBootselDevices:
             tmp_path,
             "1-3",
             "2e8a",
-            "0003",
+            "000f",
             serial="AAA",
             bus=1,
             devnum=3,
@@ -223,7 +223,7 @@ class TestFindBootselDevices:
             tmp_path,
             "1-5",
             "2e8a",
-            "0003",
+            "000f",
             serial="BBB",
             bus=1,
             devnum=6,
@@ -245,7 +245,7 @@ class TestFindBootselDevices:
         dev = tmp_path / "1-6"
         dev.mkdir()
         (dev / "idVendor").write_text("2e8a\n")
-        (dev / "idProduct").write_text("0003\n")
+        (dev / "idProduct").write_text("000f\n")
         # no serial, no busnum, no devnum
         devs = find_bootsel_devices(tmp_path)
         assert devs == [
@@ -305,7 +305,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-1",
             "2e8a",
-            "0003",
+            "000f",
             serial="AAA",
             bus=1,
             devnum=3,
@@ -314,7 +314,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-2",
             "2e8a",
-            "0003",
+            "000f",
             serial="BBB",
             bus=1,
             devnum=4,
@@ -376,7 +376,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-1",
             "2e8a",
-            "0003",
+            "000f",
             serial="AAA",
             bus=1,
             devnum=3,
@@ -385,7 +385,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-2",
             "2e8a",
-            "0003",
+            "000f",
             serial="BBB",
             bus=1,
             devnum=4,
@@ -424,7 +424,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-1",
             "2e8a",
-            "0003",
+            "000f",
             serial="AAA",
             bus=1,
             devnum=3,
@@ -433,7 +433,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-2",
             "2e8a",
-            "0003",
+            "000f",
             serial="BBB",
             bus=1,
             devnum=4,
@@ -466,7 +466,7 @@ class TestMainAutoDiscover:
         dev = sysfs / "1-1"
         dev.mkdir()
         (dev / "idVendor").write_text("2e8a\n")
-        (dev / "idProduct").write_text("0003\n")
+        (dev / "idProduct").write_text("000f\n")
         (dev / "busnum").write_text("1\n")
         (dev / "devnum").write_text("7\n")
         # no serial file
@@ -502,7 +502,7 @@ class TestMainAutoDiscover:
             sysfs,
             "1-1",
             "2e8a",
-            "0003",
+            "000f",
             serial="AAA",
             bus=1,
             devnum=3,
@@ -510,7 +510,7 @@ class TestMainAutoDiscover:
         dev = sysfs / "1-2"
         dev.mkdir()
         (dev / "idVendor").write_text("2e8a\n")
-        (dev / "idProduct").write_text("0003\n")
+        (dev / "idProduct").write_text("000f\n")
         # no serial, no busnum/devnum -> incomplete selector
 
         monkeypatch.setattr(flash_test_mod, "SYSFS_USB_DEVICES", sysfs)

--- a/picohost/tests/test_gpio.py
+++ b/picohost/tests/test_gpio.py
@@ -1,96 +1,130 @@
-"""Tests for picohost.gpio — mass BOOTSEL/reset via bussed GPIO lines.
+"""Tests for picohost.gpio — mass BOOTSEL/reset via the ``pinctrl`` CLI.
 
-All assertions run against gpiozero's mock pin factory (installed by
-the ``mock_pins`` conftest fixture). The wiring uses inverting
-drivers: driving a Pi pin HIGH pulls the bussed pico line to ground
-(assert); driving it LOW releases the line. The ordering tests record
-``OutputDevice.on``/``off`` and ``_set_function`` events to prove the
-sequence and that every line is released even on error.
+The bussed control lines use inverting drivers: ``pinctrl set <gpio> op
+dh`` (drive-high) grounds the bussed pico line (assert), and ``dl``
+(drive-low) releases it. These tests mock ``subprocess.run`` so no real
+GPIO is ever touched, and assert the exact ``(gpio, level)`` sequence
+plus that both lines are released even on error.
 """
 
+import subprocess
+
 import pytest
-from gpiozero import OutputDevice
-from gpiozero.pins.mock import MockPin
 
 import picohost.gpio as gpio
 
+ASSERT = gpio._ASSERT
+RELEASE = gpio._RELEASE
+
 
 @pytest.fixture
-def events(monkeypatch, mock_pins):
-    """Record OutputDevice.on/off calls and pin function changes.
+def pinctrl(monkeypatch):
+    """Record pinctrl invocations as ``(gpio, level)`` tuples.
 
-    Entries are ``("on", pin)``, ``("off", pin)`` and
-    ``("func", pin, value)`` tuples; pins compare by identity, and the
-    mock factory caches instances, so they can be matched against
-    ``mock_pins.pin(n)``.
+    Patches ``subprocess.run`` in :mod:`picohost.gpio` (so nothing
+    touches real hardware) and no-ops ``time.sleep``. Returns the list
+    of recorded calls in order; tests that need ``sleep`` to raise can
+    re-monkeypatch it (their override wins over this fixture's).
     """
-    log = []
+    calls = []
 
-    orig_on = OutputDevice.on
+    def fake_run(cmd, **kwargs):
+        assert cmd[:2] == ["pinctrl", "set"]
+        assert cmd[3] == "op"
+        calls.append((int(cmd[2]), cmd[4]))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
 
-    def spy_on(self):
-        log.append(("on", self.pin))
-        orig_on(self)
+    monkeypatch.setattr(gpio.subprocess, "run", fake_run)
+    monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
+    return calls
 
-    monkeypatch.setattr(OutputDevice, "on", spy_on)
 
-    orig_off = OutputDevice.off
+def _last_level_per_gpio(calls):
+    last = {}
+    for g, level in calls:
+        last[g] = level
+    return last
 
-    def spy_off(self):
-        log.append(("off", self.pin))
-        orig_off(self)
 
-    monkeypatch.setattr(OutputDevice, "off", spy_off)
+class TestPinctrl:
+    def test_invokes_subprocess_with_check(self, monkeypatch):
+        """`pinctrl set <gpio> op <level>`, with check=True so a
+        nonzero exit raises rather than silently no-op'ing the line."""
+        seen = {}
 
-    orig_set = MockPin._set_function
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            seen["check"] = kwargs.get("check")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
 
-    def spy_set(self, value):
-        log.append(("func", self, value))
-        orig_set(self, value)
+        monkeypatch.setattr(gpio.subprocess, "run", fake_run)
 
-    monkeypatch.setattr(MockPin, "_set_function", spy_set)
-    return log
+        gpio._pinctrl(17, "dh")
+
+        assert seen["cmd"] == ["pinctrl", "set", "17", "op", "dh"]
+        assert seen["check"] is True
+
+    def test_raises_on_nonzero_exit(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd, "", "boom")
+
+        monkeypatch.setattr(gpio.subprocess, "run", fake_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            gpio._pinctrl(17, "dh")
 
 
 class TestEnterBootsel:
-    def test_sequence_order(self, events, mock_pins, monkeypatch):
-        """Reset first, BOOTSEL while held in reset, release in order.
+    def test_sequence_order(self, pinctrl):
+        """17 dh, 18 dh, 17 dl, 18 dl — the verified-reliable order.
 
-        Asserting RESET before BOOTSEL means the shared QSPI-CS line is
-        only pulled low while the picos are already halted; the bootrom
-        samples BOOTSEL as RUN is released, so RUN must be released
-        before BOOTSEL.
+        Asserting RUN before BOOTSEL keeps the shared QSPI-CS line
+        pulled only while the picos are halted; releasing RUN before
+        BOOTSEL lets the bootrom sample BOOTSEL as they exit reset.
         """
+        gpio.enter_bootsel()
+
+        assert pinctrl == [
+            (gpio.RUN_GPIO, ASSERT),
+            (gpio.BOOTSEL_GPIO, ASSERT),
+            (gpio.RUN_GPIO, RELEASE),
+            (gpio.BOOTSEL_GPIO, RELEASE),
+        ]
+
+    def test_exact_argv(self, monkeypatch):
+        """Each step shells out as ``pinctrl set <gpio> op <dh|dl>``."""
+        argvs = []
+
+        def fake_run(cmd, **kwargs):
+            argvs.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(gpio.subprocess, "run", fake_run)
         monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
 
         gpio.enter_bootsel()
 
-        bootsel = mock_pins.pin(gpio.BOOTSEL_GPIO)
-        run = mock_pins.pin(gpio.RUN_GPIO)
-        # list.index finds the first occurrence of each event.
-        assert (
-            events.index(("on", run))
-            < events.index(("on", bootsel))
-            < events.index(("off", run))
-            < events.index(("off", bootsel))
-        )
+        assert argvs[:4] == [
+            ["pinctrl", "set", "17", "op", "dh"],
+            ["pinctrl", "set", "18", "op", "dh"],
+            ["pinctrl", "set", "17", "op", "dl"],
+            ["pinctrl", "set", "18", "op", "dl"],
+        ]
 
-    def test_pins_end_released(self, mock_pins, monkeypatch):
-        # Both Pi pins end LOW (drivers off) and re-muxed to input,
-        # where the Pi's default pull-downs keep the drivers off.
-        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
-
+    def test_lines_end_released(self, pinctrl):
+        """Both lines finish released (dl) — the safe, runnable state."""
         gpio.enter_bootsel()
 
-        for n in (gpio.BOOTSEL_GPIO, gpio.RUN_GPIO):
-            assert mock_pins.pin(n).state is False
-            assert mock_pins.pin(n).function == "input"
+        last = _last_level_per_gpio(pinctrl)
+        assert last[gpio.RUN_GPIO] == RELEASE
+        assert last[gpio.BOOTSEL_GPIO] == RELEASE
 
-    def test_releases_pins_on_exception(self, mock_pins, monkeypatch):
-        """Both drivers switch off even if interrupted mid-sequence.
+    def test_releases_lines_on_exception(self, pinctrl, monkeypatch):
+        """Both lines are released even if interrupted mid-sequence.
 
         A stuck-asserted BOOTSEL driver grounds the picos' shared QSPI
-        flash CS and corrupts every running pico.
+        flash CS and corrupts every running pico, so cleanup must
+        release BOOTSEL (before RUN) no matter what.
         """
         calls = {"n": 0}
 
@@ -104,32 +138,59 @@ class TestEnterBootsel:
         with pytest.raises(RuntimeError, match="boom"):
             gpio.enter_bootsel()
 
-        for n in (gpio.BOOTSEL_GPIO, gpio.RUN_GPIO):
-            assert mock_pins.pin(n).state is False
-            assert mock_pins.pin(n).function == "input"
+        # cleanup releases BOOTSEL before RUN
+        assert pinctrl[-2:] == [
+            (gpio.BOOTSEL_GPIO, RELEASE),
+            (gpio.RUN_GPIO, RELEASE),
+        ]
+        last = _last_level_per_gpio(pinctrl)
+        assert last[gpio.RUN_GPIO] == RELEASE
+        assert last[gpio.BOOTSEL_GPIO] == RELEASE
+
+    def test_cleanup_runs_even_if_a_release_fails(self, monkeypatch):
+        """If releasing BOOTSEL fails, RUN is still released, and the
+        original error propagates — not the cleanup failure."""
+        seq = []
+
+        def fake_run(cmd, **kwargs):
+            seq.append((int(cmd[2]), cmd[4]))
+            # Make every BOOTSEL release fail (incl. the cleanup one).
+            if cmd[2] == str(gpio.BOOTSEL_GPIO) and cmd[4] == RELEASE:
+                raise subprocess.CalledProcessError(1, cmd, "", "no perm")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        sleeps = {"n": 0}
+
+        def boom(seconds):
+            sleeps["n"] += 1
+            if sleeps["n"] == 2:  # interrupt at the run_pulse hold
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(gpio.subprocess, "run", fake_run)
+        monkeypatch.setattr(gpio.time, "sleep", boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            gpio.enter_bootsel()
+
+        # RUN still released by cleanup despite the BOOTSEL release error
+        assert (gpio.RUN_GPIO, RELEASE) in seq
 
 
 class TestReset:
-    def test_pulses_run_then_releases(self, events, mock_pins,
-                                      monkeypatch):
-        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
-
+    def test_pulses_run_then_releases(self, pinctrl):
         gpio.reset()
 
-        run = mock_pins.pin(gpio.RUN_GPIO)
-        assert events.index(("on", run)) < events.index(("off", run))
-        assert run.state is False
-        assert run.function == "input"
+        assert pinctrl == [
+            (gpio.RUN_GPIO, ASSERT),
+            (gpio.RUN_GPIO, RELEASE),
+        ]
 
-    def test_does_not_touch_bootsel(self, events, mock_pins, monkeypatch):
-        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
-
+    def test_does_not_touch_bootsel(self, pinctrl):
         gpio.reset()
 
-        run = mock_pins.pin(gpio.RUN_GPIO)
-        assert [e for e in events if e[0] == "on"] == [("on", run)]
+        assert all(g == gpio.RUN_GPIO for g, _ in pinctrl)
 
-    def test_releases_on_exception(self, mock_pins, monkeypatch):
+    def test_releases_on_exception(self, pinctrl, monkeypatch):
         def boom(seconds):
             raise RuntimeError("boom")
 
@@ -138,32 +199,8 @@ class TestReset:
         with pytest.raises(RuntimeError, match="boom"):
             gpio.reset()
 
-        run = mock_pins.pin(gpio.RUN_GPIO)
-        assert run.state is False
-        assert run.function == "input"
-
-
-class TestLineDriver:
-    def test_construction_starts_released(self, mock_pins):
-        """Opening a line must start with the driver off (line floats
-        high via the picos' pull-ups), never asserted."""
-        pin = mock_pins.pin(gpio.BOOTSEL_GPIO)
-
-        with gpio._line_driver(gpio.BOOTSEL_GPIO):
-            assert pin.function == "output"
-            assert pin.state is False  # driver off
-
-        assert pin.function == "input"
-
-    def test_drive_semantics(self, mock_pins):
-        """on() drives the Pi pin HIGH — the inverting driver grounds
-        the bussed line (assert); off() releases it."""
-        with gpio._line_driver(gpio.RUN_GPIO) as dev:
-            pin = mock_pins.pin(gpio.RUN_GPIO)
-            dev.on()
-            assert pin.state is True
-            dev.off()
-            assert pin.state is False
+        assert pinctrl[-1] == (gpio.RUN_GPIO, RELEASE)
+        assert (gpio.BOOTSEL_GPIO, ASSERT) not in pinctrl
 
 
 class TestConstants:
@@ -176,7 +213,44 @@ class TestConstants:
         assert gpio.BOOTSEL_GPIO == 18
         assert gpio.RUN_GPIO == 17
 
+    def test_drive_levels(self):
+        """Inverting drivers: dh asserts (grounds the line), dl
+        releases. These pinctrl tokens are the verified ones."""
+        assert gpio._ASSERT == "dh"
+        assert gpio._RELEASE == "dl"
+
 
 class TestAvailable:
-    def test_true_under_mock_factory(self, mock_pins):
+    def test_true_when_pinctrl_present(self, monkeypatch):
+        monkeypatch.setattr(
+            gpio.shutil, "which", lambda name: "/usr/bin/pinctrl"
+        )
         assert gpio.available() is True
+
+    def test_false_when_pinctrl_absent(self, monkeypatch):
+        monkeypatch.setattr(gpio.shutil, "which", lambda name: None)
+        assert gpio.available() is False
+
+
+class TestMain:
+    def test_bootsel_subcommand_invokes_enter_bootsel(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            gpio, "enter_bootsel", lambda: calls.append("bootsel")
+        )
+        monkeypatch.setattr(gpio, "reset", lambda: calls.append("reset"))
+        gpio.main(["bootsel"])
+        assert calls == ["bootsel"]
+
+    def test_reset_subcommand_invokes_reset(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            gpio, "enter_bootsel", lambda: calls.append("bootsel")
+        )
+        monkeypatch.setattr(gpio, "reset", lambda: calls.append("reset"))
+        gpio.main(["reset"])
+        assert calls == ["reset"]
+
+    def test_subcommand_required(self):
+        with pytest.raises(SystemExit):
+            gpio.main([])

--- a/picohost/tests/test_gpio.py
+++ b/picohost/tests/test_gpio.py
@@ -1,0 +1,182 @@
+"""Tests for picohost.gpio — mass BOOTSEL/reset via bussed GPIO lines.
+
+All assertions run against gpiozero's mock pin factory (installed by
+the ``mock_pins`` conftest fixture). The wiring uses inverting
+drivers: driving a Pi pin HIGH pulls the bussed pico line to ground
+(assert); driving it LOW releases the line. The ordering tests record
+``OutputDevice.on``/``off`` and ``_set_function`` events to prove the
+sequence and that every line is released even on error.
+"""
+
+import pytest
+from gpiozero import OutputDevice
+from gpiozero.pins.mock import MockPin
+
+import picohost.gpio as gpio
+
+
+@pytest.fixture
+def events(monkeypatch, mock_pins):
+    """Record OutputDevice.on/off calls and pin function changes.
+
+    Entries are ``("on", pin)``, ``("off", pin)`` and
+    ``("func", pin, value)`` tuples; pins compare by identity, and the
+    mock factory caches instances, so they can be matched against
+    ``mock_pins.pin(n)``.
+    """
+    log = []
+
+    orig_on = OutputDevice.on
+
+    def spy_on(self):
+        log.append(("on", self.pin))
+        orig_on(self)
+
+    monkeypatch.setattr(OutputDevice, "on", spy_on)
+
+    orig_off = OutputDevice.off
+
+    def spy_off(self):
+        log.append(("off", self.pin))
+        orig_off(self)
+
+    monkeypatch.setattr(OutputDevice, "off", spy_off)
+
+    orig_set = MockPin._set_function
+
+    def spy_set(self, value):
+        log.append(("func", self, value))
+        orig_set(self, value)
+
+    monkeypatch.setattr(MockPin, "_set_function", spy_set)
+    return log
+
+
+class TestEnterBootsel:
+    def test_sequence_order(self, events, mock_pins, monkeypatch):
+        """Reset first, BOOTSEL while held in reset, release in order.
+
+        Asserting RESET before BOOTSEL means the shared QSPI-CS line is
+        only pulled low while the picos are already halted; the bootrom
+        samples BOOTSEL as RUN is released, so RUN must be released
+        before BOOTSEL.
+        """
+        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
+
+        gpio.enter_bootsel()
+
+        bootsel = mock_pins.pin(gpio.BOOTSEL_GPIO)
+        run = mock_pins.pin(gpio.RUN_GPIO)
+        # list.index finds the first occurrence of each event.
+        assert (
+            events.index(("on", run))
+            < events.index(("on", bootsel))
+            < events.index(("off", run))
+            < events.index(("off", bootsel))
+        )
+
+    def test_pins_end_released(self, mock_pins, monkeypatch):
+        # Both Pi pins end LOW (drivers off) and re-muxed to input,
+        # where the Pi's default pull-downs keep the drivers off.
+        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
+
+        gpio.enter_bootsel()
+
+        for n in (gpio.BOOTSEL_GPIO, gpio.RUN_GPIO):
+            assert mock_pins.pin(n).state is False
+            assert mock_pins.pin(n).function == "input"
+
+    def test_releases_pins_on_exception(self, mock_pins, monkeypatch):
+        """Both drivers switch off even if interrupted mid-sequence.
+
+        A stuck-asserted BOOTSEL driver grounds the picos' shared QSPI
+        flash CS and corrupts every running pico.
+        """
+        calls = {"n": 0}
+
+        def boom(seconds):
+            calls["n"] += 1
+            if calls["n"] == 3:  # the bootsel_sample hold
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(gpio.time, "sleep", boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            gpio.enter_bootsel()
+
+        for n in (gpio.BOOTSEL_GPIO, gpio.RUN_GPIO):
+            assert mock_pins.pin(n).state is False
+            assert mock_pins.pin(n).function == "input"
+
+
+class TestReset:
+    def test_pulses_run_then_releases(self, events, mock_pins,
+                                      monkeypatch):
+        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
+
+        gpio.reset()
+
+        run = mock_pins.pin(gpio.RUN_GPIO)
+        assert events.index(("on", run)) < events.index(("off", run))
+        assert run.state is False
+        assert run.function == "input"
+
+    def test_does_not_touch_bootsel(self, events, mock_pins, monkeypatch):
+        monkeypatch.setattr(gpio.time, "sleep", lambda s: None)
+
+        gpio.reset()
+
+        run = mock_pins.pin(gpio.RUN_GPIO)
+        assert [e for e in events if e[0] == "on"] == [("on", run)]
+
+    def test_releases_on_exception(self, mock_pins, monkeypatch):
+        def boom(seconds):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(gpio.time, "sleep", boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            gpio.reset()
+
+        run = mock_pins.pin(gpio.RUN_GPIO)
+        assert run.state is False
+        assert run.function == "input"
+
+
+class TestLineDriver:
+    def test_construction_starts_released(self, mock_pins):
+        """Opening a line must start with the driver off (line floats
+        high via the picos' pull-ups), never asserted."""
+        pin = mock_pins.pin(gpio.BOOTSEL_GPIO)
+
+        with gpio._line_driver(gpio.BOOTSEL_GPIO):
+            assert pin.function == "output"
+            assert pin.state is False  # driver off
+
+        assert pin.function == "input"
+
+    def test_drive_semantics(self, mock_pins):
+        """on() drives the Pi pin HIGH — the inverting driver grounds
+        the bussed line (assert); off() releases it."""
+        with gpio._line_driver(gpio.RUN_GPIO) as dev:
+            pin = mock_pins.pin(gpio.RUN_GPIO)
+            dev.on()
+            assert pin.state is True
+            dev.off()
+            assert pin.state is False
+
+
+class TestConstants:
+    def test_wiring_assignment(self):
+        """BCM 18 = BOOTSEL bus, BCM 17 = RUN bus (hardware wiring).
+
+        Swapping these would pulse BOOTSEL as if it were RUN — guard
+        the assignment explicitly.
+        """
+        assert gpio.BOOTSEL_GPIO == 18
+        assert gpio.RUN_GPIO == 17
+
+
+class TestAvailable:
+    def test_true_under_mock_factory(self, mock_pins):
+        assert gpio.available() is True


### PR DESCRIPTION
## Summary

Replaces the per-Pico CDC→BOOTSEL→flash USB round-trips (the remaining headache on the observatory's contended hub) with a GPIO-driven mass flow, using the new hardware wiring: all 7 BOOTSEL pads bussed to a driver on Pi GPIO 18, all RUN/RESET pads to one on GPIO 17 (BCM, **inverting drivers**: Pi pin HIGH grounds the line, LOW releases it).

- **New `picohost.gpio` module** — `enter_bootsel()` drives the whole fleet into BOOTSEL in one shot (works even for wedged/bricked firmware): assert RUN → assert BOOTSEL while held in reset (the shared QSPI-CS line is never pulled low under running firmware) → release RUN (bootrom samples BOOTSEL) → release BOOTSEL. `reset()` mass-reboots the fleet. Drivers are switched off and pins re-muxed to input on every exit path.
- **`flash-picos` defaults to the GPIO flow**: mass BOOTSEL entry → `picotool load --bus/--address` per device with no `-x`/`-f` over a quiet bus → one mass reset → device-info read + Redis publication as before. `--no-gpio` and `--port`/`--usb-serial` route to the legacy USB path; a missing GPIO backend fails fast (no silent fallback).
- **New `pico-gpio` CLI** — `bootsel`/`reset` subcommands for standalone ops use.
- Tests run against gpiozero's mock pin factory (`GPIOZERO_PIN_FACTORY=mock` via conftest); 40 new tests, 450 total green, ruff clean.

## Stacking

- Based on `fix/flash-picos-rp2350-bootsel` (reuses its sysfs resolver / bus-address selection / RP2350 PID fixes — that branch remains the `--no-gpio` fallback path). Retarget to `main` once the fix PR merges.
- Requires `gpiozero>=2` from `feat/picohost-gpiozero-dep` (not duplicated here); merge that first so CI has the dependency declared.

## Test Plan

- [x] `pytest -q` — 450 passed (mock pin factory, no hardware)
- [x] `ruff check src/ tests/` — clean
- [ ] Rig validation on the hub Pi: `pico-gpio bootsel` → `lsusb` shows 7× `2e8a:000f`; `pico-gpio reset` → 7× `2e8a:0009`
- [ ] `flash-picos --uf2 build/pico_multi.uf2` on the hub — all 7 flash, one mass reset, device list published to Redis
- [ ] `flash-picos --uf2 … --no-gpio` still exercises the legacy USB path

🤖 Generated with [Claude Code](https://claude.com/claude-code)