### PR TITLE
fix(flash_picos): isolate serial readback in a child process so a wedged port can't pin process exit

### DIFF
--- a/picohost/src/picohost/_serial_reader.py
+++ b/picohost/src/picohost/_serial_reader.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Standalone serial-read helper, run as a *child process* by flash_picos.
+
+Why a separate process, and why run by file path
+------------------------------------------------
+A board that enumerated but whose USB endpoint has wedged (the "-110
+mute" state) can block the kernel's ``cdc_acm`` teardown: the final
+``os.close()`` of the tty never returns (uninterruptible sleep). pyserial's
+``timeout`` bounds reads, not open/close.
+
+A *thread* cannot escape this. Bounding the wait only frees the calling
+thread; the worker stays stuck in the kernel syscall, and a process cannot
+complete ``exit_group(2)`` while any of its threads is in uninterruptible
+sleep — so the whole process hangs at exit even though its main thread is
+done. (That is exactly the residual hang that survived bounding the wait:
+flash-picos finished its work but never exited, so ``eigsep-field patch``,
+which waits on it unbounded, hung forever.)
+
+Isolating the open/read/close in a child process is what fixes it: the
+wedge pins *this* child, and ``flash_picos`` abandons it and exits cleanly.
+The kernel fd-teardown that blocks then happens in the abandoned child
+(reparented to init), not in flash-picos.
+
+This file is launched by **file path** (``python .../_serial_reader.py``),
+not imported as ``picohost._serial_reader`` — running it as a script does
+not execute ``picohost/__init__`` and so does not pull in the package's
+heavy imports (eigsep_redis, etc.) on every per-board readback. Keep it
+dependency-light: stdlib plus pyserial only.
+
+Protocol (one JSON object line written to stdout, then flushed):
+  {"data": {...}}                  first valid JSON status line from the port
+  {"timeout": true}                port opened but no JSON within the window
+  {"err": "...", "errno": N|null}  open/read raised (errno preserved so the
+                                   parent can classify EACCES/EBUSY/-110)
+The line is delivered *before* the (possibly wedging) close, so the parent
+gets the data even when the close never returns.
+"""
+
+import json
+import sys
+import time
+
+from serial import Serial
+
+
+def run(port, baud, timeout, out):
+    """Open *port*, write one protocol line to *out*, then close.
+
+    The write+flush always precede the close so a wedging close cannot
+    swallow a line we already read. Returns ``0`` (process exit code).
+    """
+    try:
+        ser = Serial(port, baudrate=baud, timeout=1)
+    except Exception as e:  # open failed (EACCES/EBUSY/ENOENT/-110/...)
+        out.write(
+            json.dumps({"err": str(e), "errno": getattr(e, "errno", None)})
+            + "\n"
+        )
+        out.flush()
+        return 0
+    try:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                line = ser.readline().decode("utf-8", errors="ignore").strip()
+            except Exception as e:  # read failed mid-stream
+                out.write(
+                    json.dumps(
+                        {"err": str(e), "errno": getattr(e, "errno", None)}
+                    )
+                    + "\n"
+                )
+                out.flush()
+                return 0
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            out.write(json.dumps({"data": parsed}) + "\n")
+            out.flush()
+            return 0
+        out.write(json.dumps({"timeout": True}) + "\n")
+        out.flush()
+        return 0
+    finally:
+        # The line (if any) is already delivered. This is the call that can
+        # wedge on a mute USB endpoint; if it does, the parent abandons us.
+        try:
+            ser.close()
+        except Exception:
+            pass
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    port, baud, timeout = argv[0], int(argv[1]), float(argv[2])
+    return run(port, baud, timeout, sys.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -3,14 +3,14 @@ import argparse
 import errno
 import json
 import logging
+import os
+import select
 import subprocess
 import sys
-import threading
 import time
 from pathlib import Path
 
 from eigsep_redis import Transport
-from serial import Serial
 from serial.tools import list_ports
 
 from . import manager_service
@@ -322,75 +322,124 @@ def flash_uf2(
 # Extra wall-clock budget, beyond the read *timeout*, for the serial
 # port's open and close to complete. A marginal CDC port whose USB
 # endpoint has wedged (the "-110 mute" state) can block in the kernel's
-# cdc_acm teardown — os.close() inside the `with Serial(...)` exit never
-# returns — and pyserial's timeout bounds only reads, not open/close. The
-# read therefore runs on a daemon worker we bound by wall clock and
-# abandon if it overruns, so one wedged port cannot hang the whole fleet
-# readback.
+# cdc_acm teardown — os.close() of the tty never returns — and pyserial's
+# timeout bounds only reads, not open/close.
 _SERIAL_TEARDOWN_GRACE_S = 2.0
+
+# The open/read/close runs in a *child process* (see _serial_reader.py),
+# launched by file path so it does not import the picohost package (and
+# its heavy deps) on every per-board read.
+_SERIAL_READER_SCRIPT = str(Path(__file__).with_name("_serial_reader.py"))
+
+
+def _read_line_bounded(stream, bound):
+    """Return the first newline-terminated line from *stream*, or ``None``.
+
+    Polls the underlying fd with :func:`select.select` so the wait is
+    bounded by *bound* seconds even if the writer never sends a newline or
+    never closes its end (a wedged reader child). Returns ``None`` on
+    timeout or on EOF-without-a-line.
+    """
+    fd = stream.fileno()
+    buf = bytearray()
+    deadline = time.monotonic() + bound
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        readable, _, _ = select.select([fd], [], [], remaining)
+        if not readable:
+            return None
+        chunk = os.read(fd, 4096)
+        if not chunk:  # EOF before any newline
+            return None
+        buf.extend(chunk)
+        nl = buf.find(b"\n")
+        if nl != -1:
+            return bytes(buf[: nl + 1]).decode("utf-8", errors="ignore")
+
+
+def _abandon_reader(proc):
+    """Tear down the reader child without ever blocking on a wedged one.
+
+    A reader stuck in ``os.close()`` of a mute CDC port is in
+    uninterruptible sleep: it will not die on ``SIGKILL`` until the kernel
+    teardown returns, so we must NOT wait for it — flash-picos has to stay
+    free to exit. The orphan is reparented to init, which reaps it once the
+    syscall finally unwinds (and ``subprocess`` reaps any cleanly-finished
+    child on the next :class:`~subprocess.Popen`). A reader that already
+    exited is reaped here with a short, bounded wait so it does not linger.
+    """
+    try:
+        proc.stdout.close()
+    except OSError:
+        pass
+    if proc.poll() is None:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    try:
+        proc.wait(timeout=_SERIAL_TEARDOWN_GRACE_S)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def read_json_from_serial(port, baud, timeout):
     """Open *port* and return the first valid JSON line, or raise.
 
-    Runs the open/read/close on a daemon worker bounded by wall clock
-    (*timeout* for the read, plus :data:`_SERIAL_TEARDOWN_GRACE_S` for
-    open and close). A board whose USB endpoint has wedged can block the
-    kernel's cdc_acm teardown indefinitely — ``os.close()`` inside the
-    ``with Serial(...)`` exit never returns, and pyserial's ``timeout``
-    does not cover it. Rather than let that freeze the fleet readback
-    (observed in the field: flash-picos hung in :func:`_read_fleet_cdc`
-    on a mute ``/dev/ttyACMn`` after reading the rest of the fleet), the
-    worker is abandoned and a :class:`RuntimeError` raised so the caller
-    classifies the port as a failed read and moves on. A line read before
-    a blocking close is still returned: the worker publishes it before
-    unwinding the ``with``.
+    The open/read/close runs in a child process (:mod:`_serial_reader`),
+    not a thread, and is bounded by wall clock (*timeout* for the read,
+    plus :data:`_SERIAL_TEARDOWN_GRACE_S` for open and close). A board
+    whose USB endpoint has wedged can block the kernel's cdc_acm teardown
+    indefinitely — ``os.close()`` of the tty never returns, and pyserial's
+    ``timeout`` does not cover it. A *thread* cannot escape that: bounding
+    the wait frees the calling thread, but the worker stays stuck in the
+    kernel and a process cannot finish ``exit_group()`` while any thread is
+    in uninterruptible sleep — so flash-picos hung at exit even after the
+    main thread was done (and ``eigsep-field patch``, waiting on it
+    unbounded, hung forever). Running it in a child process means the wedge
+    pins the child; we abandon it and exit cleanly.
 
-    Raises :class:`RuntimeError` on timeout/wedge, or re-raises the
-    worker's open/read ``OSError`` — mirroring the previous direct-read
+    The child writes one JSON line and flushes *before* its close, so a
+    line read just before a blocking close is still returned. Raises
+    :class:`RuntimeError` on timeout/wedge, or an ``OSError`` (with
+    ``errno`` preserved) on open/read failure — mirroring the previous
     contract so :func:`_classify_read_failure` verdicts are unchanged.
     """
-    result = {}
-    done = threading.Event()
-
-    def _read():
-        try:
-            with Serial(port, baudrate=baud, timeout=1) as ser:
-                deadline = time.monotonic() + timeout
-                while time.monotonic() < deadline:
-                    line = ser.readline().decode("utf-8", errors="ignore")
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        parsed = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    # Publish before leaving the `with`: if close wedges,
-                    # the caller still gets the line we already read.
-                    result["data"] = parsed
-                    done.set()
-                    return
-        except Exception as e:  # open or read failed
-            result["exc"] = e
-            done.set()
-            return
-        result["exc"] = RuntimeError(f"[{port}] Timed out waiting for JSON")
-        done.set()
-
-    threading.Thread(
-        target=_read, name=f"serial-read-{port}", daemon=True
-    ).start()
-    done.wait(timeout + _SERIAL_TEARDOWN_GRACE_S)
-    if "data" in result:
-        return result["data"]
-    if "exc" in result:
-        raise result["exc"]
-    raise RuntimeError(
-        f"[{port}] serial open/read/close did not complete within "
-        f"{timeout + _SERIAL_TEARDOWN_GRACE_S:.0f}s; the port is wedged "
-        f"(USB endpoint stuck) — abandoning it"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            _SERIAL_READER_SCRIPT,
+            str(port),
+            str(baud),
+            str(timeout),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
     )
+    try:
+        line = _read_line_bounded(
+            proc.stdout, timeout + _SERIAL_TEARDOWN_GRACE_S
+        )
+    finally:
+        _abandon_reader(proc)
+
+    if line is None:
+        raise RuntimeError(
+            f"[{port}] serial open/read/close did not complete within "
+            f"{timeout + _SERIAL_TEARDOWN_GRACE_S:.0f}s; the port is wedged "
+            f"(USB endpoint stuck) — abandoning it"
+        )
+    msg = json.loads(line)
+    if "data" in msg:
+        return msg["data"]
+    if "err" in msg:
+        code = msg.get("errno")
+        if code is not None:
+            raise OSError(code, msg["err"])
+        raise OSError(msg["err"])
+    raise RuntimeError(f"[{port}] Timed out waiting for JSON")
 
 
 _REENUMERATE_TIMEOUT_S = 10.0

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -431,7 +431,12 @@ def read_json_from_serial(port, baud, timeout):
             f"{timeout + _SERIAL_TEARDOWN_GRACE_S:.0f}s; the port is wedged "
             f"(USB endpoint stuck) — abandoning it"
         )
-    msg = json.loads(line)
+    try:
+        msg = json.loads(line)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"[{port}] serial read returned invalid JSON: {e.msg}"
+        ) from e
     if "data" in msg:
         return msg["data"]
     if "err" in msg:

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -1,6 +1,7 @@
 """Tests for picohost.flash_picos.flash_and_discover."""
 
 import errno
+import json
 import logging
 import types
 
@@ -758,101 +759,186 @@ class TestReadDeviceInfo:
         assert [d["usb_serial"] for d in devices] == ["SER_A"]
 
 
-class TestReadJsonFromSerialBoundedTeardown:
-    """read_json_from_serial must never hang the fleet read on a wedged
-    port.
+class TestSerialReaderChild:
+    """The child reader (_serial_reader.run) must deliver its line BEFORE
+    closing the port.
 
-    A board that enumerated but whose USB endpoint is stuck ("-110
-    mute") can block in the kernel's cdc_acm teardown: ``os.close()``
-    inside the ``with Serial(...)`` exit never returns. Observed in the
-    field — flash-picos froze in _read_fleet_cdc on /dev/ttyACM4 after
-    reading the other four boards. pyserial's ``timeout`` bounds reads,
-    not open/close, so the read runs on an abandonable worker bounded by
-    wall clock: a wedged port becomes a classified failure and the rest
-    of the fleet is still read and published.
+    A board whose USB endpoint is stuck ("-110 mute") can block the
+    kernel's cdc_acm teardown: the tty ``os.close()`` never returns. The
+    child therefore writes+flushes its one protocol line first, so a line
+    read just before a wedging close still reaches the parent.
     """
 
-    @staticmethod
-    def _run_bounded(fn, bound=5.0):
-        """Run *fn* on a daemon thread; return ``(finished, box)``.
+    def test_emits_data_before_close(self, monkeypatch):
+        import io
 
-        Lets the test assert the call returned within *bound* without the
-        suite itself hanging when the code under test blocks.
-        """
-        import threading
+        import picohost._serial_reader as sr
 
-        box = {}
+        events = []
 
-        def run():
-            try:
-                box["ret"] = fn()
-            except BaseException as e:  # record for the assertion
-                box["exc"] = e
-
-        t = threading.Thread(target=run, daemon=True)
-        t.start()
-        t.join(bound)
-        return (not t.is_alive()), box
-
-    def test_wedged_close_does_not_hang(self, monkeypatch):
-        import threading
-
-        import picohost.flash_picos as fp
-
-        wedged = threading.Event()  # never set: os.close() never returns
-
-        class WedgedSerial:
-            def __init__(self, port, baudrate=115200, timeout=1):
-                self.port = port
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc):
-                wedged.wait()  # block forever in teardown
-
-            def readline(self):
-                return b""  # nothing to read -> inner read times out
-
-        monkeypatch.setattr(fp, "Serial", WedgedSerial)
-        monkeypatch.setattr(fp, "_SERIAL_TEARDOWN_GRACE_S", 0.3, raising=False)
-
-        finished, box = self._run_bounded(
-            lambda: fp.read_json_from_serial("/dev/ttyACM4", 115200, 0.2)
-        )
-
-        assert finished, "read_json_from_serial hung on a wedged serial close"
-        assert isinstance(box.get("exc"), RuntimeError)
-
-    def test_returns_data_captured_before_blocking_close(self, monkeypatch):
-        import threading
-
-        import picohost.flash_picos as fp
-
-        wedged = threading.Event()  # close blocks, but data already read
-
-        class SlowCloseSerial:
-            def __init__(self, port, baudrate=115200, timeout=1):
-                self.port = port
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc):
-                wedged.wait()
+        class FakeSerial:
+            def __init__(self, *a, **k):
+                pass
 
             def readline(self):
                 return b'{"app_id": 5}\n'
 
-        monkeypatch.setattr(fp, "Serial", SlowCloseSerial)
-        monkeypatch.setattr(fp, "_SERIAL_TEARDOWN_GRACE_S", 0.3, raising=False)
+            def close(self):
+                events.append("close")
 
-        finished, box = self._run_bounded(
-            lambda: fp.read_json_from_serial("/dev/ttyACM4", 115200, 10)
+        class RecordingOut(io.StringIO):
+            def write(self, s):
+                events.append("write")
+                return super().write(s)
+
+        monkeypatch.setattr(sr, "Serial", FakeSerial)
+        out = RecordingOut()
+
+        assert sr.run("/dev/ttyACM4", 115200, 10, out) == 0
+        assert json.loads(out.getvalue()) == {"data": {"app_id": 5}}
+        # The line must be written before the (possibly wedging) close.
+        assert events == ["write", "close"]
+
+    def test_open_error_preserves_errno(self, monkeypatch):
+        import io
+
+        import picohost._serial_reader as sr
+
+        class FailingSerial:
+            def __init__(self, *a, **k):
+                raise OSError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr(sr, "Serial", FailingSerial)
+        out = io.StringIO()
+
+        sr.run("/dev/ttyACM4", 115200, 10, out)
+        msg = json.loads(out.getvalue())
+        assert msg["errno"] == errno.EACCES
+        assert "Permission denied" in msg["err"]
+
+    def test_silent_port_reports_timeout(self, monkeypatch):
+        import io
+
+        import picohost._serial_reader as sr
+
+        class SilentSerial:
+            def __init__(self, *a, **k):
+                pass
+
+            def readline(self):
+                return b""  # never emits a line
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(sr, "Serial", SilentSerial)
+        out = io.StringIO()
+
+        sr.run("/dev/ttyACM4", 115200, 0.1, out)
+        assert json.loads(out.getvalue()) == {"timeout": True}
+
+
+class _FakeReaderProc:
+    """Stand-in for the reader child's Popen, backed by a real OS pipe so
+    the parent's select()/os.read() path is exercised for real.
+
+    With ``eof=False`` the write end is left open, modelling a child that
+    has delivered its line but not exited (its close is wedging). ``wait``
+    always raises :class:`~subprocess.TimeoutExpired`, modelling the worst
+    case — a child that will not reap within the grace — so every parent
+    test also proves :func:`read_json_from_serial` never blocks on it.
+    """
+
+    def __init__(self, payload=b"", *, eof=True):
+        import os
+
+        r, self._w = os.pipe()
+        self.stdout = os.fdopen(r, "rb", buffering=0)
+        if payload:
+            os.write(self._w, payload)
+        if eof:
+            os.close(self._w)
+            self._w = None
+        self.killed = False
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self, timeout=None):
+        import subprocess
+
+        raise subprocess.TimeoutExpired("reader", timeout)
+
+    def cleanup(self):
+        import os
+
+        if self._w is not None:
+            os.close(self._w)
+            self._w = None
+
+
+class TestReadJsonFromSerialChildProcess:
+    """read_json_from_serial runs the open/read/close in a child process,
+    not a thread, so a wedged CDC port pins the child (which flash-picos
+    abandons) and never the flash-picos process — a thread stuck in the
+    kernel's uninterruptible cdc_acm close would otherwise keep the
+    process from exiting, hanging ``eigsep-field patch`` forever.
+    """
+
+    def _patch(self, monkeypatch, fake):
+        monkeypatch.setattr(fp.subprocess, "Popen", lambda *a, **k: fake)
+
+    def test_returns_data_even_if_child_does_not_exit(self, monkeypatch):
+        fake = _FakeReaderProc(b'{"data": {"app_id": 5}}\n', eof=False)
+        self._patch(monkeypatch, fake)
+        try:
+            assert fp.read_json_from_serial("/dev/ttyACM4", 115200, 10) == {
+                "app_id": 5
+            }
+        finally:
+            fake.cleanup()
+        assert fake.killed  # the lingering child was abandoned, not awaited
+
+    def test_does_not_leak_a_thread(self, monkeypatch):
+        import threading
+
+        base = threading.active_count()
+        fake = _FakeReaderProc(b'{"data": {"x": 1}}\n')
+        self._patch(monkeypatch, fake)
+        fp.read_json_from_serial("/dev/ttyACM4", 115200, 10)
+        # The read no longer runs on an in-process thread; nothing it spawns
+        # can survive to pin process exit.
+        assert threading.active_count() == base
+
+    def test_no_output_within_bound_raises(self, monkeypatch):
+        fake = _FakeReaderProc(b"", eof=False)  # never speaks, never closes
+        self._patch(monkeypatch, fake)
+        monkeypatch.setattr(fp, "_SERIAL_TEARDOWN_GRACE_S", 0.2)
+        try:
+            with pytest.raises(RuntimeError, match="wedged"):
+                fp.read_json_from_serial("/dev/ttyACM4", 115200, 0.2)
+        finally:
+            fake.cleanup()
+        assert fake.killed
+
+    def test_err_line_raises_oserror_with_errno(self, monkeypatch):
+        fake = _FakeReaderProc(
+            b'{"err": "could not open port", "errno": %d}\n' % errno.EBUSY
         )
+        self._patch(monkeypatch, fake)
+        with pytest.raises(OSError) as ei:
+            fp.read_json_from_serial("/dev/ttyACM4", 115200, 10)
+        assert ei.value.errno == errno.EBUSY
 
-        assert finished, "did not return data read before the blocking close"
-        assert box.get("ret") == {"app_id": 5}
+    def test_timeout_line_raises_runtimeerror(self, monkeypatch):
+        fake = _FakeReaderProc(b'{"timeout": true}\n')
+        self._patch(monkeypatch, fake)
+        with pytest.raises(RuntimeError, match="Timed out"):
+            fp.read_json_from_serial("/dev/ttyACM4", 115200, 10)
 
 
 class TestResolveBusAddress:


### PR DESCRIPTION
## Problem

`eigsep-field patch pico-firmware` hung indefinitely after flashing — the last output was `Read device info from /dev/ttyACMn` and then nothing.

Commit `66c5f8f` bounded the readback **wait** but kept the open/read/close on a **daemon thread**. That only frees the *calling* thread. A board whose USB endpoint has wedged (the "-110 mute" state) blocks the kernel's `cdc_acm` teardown, so the tty `os.close()` never returns (uninterruptible sleep) — and **a process cannot finish `exit_group(2)` while any of its threads is in uninterruptible sleep.**

So flash-picos read every board, published to Redis, finished all its work — and then **hung at exit**, with the abandoned daemon worker stuck in `close()`. `eigsep-field`'s `_patch.py:_run` waits on flash-picos with an unbounded `subprocess.run`, so it blocked forever. The symptom looked like the *read* froze, but the process had actually finished and just couldn't terminate.

The previous fix's own test (`test_returns_data_captured_before_blocking_close`) deliberately left the worker blocked in close "forever" and treated it as harmless — which it is on a Python `Event`, but not on a real kernel `os.close()`.

## Fix

A thread can never escape an uninterruptible kernel syscall — only process isolation can. Move the open/read/close into a **child process** (`_serial_reader.py`):

- Launched **by file path** so it doesn't import the heavy `picohost` package on every per-board read (stdlib + pyserial only).
- Parent reads one JSON line bounded by `select()`, then **abandons** the child (kill, never block on `wait`).
- A wedged close now pins the *child* (reparented to init); flash-picos exits cleanly.
- The child writes+flushes its line **before** the close, so a line read just before a blocking close is still returned.
- `errno` is preserved across the process boundary, so `_classify_read_failure`'s EACCES/EBUSY/-110 verdicts are unchanged.

## Tests

- Replaced `TestReadJsonFromSerialBoundedTeardown` (which encoded and sanctioned the forever-blocking worker close) with tests for the child protocol and the parent's bounded-read / abandon / errno behavior, including that the read leaks **no in-process thread**.
- `tests/test_flash_picos.py`: 103 passed locally; `ruff check`/`format` clean.

## Follow-up (not in this PR)

Worth adding a hard wall-clock timeout to `eigsep-field`'s `_patch.py:_run` `subprocess.run` as a second line of defense against any future child wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)