### PR TITLE
feat(tempctrl): lower default drive clamp from 0.6 to 0.2

### DIFF
--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -765,7 +765,7 @@ class PicoPeltier(PicoDevice):
         self._last_enable = cmd
 
     def set_clamp(self, LNA=None, LOAD=None):
-        """Set maximum drive level [0.0, 1.0], 0.6 default."""
+        """Set maximum drive level [0.0, 1.0], 0.2 default."""
         cmd = {}
         if LNA is not None:
             cmd["LNA_clamp"] = LNA

--- a/picohost/src/picohost/emulators/tempctrl.py
+++ b/picohost/src/picohost/emulators/tempctrl.py
@@ -42,7 +42,7 @@ class TempControlState:
         self.Ki = 0.0
         self.integral = 0.0
         self.last_sample_seen = False
-        self.clamp = 0.6
+        self.clamp = 0.2
         self.hysteresis = 0.5
         self.enabled = False
         self.active = False

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -216,7 +216,9 @@ class TestPeltierIntegration:
         """Temperature control converges to target through serial pipeline."""
         cadence = peltier.EMULATOR_CADENCE_MS
         peltier.set_temperature(T_LNA=35.0)
-        peltier.set_clamp(LNA=0.6)  # explicit: default 0.2 would need ~3x the cycles
+        peltier.set_clamp(
+            LNA=0.6
+        )  # explicit: default 0.2 would need ~3x the cycles
         peltier.set_enable(LNA=True)
         # 10°C delta, drive clamped at 0.6, drift 0.05/op -> ~0.03°C/op
         # ~333 ops to converge + margin for hysteresis settling

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -216,6 +216,7 @@ class TestPeltierIntegration:
         """Temperature control converges to target through serial pipeline."""
         cadence = peltier.EMULATOR_CADENCE_MS
         peltier.set_temperature(T_LNA=35.0)
+        peltier.set_clamp(LNA=0.6)  # explicit: default 0.2 would need ~3x the cycles
         peltier.set_enable(LNA=True)
         # 10°C delta, drive clamped at 0.6, drift 0.05/op -> ~0.03°C/op
         # ~333 ops to converge + margin for hysteresis settling
@@ -551,16 +552,18 @@ class TestConvergenceTiming:
     def test_peltier_convergence_bounded(self):
         """Temperature converges within a cycle count derived from the model.
 
-        With default params (Kp=0.2, Ki=0, clamp=0.6) the controller is
-        pure proportional, so drive saturates at the clamp until T_delta
-        drops below clamp/Kp = 3°C. THERMAL_DRIFT_RATE=0.05 gives 0.03°C
-        per clamped op; a 10°C move (25→35) needs ~233 ops at saturation
-        plus a P-controlled tail into the deadband. Allow 500 ops.
+        With default gains (Kp=0.2, Ki=0) and clamp set to 0.6 the
+        controller is pure proportional, so drive saturates at the clamp
+        until T_delta drops below clamp/Kp = 3°C. THERMAL_DRIFT_RATE=0.05
+        gives 0.03°C per clamped op; a 10°C move (25→35) needs ~233 ops
+        at saturation plus a P-controlled tail into the deadband. Allow
+        500 ops.
         """
         p = DummyPicoPeltier("/dev/dummy", keepalive_interval=0.2)
         try:
             cadence = p.EMULATOR_CADENCE_MS
             p.set_temperature(T_LNA=35.0)
+            p.set_clamp(LNA=0.6)
             p.set_enable(LNA=True)
             settled = wait_for_settle(
                 lambda: round(p.last_status.get("LNA_T_now", 0), 1),

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -171,6 +171,7 @@ class TestTempCtrlEmulator:
                 "LNA_temp_target": 40.0,
                 "LNA_enable": True,
                 "LNA_hysteresis": 0.5,
+                "LNA_clamp": 0.6,  # default 0.2 saturates too slowly for 1000 ops
             }
         )
         for _ in range(1000):
@@ -186,6 +187,7 @@ class TestTempCtrlEmulator:
                 "LNA_temp_target": 35.0,
                 "LNA_enable": True,
                 "LNA_hysteresis": 0.5,
+                "LNA_clamp": 0.6,  # default 0.2 saturates too slowly for 1000 ops
             }
         )
         for _ in range(1000):

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -200,7 +200,7 @@ class TestTempCtrlProtocol:
         assert emu.lna.Kp == 0.2
         assert emu.lna.Ki == 0.0
         assert emu.lna.integral == 0.0
-        assert emu.lna.clamp == 0.6
+        assert emu.lna.clamp == 0.2
         assert emu.lna.hysteresis == 0.5
         assert emu.lna.enabled is False
 

--- a/src/tempctrl.c
+++ b/src/tempctrl.c
@@ -55,7 +55,7 @@ void init_single_tempctrl(TempControl *tempctrl,
     tempctrl->Ki = 0.0;
     tempctrl->integral = 0.0;
     tempctrl->last_sample_ms = 0;
-    tempctrl->clamp = 0.6;  // Maximum drive level
+    tempctrl->clamp = 0.2;  // Maximum drive level; low default keeps Peltier current manageable
     tempctrl->hysteresis = 0.5;
     tempctrl->enabled = false;
     tempctrl->active = false;


### PR DESCRIPTION
## Summary
- Lower the firmware default drive clamp from 0.6 to 0.2 so an unconfigured tempctrl channel keeps Peltier current manageable; hosts can still raise it explicitly via `LNA_clamp` / `LOAD_clamp`
- Update the emulator default and the `set_clamp` docstring in lockstep (emulator parity)
- Convergence tests whose cycle budgets were derived from the 0.6 saturation rate now set the clamp explicitly to 0.6 instead of relying on the default

## Test plan
- [x] Full picohost suite: 397 passed
- [x] Firmware builds clean for pico2 (`make -j` in existing build dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)