### PR TITLE
ci: fix invalid secrets reference in emulator-parity if condition

### DIFF
--- a/.github/workflows/claude-emulator-parity.yml
+++ b/.github/workflows/claude-emulator-parity.yml
@@ -20,6 +20,11 @@ jobs:
       pull-requests: write
       id-token: write
 
+    # The `secrets` context is not available in `if:` conditions, so surface
+    # the token's presence as an env var that the steps can gate on instead.
+    env:
+      HAS_CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -27,7 +32,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude firmware/emulator parity review
-        if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        if: ${{ env.HAS_CLAUDE_TOKEN == 'true' }}
         continue-on-error: true
         id: claude-emulator-parity
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Problem

The `Claude Emulator Parity` workflow has been **invalid since it was added in #99** and has never run successfully. Every single push produced a 0-job, 0-second `failure` run attributed to the push event (GitHub's signature for a workflow file that fails validation before any job can be scheduled), with the banner *"This run likely failed because of a workflow file issue."*

Root cause: the `secrets` context is **not available in `if:` conditionals**. The step guard

```yaml
if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
```

made the entire workflow file invalid, so GitHub startup-failed it on every commit. The "advisory, never blocks" design held — it never gated a merge — but the advisory parity review **never actually executed** (no PR comment was ever posted).

## Fix

Surface the token's presence as a job-level `env` var (where the `secrets` context *is* allowed) and gate the step on that:

```yaml
env:
  HAS_CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
...
    if: ${{ env.HAS_CLAUDE_TOKEN == 'true' }}
```

Behavior is otherwise unchanged: still advisory, still `continue-on-error`, still only triggers on PRs touching `src/**` / `emulators/**`.

## Verification

Previously *every* commit generated a parity startup-failure run. The push of this branch produced **none** — confirming the file now passes GitHub's workflow validation.

Note: the end-to-end behavior (the review posting its PR comment) can only exercise on a PR that touches `src/**` or `emulators/**`, since that is the workflow's trigger; this PR only edits the workflow file, so it won't self-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)