### PR TITLE
refactor(flash_picos): remove device-info readback retries

### DIFF
--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -341,11 +341,6 @@ _INTER_DEVICE_SETTLE_S = 1.0
 # the bus settle before reading any device so a board's first status
 # lines aren't lost to enumeration churn.
 _POST_RESET_SETTLE_S = 2.0
-# The device-info readback (resolve CDC port + read one JSON line) can
-# flake when several Picos re-enumerate together — retry before giving
-# up, since the flash itself already succeeded.
-_READBACK_MAX_ATTEMPTS = 3
-_READBACK_RETRY_BACKOFF_S = 1.0
 # After the GPIO mass reset, wait for the whole flashed fleet to
 # re-enumerate as CDC before reading any of them.
 _CDC_DISCOVER_TIMEOUT_S = 15.0
@@ -418,79 +413,51 @@ def _resolve_post_flash_port(
     return None
 
 
-def _read_cdc_port(
-    port,
-    usb_serial,
-    baud,
-    timeout,
-    attempts=_READBACK_MAX_ATTEMPTS,
-    backoff=_READBACK_RETRY_BACKOFF_S,
-):
-    """Read one device-info JSON line from CDC *port*, with retries.
+def _read_cdc_port(port, usb_serial, baud, timeout):
+    """Read one device-info JSON line from CDC *port*.
 
     Returns the device-info dict (with ``port``/``usb_serial`` added),
-    or ``None`` once *attempts* are exhausted. The read is retried
-    because, especially after the GPIO mass reset, several Picos
-    re-enumerate together: a board can be briefly busy or slow to start
-    emitting its 200 ms status, so a single timeout drops a Pico that in
-    fact flashed fine. On each retry the port is re-resolved from
-    *usb_serial* (when known) in case the kernel renamed it.
+    or ``None`` on failure. A single attempt is enough: the post-flash
+    re-enumeration races are absorbed before this point (fleet CDC
+    discovery and bus settle on the GPIO path, port re-resolution on
+    the USB path, udev settle here) and the read itself waits up to
+    *timeout* seconds for a status line the firmware emits every
+    200 ms — a board that still says nothing is persistently broken
+    (wrong DIP, failed boot), not transiently busy.
     """
-    last_err = None
-    for attempt in range(1, attempts + 1):
-        if port is None:
-            last_err = (
-                f"no CDC port for serial={usb_serial} "
-                f"(did not re-enumerate within {_REENUMERATE_TIMEOUT_S}s)"
-            )
-        else:
-            _udev_settle()
-            try:
-                data = read_json_from_serial(port, baud, timeout)
-                data["port"] = port
-                data["usb_serial"] = usb_serial
-                return data
-            except (RuntimeError, OSError) as e:
-                last_err = str(e)
-        if attempt < attempts:
-            logger.warning(
-                "device-info read for serial=%s on %s failed (attempt "
-                "%d/%d): %s; retrying",
-                usb_serial,
-                port,
-                attempt,
-                attempts,
-                last_err,
-            )
-            time.sleep(backoff)
-            if usb_serial is not None:
-                port = _resolve_post_flash_port(usb_serial)
-    logger.error(
-        "could not read device info for serial=%s on %s after %d "
-        "attempts: %s (it flashed — re-run flash-picos, or check the "
-        "board's DIP/app if it never reports)",
-        usb_serial,
-        port,
-        attempts,
-        last_err,
-    )
-    return None
+    if port is None:
+        logger.error(
+            "no CDC port for serial=%s (did not re-enumerate within %.0fs)",
+            usb_serial,
+            _REENUMERATE_TIMEOUT_S,
+        )
+        return None
+    _udev_settle()
+    try:
+        data = read_json_from_serial(port, baud, timeout)
+    except (RuntimeError, OSError) as e:
+        logger.error(
+            "could not read device info for serial=%s on %s: %s (it "
+            "flashed — re-run flash-picos, or check the board's DIP/app "
+            "if it never reports)",
+            usb_serial,
+            port,
+            e,
+        )
+        return None
+    data["port"] = port
+    data["usb_serial"] = usb_serial
+    return data
 
 
-def _read_device_info(
-    usb_serial,
-    baud,
-    timeout,
-    attempts=_READBACK_MAX_ATTEMPTS,
-    backoff=_READBACK_RETRY_BACKOFF_S,
-):
+def _read_device_info(usb_serial, baud, timeout):
     """Resolve the post-flash CDC port for *usb_serial* and read its JSON.
 
     Used by the USB per-device path, which already knows each Pico by
     its (stable) CDC serial.
     """
     port = _resolve_post_flash_port(usb_serial)
-    return _read_cdc_port(port, usb_serial, baud, timeout, attempts, backoff)
+    return _read_cdc_port(port, usb_serial, baud, timeout)
 
 
 def _read_fleet_cdc(expected, baud, timeout):
@@ -598,8 +565,7 @@ def flash_and_discover(
         # picotool load reboots the Pico, which re-enumerates as a
         # CDC device. _read_device_info resolves the current path from
         # the stable usb_serial (the kernel may assign a different
-        # /dev/ttyACMn than it had pre-flash) and reads its JSON, with
-        # retries.
+        # /dev/ttyACMn than it had pre-flash) and reads its JSON.
         data = _read_device_info(port_serial, baud, timeout)
         if data is not None:
             all_devices.append(data)

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -672,34 +672,28 @@ class TestResolvePostFlashPort:
 
 
 class TestReadDeviceInfo:
-    """The post-flash device-info readback retries before giving up.
+    """The post-flash device-info readback is a single attempt.
 
-    After the GPIO mass reset the whole fleet re-enumerates at once, so
-    a board that flashed fine can briefly fail to yield its JSON — a
-    single timeout must not drop it.
+    Failing boards fail persistently (wrong DIP, failed boot), so a
+    board whose read fails is dropped immediately rather than retried.
     """
 
     def _patch_common(self, monkeypatch, fp):
         monkeypatch.setattr(fp, "_udev_settle", lambda: None)
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
 
-    def test_retries_then_succeeds(self, monkeypatch):
+    def test_reads_device_info(self, monkeypatch):
         import picohost.flash_picos as fp
 
         self._patch_common(monkeypatch, fp)
         monkeypatch.setattr(
             fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
         )
-
-        attempts = {"n": 0}
-
-        def fake_read(port, baud, timeout):
-            attempts["n"] += 1
-            if attempts["n"] == 1:  # first read flakes
-                raise RuntimeError("Timed out waiting for JSON")
-            return {"app_id": 3}
-
-        monkeypatch.setattr(fp, "read_json_from_serial", fake_read)
+        monkeypatch.setattr(
+            fp,
+            "read_json_from_serial",
+            lambda port, baud, timeout: {"app_id": 3},
+        )
 
         data = fp._read_device_info("SER_A", 115200, 1)
         assert data == {
@@ -707,9 +701,8 @@ class TestReadDeviceInfo:
             "port": "/dev/ttyACM0",
             "usb_serial": "SER_A",
         }
-        assert attempts["n"] == 2
 
-    def test_returns_none_after_exhausting_attempts(self, monkeypatch):
+    def test_returns_none_on_read_failure(self, monkeypatch):
         import picohost.flash_picos as fp
 
         self._patch_common(monkeypatch, fp)
@@ -725,57 +718,39 @@ class TestReadDeviceInfo:
 
         monkeypatch.setattr(fp, "read_json_from_serial", always_timeout)
 
-        data = fp._read_device_info("SER_A", 115200, 1, attempts=3)
+        data = fp._read_device_info("SER_A", 115200, 1)
         assert data is None
-        assert calls["n"] == 3
+        assert calls["n"] == 1  # no retry
 
-    def test_reresolves_port_each_attempt(self, monkeypatch):
-        """The port may rename across re-enumeration; resolve it fresh
-        on every attempt rather than reusing a stale path."""
+    def test_returns_none_when_port_missing(self, monkeypatch):
+        """A Pico that never re-enumerated has no port to read from."""
         import picohost.flash_picos as fp
 
         self._patch_common(monkeypatch, fp)
+        monkeypatch.setattr(fp, "_resolve_post_flash_port", lambda s: None)
 
-        ports = iter(["/dev/ttyACM0", "/dev/ttyACM4"])
-        monkeypatch.setattr(
-            fp, "_resolve_post_flash_port", lambda s: next(ports)
-        )
+        def fail_read(port, baud, timeout):
+            raise AssertionError("must not read without a port")
 
-        seen = []
+        monkeypatch.setattr(fp, "read_json_from_serial", fail_read)
 
-        def fake_read(port, baud, timeout):
-            seen.append(port)
-            if len(seen) == 1:
-                raise RuntimeError("Timed out waiting for JSON")
-            return {"app_id": 0}
+        assert fp._read_device_info("SER_A", 115200, 1) is None
 
-        monkeypatch.setattr(fp, "read_json_from_serial", fake_read)
-
-        data = fp._read_device_info("SER_A", 115200, 1)
-        assert seen == ["/dev/ttyACM0", "/dev/ttyACM4"]
-        assert data["port"] == "/dev/ttyACM4"
-
-    def test_gpio_flow_recovers_flaky_readback(self, _mock_gpio_flash):
-        """End-to-end: a board whose first read times out is still
-        published once the retry succeeds."""
+    def test_gpio_flow_drops_unreadable_board(self, _mock_gpio_flash):
+        """End-to-end: a board whose read times out is dropped; the
+        rest of the fleet is still published."""
         m = _mock_gpio_flash
-        attempts = {"/dev/ttyACM5": 0, "/dev/ttyACM6": 0}
 
-        def flaky_read(port, baud, timeout):
-            attempts[port] += 1
-            # SER_B's port flakes once, then yields JSON.
-            if port == "/dev/ttyACM6" and attempts[port] == 1:
+        def read(port, baud, timeout):
+            if port == "/dev/ttyACM6":  # SER_B never yields JSON
                 raise RuntimeError("Timed out waiting for JSON")
-            return {
-                "/dev/ttyACM5": {"app_id": 0},
-                "/dev/ttyACM6": {"app_id": 5},
-            }[port]
+            return {"/dev/ttyACM5": {"app_id": 0}}[port]
 
-        m.monkeypatch.setattr(m.fp, "read_json_from_serial", flaky_read)
+        m.monkeypatch.setattr(m.fp, "read_json_from_serial", read)
 
         devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
 
-        assert sorted(d["usb_serial"] for d in devices) == ["SER_A", "SER_B"]
+        assert [d["usb_serial"] for d in devices] == ["SER_A"]
 
 
 class TestResolveBusAddress:


### PR DESCRIPTION
## What

Remove the device-info readback retries in `flash_picos.py`. The post-flash CDC readback previously retried 3× with 1 s backoff (`_READBACK_MAX_ATTEMPTS`, `_READBACK_RETRY_BACKOFF_S`), costing ~22 s of dead time per hard-failing board. `_read_cdc_port` / `_read_device_info` now read once and drop an unreadable board with a single error line.

## Why

In the field a board either reports on the first attempt or fails all three. The transient re-enumeration races the retry was meant to absorb are already handled upstream by:
- the fleet CDC-discovery poll,
- the post-reset settle,
- the udev settle, and
- the 10 s per-read JSON timeout.

A board that still says nothing after all that is persistently broken (wrong DIP, failed boot), not transiently busy — so retrying just burns wall-clock.

## Changes

- `flash_picos.py`: drop the two retry constants and collapse `_read_cdc_port`/`_read_device_info` to a single attempt.
- `test_flash_picos.py`: rework `TestReadDeviceInfo` to assert single-attempt behavior (reads once, drops on failure, no retry, none-on-missing-port) and the GPIO end-to-end "drop unreadable board, publish the rest" path.

Net: 62 insertions / 121 deletions. All 65 tests in `test_flash_picos.py` pass.

## Note

This work was originally done in a git worktree that was deleted before pushing; recovered from a dangling commit (`0088436`) and re-anchored to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
