### PR TITLE
feat(motor): persist step position across pico reboots (boot_id + Redis checkpoint)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(pico_multi
     hardware_pio
     hardware_adc
     pico_unique_id
+    pico_rand
     cjson
     eigsep_command
     onewire

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -6,7 +6,7 @@ pattern in ``eigsep_observing.corr``: each class takes an
 ``eigsep_redis.Transport`` at construction, and the concerns are
 split into the smallest stable surface per bus.
 
-Five buses here:
+Six buses here:
 
 - :class:`PicoConfigStore` — persistent single-key blob holding the
   list of picos (app id, serial port, usb serial) written once by
@@ -16,6 +16,12 @@ Five buses here:
   both pots). Written by ``calibrate-pot`` and read by
   :class:`picohost.PicoPotentiometer` at startup so a rebooted
   pot Pico picks up its cal from Redis without a local JSON file.
+- :class:`MotorPositionStore` — persistent single-key blob holding
+  the motor's last known step positions and the firmware
+  ``boot_id`` they belong to. Written by
+  :class:`picohost.PicoMotor`'s redis handler on every position
+  change and read back to re-seed the firmware step counters after
+  a pico power cycle (positions live in RAM and reset to 0).
 - :class:`PicoCmdReader` — blocking reader for the pico command
   stream. Consumed by the manager's command-relay thread.
 - :class:`PicoRespWriter` — writer for the pico response stream.
@@ -39,6 +45,7 @@ import logging
 from eigsep_redis import SingleStreamReader, SingleStreamWriter
 
 from .keys import (
+    MOTOR_POS_KEY,
     PICO_CMD_STREAM,
     PICO_CONFIG_KEY,
     PICO_RESP_STREAM,
@@ -168,6 +175,90 @@ class PotCalStore:
     def clear(self):
         """Delete the stored calibration."""
         self.transport.r.delete(POT_CAL_KEY)
+
+
+class MotorPositionStore:
+    """
+    Persistent single-key store for the motor's last known position.
+
+    The value under :data:`MOTOR_POS_KEY` is a JSON object
+    ``{"az_pos": int, "el_pos": int, "boot_id": int,
+    "upload_time": ...}`` — the canonical ``upload_time`` field is
+    injected by :meth:`Transport.upload_dict` at the top level.
+
+    :class:`picohost.PicoMotor`'s redis handler uploads on every
+    position change and compares the stored ``boot_id`` against the
+    one in each firmware status packet: a mismatch means the pico
+    power-cycled (its RAM step counters reset to 0) and the stored
+    positions are pushed back down via ``az_set_pos``/``el_set_pos``.
+    The store therefore only ever holds positions paired with the
+    boot they were counted in.
+
+    This recovers the operator-defined zero across reboots; it cannot
+    detect motion that happened while unpowered (the rig being moved
+    by hand, or steps lost between the last status tick and a
+    power cut) — an absolute sensor (pot) is the only cure for that.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload(self, az_pos, el_pos, boot_id):
+        """Upload the current position checkpoint.
+
+        Parameters
+        ----------
+        az_pos, el_pos : int
+            Step positions as reported by the firmware.
+        boot_id : int
+            The firmware boot id the positions were observed under.
+        """
+        self.transport.upload_dict(
+            {
+                "az_pos": int(az_pos),
+                "el_pos": int(el_pos),
+                "boot_id": int(boot_id),
+            },
+            MOTOR_POS_KEY,
+        )
+
+    def get(self):
+        """Return the stored checkpoint dict.
+
+        Returns
+        -------
+        dict or None
+            ``None`` if no checkpoint has been uploaded, or if the
+            stored JSON fails to decode or lacks integer ``az_pos`` /
+            ``el_pos`` / ``boot_id`` fields. The caller treats that
+            as "no checkpoint" — it never seeds from a blob it cannot
+            fully validate.
+        """
+        raw = self.transport.get_raw(MOTOR_POS_KEY)
+        if raw is None:
+            return None
+        try:
+            blob = json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Corrupted {MOTOR_POS_KEY} in Redis ({e}); "
+                "ignoring checkpoint."
+            )
+            return None
+        try:
+            for key in ("az_pos", "el_pos", "boot_id"):
+                blob[key] = int(blob[key])
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning(
+                f"Malformed {MOTOR_POS_KEY} in Redis ({e}); "
+                "ignoring checkpoint."
+            )
+            return None
+        return blob
+
+    def clear(self):
+        """Delete the stored checkpoint."""
+        self.transport.r.delete(MOTOR_POS_KEY)
 
 
 class PicoCmdReader(SingleStreamReader):

--- a/picohost/src/picohost/emulators/motor.py
+++ b/picohost/src/picohost/emulators/motor.py
@@ -1,3 +1,5 @@
+import random
+
 from .base import PicoEmulator, _safe_int
 
 DEFAULT_DELAY_US = 600
@@ -61,6 +63,10 @@ class MotorEmulator(PicoEmulator):
     def init(self):
         self.azimuth = StepperState()
         self.elevation = StepperState()
+        # Mirrors motor_init() in motor.c: positions zeroed and a fresh
+        # random 30-bit boot id drawn. Re-calling init() on a running
+        # emulator therefore models a firmware power cycle.
+        self.boot_id = random.getrandbits(30)
 
     def server(self, cmd):
         az = self.azimuth
@@ -104,6 +110,7 @@ class MotorEmulator(PicoEmulator):
             "sensor_name": "motor",
             "status": "update",
             "app_id": self.app_id,
+            "boot_id": self.boot_id,
             "az_pos": self.azimuth.position,
             "az_target_pos": self.azimuth.target_pos,
             "el_pos": self.elevation.position,

--- a/picohost/src/picohost/keys.py
+++ b/picohost/src/picohost/keys.py
@@ -11,6 +11,7 @@ or eigsep_observing (``stream:corr``, ``corr_config``, …).
 
 PICO_CONFIG_KEY = "pico_config"
 POT_CAL_KEY = "pot_calibration"
+MOTOR_POS_KEY = "motor_position"
 PICO_CMD_STREAM = "stream:pico_cmd"
 PICO_RESP_STREAM = "stream:pico_resp"
 PICO_CLAIM_PREFIX = "pico_claim"

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -53,6 +53,7 @@ from .base import (
     PicoRFSwitch,
 )
 from .buses import (
+    MotorPositionStore,
     PicoClaimStore,
     PicoCmdReader,
     PicoConfigStore,
@@ -158,6 +159,7 @@ class PicoManager:
         self._metadata_writer = MetadataWriter(transport)
         self._config_store = PicoConfigStore(transport)
         self._pot_cal_store = PotCalStore(transport)
+        self._motor_pos_store = MotorPositionStore(transport)
         self._cmd_reader = PicoCmdReader(transport)
         self._resp_writer = PicoRespWriter(transport)
         self._claim_store = PicoClaimStore(transport)
@@ -257,6 +259,8 @@ class PicoManager:
             }
             if cls is PicoPotentiometer:
                 kwargs["pot_cal_store"] = self._pot_cal_store
+            elif cls is PicoMotor:
+                kwargs["motor_pos_store"] = self._motor_pos_store
             try:
                 pico = cls(port, **kwargs)
                 self.picos[name] = pico

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -14,6 +14,11 @@ logger = logging.getLogger(__name__)
 class PicoMotor(PicoDevice):
     """Specialized class for motor control Pico devices."""
 
+    #: Seconds to wait for a re-seeded position to show up in firmware
+    #: status before giving up and resuming checkpoints (see
+    #: :meth:`_checkpoint_and_seed`).
+    _SEED_TIMEOUT_S = 5.0
+
     def __init__(
         self,
         port,
@@ -25,6 +30,7 @@ class PicoMotor(PicoDevice):
         name=None,
         metadata_writer=None,
         usb_serial="",
+        motor_pos_store=None,
     ):
         self.step_angle_deg = step_angle_deg
         self.gear_teeth = gear_teeth
@@ -41,6 +47,18 @@ class PicoMotor(PicoDevice):
             "el_dn_delay_us": int,
         }
         self._delay_kwargs = None
+        # Position checkpoint / boot-detection state. Touched only by
+        # _checkpoint_and_seed, which runs on the reader thread; set up
+        # before super().__init__ because the reader may start in there.
+        # The whole feature is inert when motor_pos_store is None (or
+        # when there is no metadata_writer — the redis-handler wrapper
+        # is the hook, so no publishing means no checkpointing).
+        self._motor_pos_store = motor_pos_store
+        self._seen_boot_id = None
+        self._last_checkpoint = None
+        self._await_seed = None
+        self._seed_sent_time = None
+        self._warned_no_boot_id = False
         super().__init__(
             port,
             timeout=timeout,
@@ -82,13 +100,121 @@ class PicoMotor(PicoDevice):
         :meth:`PicoRFSwitch._rfswitch_redis_handler`: both adapt the
         raw firmware payload to the published Redis shape at the same
         boundary.
+
+        Also drives the position checkpoint / boot-detection logic
+        (:meth:`_checkpoint_and_seed`) off the raw integer payload,
+        before the float cast.
         """
+        self._checkpoint_and_seed(data)
         data = data.copy()
         for key in self._POSITION_FIELDS:
             v = data.get(key)
             if v is not None:
                 data[key] = float(v)
         self._base_redis_handler(data)
+
+    def _checkpoint_and_seed(self, data):
+        """Persist the step position; re-seed it after a pico reboot.
+
+        Runs on the reader thread for every firmware status packet
+        (safe: the serial write path used by the re-seed has its own
+        lock and never waits on status). Two jobs:
+
+        1. **Checkpoint.** Upload ``(az_pos, el_pos, boot_id)`` to the
+           :class:`~picohost.buses.MotorPositionStore` whenever the
+           triple changes — during a move that is one upload per
+           status tick, at rest none. The checkpoint is what survives
+           a full-system power cut (Redis on the host persists it).
+        2. **Boot detection + re-seed.** Firmware step counters live
+           in RAM and reset to 0 at power-up; ``boot_id`` is a random
+           per-boot constant in every status packet. When the
+           incoming ``boot_id`` differs from the checkpointed one,
+           the pico has rebooted since the checkpoint was written, so
+           the stored positions are pushed back down via
+           :meth:`reset_step_position`. Checkpointing is suppressed
+           until the seeded position is reflected in a status packet
+           (else the first post-reboot all-zero status would
+           overwrite the good checkpoint), bounded by
+           :data:`_SEED_TIMEOUT_S` so a lost seed command cannot
+           freeze checkpointing forever.
+
+        A matching ``boot_id`` means the firmware position is live
+        truth — a manager restart against a still-running pico never
+        re-seeds.
+        """
+        store = self._motor_pos_store
+        if store is None:
+            return
+        boot_id = data.get("boot_id")
+        az = data.get("az_pos")
+        el = data.get("el_pos")
+        if boot_id is None or az is None or el is None:
+            if not self._warned_no_boot_id:
+                self._warned_no_boot_id = True
+                logger.warning(
+                    f"{self.name}: status packet lacks boot_id or "
+                    "position fields; position checkpointing disabled "
+                    "(firmware predates boot_id?)"
+                )
+            return
+        az, el, boot_id = int(az), int(el), int(boot_id)
+
+        if boot_id != self._seen_boot_id:
+            self._handle_new_boot(boot_id)
+
+        if self._await_seed is not None:
+            if (az, el) == self._await_seed:
+                self._await_seed = None
+            elif time.time() - self._seed_sent_time > self._SEED_TIMEOUT_S:
+                logger.error(
+                    f"{self.name}: re-seeded position "
+                    f"{self._await_seed} not reflected in status "
+                    f"within {self._SEED_TIMEOUT_S}s; resuming "
+                    "checkpoints from live position"
+                )
+                self._await_seed = None
+            else:
+                # Pre-seed positions are the reset-to-zero counters,
+                # not real state — don't checkpoint them.
+                return
+
+        checkpoint = (az, el, boot_id)
+        if checkpoint != self._last_checkpoint:
+            store.upload(az_pos=az, el_pos=el, boot_id=boot_id)
+            self._last_checkpoint = checkpoint
+
+    def _handle_new_boot(self, boot_id):
+        """React to a never-seen ``boot_id``: re-seed if the stored
+        checkpoint belongs to a different boot.
+
+        ``_seen_boot_id`` is committed only after the branch completes,
+        so a failed seed send is retried on the next status packet.
+        """
+        stored = self._motor_pos_store.get()
+        if stored is None or stored["boot_id"] == boot_id:
+            # No checkpoint to restore, or the checkpoint was written
+            # under this very boot (manager restart, pico kept running):
+            # firmware position is authoritative.
+            self._seen_boot_id = boot_id
+            return
+        az, el = stored["az_pos"], stored["el_pos"]
+        age = time.time() - stored.get("upload_time", time.time())
+        logger.warning(
+            f"{self.name}: pico rebooted (boot_id "
+            f"{stored['boot_id']} -> {boot_id}); re-seeding step "
+            f"position az={az} el={el} from checkpoint ({age:.0f}s old)"
+        )
+        try:
+            self.reset_step_position(az_step=az, el_step=el)
+        except ConnectionError as e:
+            # Status packets arrive over the same serial link, so this
+            # should be unreachable; log and leave _seen_boot_id unset
+            # so the next packet retries.
+            logger.error(f"{self.name}: position re-seed failed: {e}")
+            return
+        self._await_seed = (az, el)
+        self._seed_sent_time = time.time()
+        self._seen_boot_id = boot_id
 
     def on_reconnect(self):
         """Re-apply delay configuration after a serial reconnect."""

--- a/picohost/tests/test_dummy_devices.py
+++ b/picohost/tests/test_dummy_devices.py
@@ -200,6 +200,7 @@ class TestDummyPicoMotor:
         assert "el_pos" in motor.last_status
         assert "az_target_pos" in motor.last_status
         assert "el_target_pos" in motor.last_status
+        assert "boot_id" in motor.last_status
         motor.disconnect()
 
     def test_scan_homes_after_normal_completion(self):

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -26,6 +26,7 @@ MOTOR_FIELDS = {
     "sensor_name",
     "status",
     "app_id",
+    "boot_id",
     "az_pos",
     "az_target_pos",
     "el_pos",

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -51,6 +51,19 @@ class TestMotorEmulator:
         assert status["el_pos"] == 0
         assert status["az_target_pos"] == 0
         assert status["el_target_pos"] == 0
+        # Random 30-bit per-boot id, mirroring motor_init() in motor.c.
+        assert 0 <= status["boot_id"] < 2**30
+
+    def test_reinit_models_power_cycle(self):
+        """init() zeroes the counters and draws a fresh boot_id —
+        the host-side reboot detector keys off exactly this."""
+        emu = MotorEmulator()
+        emu.server({"az_set_pos": 500})
+        old_boot = emu.boot_id
+        emu.init()
+        status = emu.get_status()
+        assert status["az_pos"] == 0
+        assert status["boot_id"] != old_boot
 
     def test_set_target_and_converge(self):
         emu = MotorEmulator()
@@ -130,6 +143,7 @@ class TestMotorEmulator:
             "sensor_name",
             "status",
             "app_id",
+            "boot_id",
             "az_pos",
             "az_target_pos",
             "el_pos",

--- a/picohost/tests/test_motor_position.py
+++ b/picohost/tests/test_motor_position.py
@@ -1,0 +1,330 @@
+"""Tests for the motor position checkpoint / boot-detection feature.
+
+Firmware step counters live in RAM and reset to 0 on power-up, so the
+host persists ``(az_pos, el_pos, boot_id)`` to
+:class:`~picohost.buses.MotorPositionStore` on every position change
+and pushes the stored positions back down (``az_set_pos`` /
+``el_set_pos``) when an incoming status packet carries a ``boot_id``
+the checkpoint doesn't match — i.e. the pico rebooted since the
+checkpoint was written.
+
+Two layers of coverage:
+
+- ``TestMotorPositionStore`` mirrors ``TestPotCalStore`` in
+  ``test_potentiometer.py`` (empty / round-trip / corrupt / clear).
+- ``TestCheckpointAndSeed`` drives ``_checkpoint_and_seed`` directly
+  with firmware-shaped status dicts on a ``__new__``-bypass instance
+  (same pattern as eigsep_observing's producer-contract tests) for
+  deterministic branch coverage; ``TestEndToEnd`` runs the real
+  ``DummyPicoMotor`` + ``MotorEmulator`` stack through reboot
+  scenarios.
+"""
+
+import time
+
+from eigsep_redis import MetadataWriter
+from eigsep_redis.testing import DummyTransport
+
+from picohost.buses import MotorPositionStore
+from picohost.keys import MOTOR_POS_KEY
+from picohost.motor import PicoMotor
+from picohost.testing import DummyPicoMotor
+
+from conftest import wait_for_condition
+
+# Firmware boot ids are random 30-bit non-negative ints
+# (get_rand_32() & 0x3fffffff), so a negative sentinel in a primed
+# checkpoint is guaranteed to differ from any live emulator boot_id.
+STALE_BOOT_ID = -1
+
+
+def _status(boot_id, az=0, el=0):
+    """A firmware-shaped motor status packet (see motor_status() in
+    motor.c). Targets mirror positions — the seed/checkpoint logic
+    reads only positions and boot_id.
+    """
+    return {
+        "sensor_name": "motor",
+        "status": "update",
+        "app_id": 0,
+        "boot_id": boot_id,
+        "az_pos": az,
+        "az_target_pos": az,
+        "el_pos": el,
+        "el_target_pos": el,
+    }
+
+
+class TestMotorPositionStore:
+    def test_get_empty_returns_none(self):
+        store = MotorPositionStore(DummyTransport())
+        assert store.get() is None
+
+    def test_round_trip(self):
+        store = MotorPositionStore(DummyTransport())
+        store.upload(az_pos=500, el_pos=-300, boot_id=7)
+        blob = store.get()
+        assert blob["az_pos"] == 500
+        assert blob["el_pos"] == -300
+        assert blob["boot_id"] == 7
+        # Canonical timestamp injected by Transport.upload_dict.
+        assert "upload_time" in blob
+
+    def test_corrupt_json_returns_none(self):
+        transport = DummyTransport()
+        store = MotorPositionStore(transport)
+        transport.r.set(MOTOR_POS_KEY, "not json{")
+        assert store.get() is None
+
+    def test_missing_field_returns_none(self):
+        transport = DummyTransport()
+        store = MotorPositionStore(transport)
+        # boot_id missing: a blob the seed logic can't fully validate
+        # must read back as "no checkpoint".
+        transport.upload_dict({"az_pos": 1, "el_pos": 2}, MOTOR_POS_KEY)
+        assert store.get() is None
+
+    def test_non_int_field_returns_none(self):
+        transport = DummyTransport()
+        store = MotorPositionStore(transport)
+        transport.upload_dict(
+            {"az_pos": "abc", "el_pos": 2, "boot_id": 7}, MOTOR_POS_KEY
+        )
+        assert store.get() is None
+
+    def test_clear(self):
+        store = MotorPositionStore(DummyTransport())
+        store.upload(az_pos=1, el_pos=2, boot_id=3)
+        store.clear()
+        assert store.get() is None
+
+
+def _bare_motor(store):
+    """A serial-less PicoMotor carrying only the checkpoint/seed state.
+
+    The ``__new__`` bypass (no serial I/O, no reader thread) mirrors
+    eigsep_observing's producer-contract tests; it lets the tests call
+    ``_checkpoint_and_seed`` with deterministic status sequences. The
+    instance-level ``reset_step_position`` shadow records seed sends
+    instead of writing to a (nonexistent) serial port.
+    """
+    m = PicoMotor.__new__(PicoMotor)
+    m.name = "motor"
+    m._motor_pos_store = store
+    m._seen_boot_id = None
+    m._last_checkpoint = None
+    m._await_seed = None
+    m._seed_sent_time = None
+    m._warned_no_boot_id = False
+    m.seeds = []
+    m.reset_step_position = lambda az_step, el_step: m.seeds.append(
+        (az_step, el_step)
+    )
+    return m
+
+
+class TestCheckpointAndSeed:
+    def test_checkpoint_uploaded_and_deduped(self):
+        store = MotorPositionStore(DummyTransport())
+        uploads = []
+        orig_upload = store.upload
+        store.upload = lambda **kw: (uploads.append(kw), orig_upload(**kw))
+        m = _bare_motor(store)
+        m._checkpoint_and_seed(_status(7, az=0, el=0))
+        m._checkpoint_and_seed(_status(7, az=0, el=0))
+        assert len(uploads) == 1
+        # A position change re-checkpoints.
+        m._checkpoint_and_seed(_status(7, az=10, el=-20))
+        assert len(uploads) == 2
+        blob = store.get()
+        assert (blob["az_pos"], blob["el_pos"], blob["boot_id"]) == (
+            10,
+            -20,
+            7,
+        )
+
+    def test_same_boot_never_seeds(self):
+        store = MotorPositionStore(DummyTransport())
+        store.upload(az_pos=500, el_pos=300, boot_id=7)
+        m = _bare_motor(store)
+        m._checkpoint_and_seed(_status(7, az=0, el=0))
+        # Checkpoint written under this very boot: firmware position is
+        # live truth (a manager restart against a running pico) — no
+        # seed, and the checkpoint follows the live report.
+        assert m.seeds == []
+        assert store.get()["az_pos"] == 0
+
+    def test_reboot_seeds_and_suppresses_checkpoint(self):
+        store = MotorPositionStore(DummyTransport())
+        store.upload(az_pos=500, el_pos=-300, boot_id=7)
+        m = _bare_motor(store)
+        # First post-reboot packet: all-zero counters, new boot_id.
+        m._checkpoint_and_seed(_status(8, az=0, el=0))
+        assert m.seeds == [(500, -300)]
+        # The good checkpoint must NOT be overwritten by the pre-seed
+        # zeros...
+        blob = store.get()
+        assert (blob["az_pos"], blob["boot_id"]) == (500, 7)
+        # ...nor by in-transit positions while the seed lands...
+        m._checkpoint_and_seed(_status(8, az=250, el=-150))
+        assert store.get()["boot_id"] == 7
+        # ...until the seeded position is reflected in a status packet,
+        # at which point checkpointing resumes under the new boot.
+        m._checkpoint_and_seed(_status(8, az=500, el=-300))
+        blob = store.get()
+        assert (blob["az_pos"], blob["el_pos"], blob["boot_id"]) == (
+            500,
+            -300,
+            8,
+        )
+        # The reboot is handled exactly once.
+        assert m.seeds == [(500, -300)]
+
+    def test_seed_timeout_resumes_checkpoints(self, caplog):
+        store = MotorPositionStore(DummyTransport())
+        store.upload(az_pos=500, el_pos=-300, boot_id=7)
+        m = _bare_motor(store)
+        m._checkpoint_and_seed(_status(8, az=0, el=0))
+        assert m.seeds == [(500, -300)]
+        # Seed never reflected (lost command / concurrent move): after
+        # the timeout, checkpointing resumes from the live position so
+        # the store can't stay frozen on a dead boot_id forever.
+        m._seed_sent_time = time.time() - 2 * PicoMotor._SEED_TIMEOUT_S
+        with caplog.at_level("ERROR", logger="picohost.motor"):
+            m._checkpoint_and_seed(_status(8, az=42, el=0))
+        assert "not reflected" in caplog.text
+        blob = store.get()
+        assert (blob["az_pos"], blob["boot_id"]) == (42, 8)
+
+    def test_empty_store_never_seeds(self):
+        store = MotorPositionStore(DummyTransport())
+        m = _bare_motor(store)
+        m._checkpoint_and_seed(_status(7, az=5, el=6))
+        assert m.seeds == []
+        assert store.get()["az_pos"] == 5
+
+    def test_corrupt_store_treated_as_empty(self, caplog):
+        transport = DummyTransport()
+        store = MotorPositionStore(transport)
+        transport.r.set(MOTOR_POS_KEY, "not json{")
+        m = _bare_motor(store)
+        with caplog.at_level("WARNING", logger="picohost.buses"):
+            m._checkpoint_and_seed(_status(8, az=0, el=0))
+        assert "Corrupted" in caplog.text
+        assert m.seeds == []
+        # The corrupt blob is replaced by a valid live checkpoint.
+        assert store.get()["boot_id"] == 8
+
+    def test_missing_boot_id_warns_once_and_disables(self, caplog):
+        store = MotorPositionStore(DummyTransport())
+        m = _bare_motor(store)
+        old_firmware = {
+            "sensor_name": "motor",
+            "status": "update",
+            "app_id": 0,
+            "az_pos": 5,
+            "az_target_pos": 5,
+            "el_pos": 6,
+            "el_target_pos": 6,
+        }
+        with caplog.at_level("WARNING", logger="picohost.motor"):
+            m._checkpoint_and_seed(old_firmware)
+            m._checkpoint_and_seed(old_firmware)
+        assert caplog.text.count("position checkpointing disabled") == 1
+        assert store.get() is None
+        assert m.seeds == []
+
+
+class TestEndToEnd:
+    """Real DummyPicoMotor + MotorEmulator + DummyTransport pipeline."""
+
+    def _build(self, store=None, transport=None):
+        transport = transport or DummyTransport()
+        store = store or MotorPositionStore(transport)
+        motor = DummyPicoMotor(
+            port="/dev/ttyUSB0",
+            metadata_writer=MetadataWriter(transport),
+            motor_pos_store=store,
+        )
+        return motor, store
+
+    def test_checkpoint_tracks_settled_position(self):
+        motor, store = self._build()
+        cadence = motor.EMULATOR_CADENCE_MS
+        try:
+            wait_for_condition(
+                lambda: (
+                    (s := store.get()) is not None
+                    and s["boot_id"] == motor._emulator.boot_id
+                ),
+                cadence_ms=cadence,
+            )
+            motor.az_target_steps(120)
+            wait_for_condition(
+                lambda: store.get()["az_pos"] == 120,
+                cadence_ms=cadence,
+            )
+        finally:
+            motor.disconnect()
+
+    def test_cold_boot_reseed(self):
+        """Manager start against a freshly booted pico: store holds a
+        checkpoint from a previous boot (sentinel boot_id), the
+        emulator reports zeros — the handler must push the checkpoint
+        back down and re-pair the store with the live boot_id.
+        """
+        transport = DummyTransport()
+        store = MotorPositionStore(transport)
+        store.upload(az_pos=500, el_pos=-300, boot_id=STALE_BOOT_ID)
+        motor, _ = self._build(store=store, transport=transport)
+        cadence = motor.EMULATOR_CADENCE_MS
+        try:
+            wait_for_condition(
+                lambda: (
+                    motor.last_status.get("az_pos") == 500
+                    and motor.last_status.get("el_pos") == -300
+                ),
+                cadence_ms=cadence,
+            )
+            wait_for_condition(
+                lambda: store.get()["boot_id"] == motor._emulator.boot_id,
+                cadence_ms=cadence,
+            )
+            blob = store.get()
+            assert (blob["az_pos"], blob["el_pos"]) == (500, -300)
+        finally:
+            motor.disconnect()
+
+    def test_midrun_power_cycle_reseed(self):
+        """Pico power-cycles while the manager keeps running: emulator
+        init() models the firmware reboot (counters zeroed, new
+        boot_id) and the handler restores the last checkpoint.
+        """
+        motor, store = self._build()
+        cadence = motor.EMULATOR_CADENCE_MS
+        try:
+            # az_target_steps waits on is_moving, which requires a
+            # first status packet to have arrived.
+            wait_for_condition(
+                lambda: motor.last_status.get("sensor_name") == "motor",
+                cadence_ms=cadence,
+            )
+            motor.az_target_steps(120)
+            wait_for_condition(
+                lambda: (
+                    store.get() is not None and store.get()["az_pos"] == 120
+                ),
+                cadence_ms=cadence,
+            )
+            old_boot = motor._emulator.boot_id
+            motor._emulator.init()
+            assert motor._emulator.boot_id != old_boot
+            wait_for_condition(
+                lambda: (
+                    motor._emulator.azimuth.position == 120
+                    and store.get()["boot_id"] == motor._emulator.boot_id
+                ),
+                cadence_ms=cadence,
+            )
+        finally:
+            motor.disconnect()

--- a/src/motor.c
+++ b/src/motor.c
@@ -1,5 +1,6 @@
 #include "motor.h"
 #include "pico/stdlib.h"
+#include "pico/rand.h"
 #include "cJSON.h"
 #include <stdlib.h>
 
@@ -12,6 +13,13 @@
 
 static Stepper azimuth;
 static Stepper elevation;
+
+/* Random per-boot identifier, reported in every motor_status packet.
+ * Step positions live in RAM and reset to 0 on power-up, so the host
+ * cannot otherwise tell "pico rebooted, position lost" apart from
+ * "parked at home". Masked to 30 bits to stay positive in cJSON's
+ * int representation. */
+static uint32_t boot_id;
 
 /**
  * @brief Initialize a stepper motor interface.
@@ -60,6 +68,7 @@ void stepper_init(Stepper *m,
 void motor_init(uint8_t app_id) {
     stepper_init(&azimuth, AZ_DIR_PIN, AZ_PUL_PIN, AZ_EN_PIN, AZ_CW_VAL);
     stepper_init(&elevation, EL_DIR_PIN, EL_PUL_PIN, EL_EN_PIN, EL_CW_VAL);
+    boot_id = get_rand_32() & 0x3fffffff;
 }
 
 /**
@@ -169,10 +178,11 @@ void motor_server(uint8_t app_id, const char *json_str) {
 
 
 void motor_status(uint8_t app_id) {
-	send_json(7,
+	send_json(8,
         KV_STR, "sensor_name", "motor",
         KV_STR, "status", "update",
         KV_INT, "app_id", app_id,
+        KV_INT, "boot_id", (int)boot_id,
         KV_INT, "az_pos", azimuth.position,
         KV_INT, "az_target_pos", azimuth.target_pos,
         KV_INT, "el_pos", elevation.position,


### PR DESCRIPTION
## Why

The operator-defined motor zero does not survive a power cycle: step positions live in firmware RAM and `stepper_init` resets them to 0 at boot, there are no limit switches or encoders, and "home" just means "drive to step 0 in whatever frame booted up". After a full-system reboot the rig silently believes wherever it sits is the scan origin.

## What

**Firmware** (`src/motor.c`, +`pico_rand` in CMakeLists):
- `motor_init` draws a random 30-bit `boot_id` (`get_rand_32() & 0x3fffffff`); `motor_status` reports it in every packet. This is the host's exact reboot detector — without it, "pico rebooted, position lost" is indistinguishable from "parked at home". Builds clean (`./build.sh`).

**picohost**:
- `MotorPositionStore` (`buses.py`, key `motor_position`, PotCalStore pattern): single-key JSON blob `{az_pos, el_pos, boot_id, upload_time}`. Validating `get()` — a blob that can't be fully validated reads as "no checkpoint", never seeded from.
- `PicoMotor._checkpoint_and_seed`, driven from the existing `_motor_redis_handler` wrapper (reader thread, raw int payload, before the float cast):
  - checkpoints `(az_pos, el_pos, boot_id)` on every change — one upload per status tick during a move, none at rest;
  - on a `boot_id` the checkpoint doesn't match, pushes the stored positions back down via `az_set_pos`/`el_set_pos` (bare fire-and-forget send; the write path has its own lock, nothing waits on status);
  - a matching `boot_id` means firmware position is live truth — a manager restart against a running pico never re-seeds;
  - checkpointing is suppressed after a re-seed until the seeded position is reflected in status (else the first post-reboot all-zero packet would overwrite the good checkpoint), bounded by a 5 s timeout so a lost command can't freeze the store;
  - status packets lacking `boot_id` (pre-this-PR firmware) disable the feature with a single WARNING.
- `PicoManager` wires the store into `PicoMotor` exactly like `PotCalStore` into `PicoPotentiometer`.
- `MotorEmulator` parity: `init()` zeroes counters and draws a fresh `boot_id`, so re-calling `init()` models a power cycle.

**Tests** (`tests/test_motor_position.py` + updates): store round-trip/corrupt/malformed; deterministic branch coverage of checkpoint dedup, same-boot no-seed, reboot seed + checkpoint suppression, seed timeout, corrupt-store fallback, old-firmware warn-once; end-to-end `DummyPicoMotor` cold-boot re-seed and mid-run power-cycle re-seed. 200 tests pass across the motor/manager suites.

## Scope / limitations (documented in the store docstring)

This recovers the zero across reboots — including pico-only power glitches while the manager keeps running. It cannot detect motion that happened while unpowered (rig moved by hand, steps lost between the last 200 ms status tick and a power cut); the planned absolute-sensor (potentiometer) cross-check is the cure for that, separate work.

## Cross-repo coordination

`eigsep_observing`'s `SENSOR_SCHEMAS["motor"]` is strict in both directions (missing *and* extra keys are violations), and its producer-contract test composes `MotorEmulator` + `_motor_redis_handler`. A companion eigsep_observing PR must land together with the picohost release that ships this: add `boot_id: int` to the motor schema (+ invariant list), and supply `_motor_pos_store = None` in the `__new__`-bypass contract fixture. The panda Pi's Redis keeps RDB persistence (EIGSEP/eigsep-field#41 scopes the persistence-disable to the backend Pi), so the checkpoint key survives full-system reboots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)