### PR TITLE
fix(flash_picos): bound serial readback so a wedged CDC port can't hang the fleet flash

### DIFF
--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -5,6 +5,7 @@ import json
 import logging
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -318,21 +319,78 @@ def flash_uf2(
     )
 
 
+# Extra wall-clock budget, beyond the read *timeout*, for the serial
+# port's open and close to complete. A marginal CDC port whose USB
+# endpoint has wedged (the "-110 mute" state) can block in the kernel's
+# cdc_acm teardown — os.close() inside the `with Serial(...)` exit never
+# returns — and pyserial's timeout bounds only reads, not open/close. The
+# read therefore runs on a daemon worker we bound by wall clock and
+# abandon if it overruns, so one wedged port cannot hang the whole fleet
+# readback.
+_SERIAL_TEARDOWN_GRACE_S = 2.0
+
+
 def read_json_from_serial(port, baud, timeout):
+    """Open *port* and return the first valid JSON line, or raise.
+
+    Runs the open/read/close on a daemon worker bounded by wall clock
+    (*timeout* for the read, plus :data:`_SERIAL_TEARDOWN_GRACE_S` for
+    open and close). A board whose USB endpoint has wedged can block the
+    kernel's cdc_acm teardown indefinitely — ``os.close()`` inside the
+    ``with Serial(...)`` exit never returns, and pyserial's ``timeout``
+    does not cover it. Rather than let that freeze the fleet readback
+    (observed in the field: flash-picos hung in :func:`_read_fleet_cdc`
+    on a mute ``/dev/ttyACMn`` after reading the rest of the fleet), the
+    worker is abandoned and a :class:`RuntimeError` raised so the caller
+    classifies the port as a failed read and moves on. A line read before
+    a blocking close is still returned: the worker publishes it before
+    unwinding the ``with``.
+
+    Raises :class:`RuntimeError` on timeout/wedge, or re-raises the
+    worker's open/read ``OSError`` — mirroring the previous direct-read
+    contract so :func:`_classify_read_failure` verdicts are unchanged.
     """
-    Open the serial port, read until a valid JSON line appears or timeout.
-    """
-    with Serial(port, baudrate=baud, timeout=1) as ser:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            line = ser.readline().decode("utf-8", errors="ignore").strip()
-            if not line:
-                continue
-            try:
-                return json.loads(line)
-            except json.JSONDecodeError:
-                continue
-    raise RuntimeError(f"[{port}] Timed out waiting for JSON")
+    result = {}
+    done = threading.Event()
+
+    def _read():
+        try:
+            with Serial(port, baudrate=baud, timeout=1) as ser:
+                deadline = time.monotonic() + timeout
+                while time.monotonic() < deadline:
+                    line = ser.readline().decode("utf-8", errors="ignore")
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        parsed = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    # Publish before leaving the `with`: if close wedges,
+                    # the caller still gets the line we already read.
+                    result["data"] = parsed
+                    done.set()
+                    return
+        except Exception as e:  # open or read failed
+            result["exc"] = e
+            done.set()
+            return
+        result["exc"] = RuntimeError(f"[{port}] Timed out waiting for JSON")
+        done.set()
+
+    threading.Thread(
+        target=_read, name=f"serial-read-{port}", daemon=True
+    ).start()
+    done.wait(timeout + _SERIAL_TEARDOWN_GRACE_S)
+    if "data" in result:
+        return result["data"]
+    if "exc" in result:
+        raise result["exc"]
+    raise RuntimeError(
+        f"[{port}] serial open/read/close did not complete within "
+        f"{timeout + _SERIAL_TEARDOWN_GRACE_S:.0f}s; the port is wedged "
+        f"(USB endpoint stuck) — abandoning it"
+    )
 
 
 _REENUMERATE_TIMEOUT_S = 10.0

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -758,6 +758,103 @@ class TestReadDeviceInfo:
         assert [d["usb_serial"] for d in devices] == ["SER_A"]
 
 
+class TestReadJsonFromSerialBoundedTeardown:
+    """read_json_from_serial must never hang the fleet read on a wedged
+    port.
+
+    A board that enumerated but whose USB endpoint is stuck ("-110
+    mute") can block in the kernel's cdc_acm teardown: ``os.close()``
+    inside the ``with Serial(...)`` exit never returns. Observed in the
+    field — flash-picos froze in _read_fleet_cdc on /dev/ttyACM4 after
+    reading the other four boards. pyserial's ``timeout`` bounds reads,
+    not open/close, so the read runs on an abandonable worker bounded by
+    wall clock: a wedged port becomes a classified failure and the rest
+    of the fleet is still read and published.
+    """
+
+    @staticmethod
+    def _run_bounded(fn, bound=5.0):
+        """Run *fn* on a daemon thread; return ``(finished, box)``.
+
+        Lets the test assert the call returned within *bound* without the
+        suite itself hanging when the code under test blocks.
+        """
+        import threading
+
+        box = {}
+
+        def run():
+            try:
+                box["ret"] = fn()
+            except BaseException as e:  # record for the assertion
+                box["exc"] = e
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        t.join(bound)
+        return (not t.is_alive()), box
+
+    def test_wedged_close_does_not_hang(self, monkeypatch):
+        import threading
+
+        import picohost.flash_picos as fp
+
+        wedged = threading.Event()  # never set: os.close() never returns
+
+        class WedgedSerial:
+            def __init__(self, port, baudrate=115200, timeout=1):
+                self.port = port
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                wedged.wait()  # block forever in teardown
+
+            def readline(self):
+                return b""  # nothing to read -> inner read times out
+
+        monkeypatch.setattr(fp, "Serial", WedgedSerial)
+        monkeypatch.setattr(fp, "_SERIAL_TEARDOWN_GRACE_S", 0.3, raising=False)
+
+        finished, box = self._run_bounded(
+            lambda: fp.read_json_from_serial("/dev/ttyACM4", 115200, 0.2)
+        )
+
+        assert finished, "read_json_from_serial hung on a wedged serial close"
+        assert isinstance(box.get("exc"), RuntimeError)
+
+    def test_returns_data_captured_before_blocking_close(self, monkeypatch):
+        import threading
+
+        import picohost.flash_picos as fp
+
+        wedged = threading.Event()  # close blocks, but data already read
+
+        class SlowCloseSerial:
+            def __init__(self, port, baudrate=115200, timeout=1):
+                self.port = port
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                wedged.wait()
+
+            def readline(self):
+                return b'{"app_id": 5}\n'
+
+        monkeypatch.setattr(fp, "Serial", SlowCloseSerial)
+        monkeypatch.setattr(fp, "_SERIAL_TEARDOWN_GRACE_S", 0.3, raising=False)
+
+        finished, box = self._run_bounded(
+            lambda: fp.read_json_from_serial("/dev/ttyACM4", 115200, 10)
+        )
+
+        assert finished, "did not return data read before the blocking close"
+        assert box.get("ret") == {"app_id": 5}
+
+
 class TestResolveBusAddress:
     def _make(
         self, root, name, vid, pid, *, serial=None, bus=None, devnum=None


### PR DESCRIPTION
## Problem

On the observatory hub, `flash-picos` froze and never completed. Ctrl-C traceback pinned it exactly:

```
_read_fleet_cdc → _read_cdc_outcome → read_json_from_serial
  with Serial(port='/dev/ttyACM4', ...)          # line 325
    __exit__ → close() → os.close(self.fd)        # blocked here forever
```

A marginal CDC port whose USB endpoint has wedged (the "-110 mute" state) blocks in the kernel's `cdc_acm` teardown — `os.close()` inside the `with Serial(...)` exit never returns. pyserial's `timeout` bounds only *reads*, not open/close, so a single wedged board hung the entire GPIO fleet readback: the four good boards had already been read, but the run never published to Redis or restarted `picomanager`.

The failure tracks the **seat**, not the Pico (confirmed by swapping Picos between seats), so the wedged board is a per-seat USB hardware fault — but the firmware/host tool should report it, not deadlock on it.

## Fix

`read_json_from_serial` now runs the open/read/close on a **daemon worker bounded by wall clock** (`timeout` for the read, plus `_SERIAL_TEARDOWN_GRACE_S` = 2s for open/close):

- **A wedged port no longer hangs the fleet.** If the worker overruns it is abandoned and a `RuntimeError` raised; `_read_cdc_outcome` classifies the port (existing `_classify_read_failure` vocabulary) and `_read_fleet_cdc` proceeds. The good boards flash, publish, and the manager restarts; the wedged board is reported.
- **A line read just before a blocking close is still returned** — the worker publishes the JSON *before* unwinding the `with`, so a board that emitted status but then wedged on close isn't lost.

Contract is unchanged for callers (still raises `RuntimeError`/`OSError`), so `_classify_read_failure` verdicts are the same.

## Tests

The existing suite monkeypatches `read_json_from_serial` wholesale, leaving the real open/close path with zero coverage — that's how this slipped through. Adds `TestReadJsonFromSerialBoundedTeardown`, which reproduces the `os.close()` hang with a fake `Serial` and asserts:

1. a wedged teardown raises within the bound instead of hanging, and
2. a line read before a blocking close is still returned.

Verification:
- New tests: RED (2 failed in 10.85s, on the hang) → GREEN (2 passed in 0.62s)
- `flash_picos` suite: 97 passed
- Full picohost suite: 520 passed
- ruff check + format: clean

## Not included (follow-ups)

- The three `subprocess.run(picotool …)` calls still have no `timeout=` — a latent hang risk during the load/boot phase (not implicated in this traceback).
- The mute-reread sweep still retries a wedged port up to 5×; a port that raised the "wedged" verdict won't recover in-process, so this adds ~40s before it's reported. Bounded, but tunable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)