### PR TITLE
feat(potmon): drop el channel, read az only

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,10 @@ JSON protocol keys use `LNA_` and `LOAD_` prefixes (e.g. `LNA_temp_target`, `LOA
 
 ### Potentiometer Wiring (APP_POTMON)
 
-Two potentiometers for position feedback, read via the RP2350 ADC:
+Azimuth potentiometer for position feedback, read via the RP2350 ADC:
 
 | Channel | GPIO | ADC Channel | JSON Key |
 |---------|------|-------------|----------|
-| **EL** (elevation) | 26 | 0 | `pot_el_voltage` |
 | **AZ** (azimuth) | 27 | 1 | `pot_az_voltage` |
 
 ### IMU Wiring (APP_IMU_EL / APP_IMU_AZ)

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -47,7 +47,7 @@ def redis_handler(writer):
     parameters, etc. — must be flattened into per-component scalar
     fields with descriptive suffixes (e.g. ``quat_i/j/k/real`` for a
     quaternion, ``accel_x/y/z`` for an acceleration vector,
-    ``pot_el_cal_slope`` / ``pot_el_cal_intercept`` for a linear
+    ``pot_az_cal_slope`` / ``pot_az_cal_intercept`` for a linear
     calibration). This invariant lets downstream consumers validate
     every field with a per-key schema, lands the data cleanly in HDF5
     attribute storage, and gives every field a meaningful per-type
@@ -882,7 +882,7 @@ class PicoPotentiometer(PicoDevice):
         usb_serial : str, optional
             USB serial number for port re-discovery.
         """
-        self._cal = {"pot_el": None, "pot_az": None}
+        self._cal = {"pot_az": None}
         super().__init__(
             port,
             timeout=timeout,
@@ -897,8 +897,6 @@ class PicoPotentiometer(PicoDevice):
         if pot_cal_store is not None:
             cal_from_redis = pot_cal_store.get()
         if cal_from_redis is not None:
-            if "pot_el" in cal_from_redis:
-                self._cal["pot_el"] = tuple(cal_from_redis["pot_el"])
             if "pot_az" in cal_from_redis:
                 self._cal["pot_az"] = tuple(cal_from_redis["pot_az"])
         elif calibration_file is not None:
@@ -919,7 +917,7 @@ class PicoPotentiometer(PicoDevice):
         calibration state.
         """
         data = data.copy()
-        for key in ("pot_el", "pot_az"):
+        for key in ("pot_az",):
             cal = self._cal[key]
             v = data.get(f"{key}_voltage")
             if cal is not None:
@@ -936,59 +934,51 @@ class PicoPotentiometer(PicoDevice):
                 data[f"{key}_angle"] = None
         self._base_redis_handler(data)
 
-    def set_calibration(self, pot_el_params=None, pot_az_params=None):
-        """Set calibration parameters (m, b) for one or both pots.
+    def set_calibration(self, pot_az_params=None):
+        """Set calibration parameters (m, b) for the az pot.
 
         Parameters
         ----------
-        pot_el_params : tuple of (float, float), optional
-            (slope, intercept) such that angle = m * voltage + b.
         pot_az_params : tuple of (float, float), optional
+            (slope, intercept) such that angle = m * voltage + b.
         """
-        if pot_el_params is not None:
-            self._cal["pot_el"] = tuple(pot_el_params)
         if pot_az_params is not None:
             self._cal["pot_az"] = tuple(pot_az_params)
 
     def load_calibration(self, path):
         """Load calibration from a JSON file.
 
-        Expected format: ``{"pot_el": [m, b], "pot_az": [m, b], ...}``
+        Expected format: ``{"pot_az": [m, b], ...}``
         """
         with open(path, "r") as f:
             cal_data = json.load(f)
-        if "pot_el" in cal_data:
-            self._cal["pot_el"] = tuple(cal_data["pot_el"])
         if "pot_az" in cal_data:
             self._cal["pot_az"] = tuple(cal_data["pot_az"])
 
     @property
     def is_calibrated(self):
-        """True if both pots have calibration parameters."""
-        return (
-            self._cal["pot_el"] is not None and self._cal["pot_az"] is not None
-        )
+        """True if the az pot has calibration parameters."""
+        return self._cal["pot_az"] is not None
 
     def read_voltage(self):
-        """Return the latest voltage readings.
+        """Return the latest az voltage reading.
 
         Returns
         -------
         dict
-            ``{"pot_el_voltage": float, "pot_az_voltage": float}``
+            ``{"pot_az_voltage": float}``
         """
         return {
-            "pot_el_voltage": self.last_status.get("pot_el_voltage"),
             "pot_az_voltage": self.last_status.get("pot_az_voltage"),
         }
 
     def read_angle(self):
-        """Convert current voltage readings to angles using calibration.
+        """Convert current az voltage reading to angle using calibration.
 
         Returns
         -------
         dict
-            ``{"pot_el": float, "pot_az": float}`` in degrees.
+            ``{"pot_az": float}`` in degrees.
 
         Raises
         ------
@@ -996,7 +986,7 @@ class PicoPotentiometer(PicoDevice):
             If calibration has not been set or voltage data is missing.
         """
         result = {}
-        for key in ("pot_el", "pot_az"):
+        for key in ("pot_az",):
             v = self.last_status.get(f"{key}_voltage")
             if v is None:
                 raise RuntimeError(f"No voltage reading for {key}")

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -121,7 +121,7 @@ class PotCalStore:
     Persistent single-key store for potentiometer calibration.
 
     The value under :data:`POT_CAL_KEY` is a JSON object shaped like
-    ``{"pot_el": [m, b], "pot_az": [m, b], "metadata": {...},
+    ``{"pot_az": [m, b], "metadata": {...},
     "upload_time": ...}`` — the canonical ``upload_time`` field is
     injected by :meth:`Transport.upload_dict` at the top level.
     ``metadata`` carries audit fields written by ``calibrate-pot``
@@ -144,7 +144,7 @@ class PotCalStore:
         Parameters
         ----------
         cal : dict
-            Must carry ``pot_el`` and ``pot_az`` entries, each a
+            Must carry a ``pot_az`` entry, a
             ``(slope, intercept)`` pair (list or tuple). Extra
             fields (e.g. ``metadata``) are preserved verbatim.
         """

--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -59,10 +59,10 @@ def collect_samples(transport, n):
     repeated calls within one calibration sweep don't double-count the
     same firmware tick.
     """
-    samples_el, samples_az = [], []
+    samples_az = []
     last_id = "$"
-    while len(samples_el) < n:
-        remaining = n - len(samples_el)
+    while len(samples_az) < n:
+        remaining = n - len(samples_az)
         resp = transport.r.xread(
             {POTMON_STREAM: last_id},
             block=int(SAMPLE_TIMEOUT_S * 1000),
@@ -76,10 +76,9 @@ def collect_samples(transport, n):
         _stream, messages = resp[0]
         for msg_id, fields in messages:
             value = json.loads(fields[b"value"])
-            samples_el.append(value["pot_el_voltage"])
             samples_az.append(value["pot_az_voltage"])
             last_id = msg_id
-    return float(np.mean(samples_el)), float(np.mean(samples_az))
+    return float(np.mean(samples_az))
 
 
 def compute_linear_fit(voltages, angles):
@@ -100,22 +99,19 @@ def compute_linear_fit(voltages, angles):
 
 def collect_minmax(transport, n_samples, total_degrees):
     """Collect at min and max only (2-point calibration)."""
-    input("\nSet both potentiometers to MINIMUM position, then press Enter.")
+    input("\nSet the az potentiometer to MINIMUM position, then press Enter.")
     print("  averaging samples...")
-    v_min_0, v_min_1 = collect_samples(transport, n_samples)
-    print(f"  pot_el min voltage: {v_min_0:.4f} V")
-    print(f"  pot_az min voltage: {v_min_1:.4f} V")
+    v_min = collect_samples(transport, n_samples)
+    print(f"  pot_az min voltage: {v_min:.4f} V")
 
-    input("\nSet both potentiometers to MAXIMUM position, then press Enter.")
+    input("\nSet the az potentiometer to MAXIMUM position, then press Enter.")
     print("  averaging samples...")
-    v_max_0, v_max_1 = collect_samples(transport, n_samples)
-    print(f"  pot_el max voltage: {v_max_0:.4f} V")
-    print(f"  pot_az max voltage: {v_max_1:.4f} V")
+    v_max = collect_samples(transport, n_samples)
+    print(f"  pot_az max voltage: {v_max:.4f} V")
 
-    voltages_0 = [v_min_0, v_max_0]
-    voltages_1 = [v_min_1, v_max_1]
+    voltages = [v_min, v_max]
     angles = [0.0, total_degrees]
-    return voltages_0, voltages_1, angles
+    return voltages, angles
 
 
 def _per_turn_stops(turns):
@@ -134,32 +130,30 @@ def _per_turn_stops(turns):
 def collect_per_turn(transport, n_samples, turns):
     """Collect at every full turn from min to max (plus a fractional final)."""
     input(
-        "\nSet both potentiometers to MINIMUM position (turn 0), "
+        "\nSet the az potentiometer to MINIMUM position (turn 0), "
         "then press Enter."
     )
     print("  averaging samples...")
-    v0, v1 = collect_samples(transport, n_samples)
-    print(f"  turn  0.00: pot_el={v0:.4f} V, pot_az={v1:.4f} V")
-    voltages_0 = [v0]
-    voltages_1 = [v1]
+    v = collect_samples(transport, n_samples)
+    print(f"  turn  0.00: pot_az={v:.4f} V")
+    voltages = [v]
     angles = [0.0]
 
     prev = 0.0
     for stop in _per_turn_stops(turns):
         delta = stop - prev
         input(
-            f"\nAdvance both pots {delta:.2f} turn(s) (to turn {stop:.2f}), "
+            f"\nAdvance the az pot {delta:.2f} turn(s) (to turn {stop:.2f}), "
             "then press Enter."
         )
         print("  averaging samples...")
-        v0, v1 = collect_samples(transport, n_samples)
-        print(f"  turn {stop:5.2f}: pot_el={v0:.4f} V, pot_az={v1:.4f} V")
-        voltages_0.append(v0)
-        voltages_1.append(v1)
+        v = collect_samples(transport, n_samples)
+        print(f"  turn {stop:5.2f}: pot_az={v:.4f} V")
+        voltages.append(v)
         angles.append(stop * 360.0)
         prev = stop
 
-    return voltages_0, voltages_1, angles
+    return voltages, angles
 
 
 def main():
@@ -241,35 +235,32 @@ def main():
 
     try:
         if args.mode == "minmax":
-            voltages_0, voltages_1, angles = collect_minmax(
+            voltages, angles = collect_minmax(
                 transport, args.n_samples, total_degrees
             )
         else:
-            voltages_0, voltages_1, angles = collect_per_turn(
+            voltages, angles = collect_per_turn(
                 transport, args.n_samples, args.turns
             )
     except (RuntimeError, ConnectionError) as exc:
         print(f"Calibration sample collection failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    cal0 = compute_linear_fit(voltages_0, angles)
-    cal1 = compute_linear_fit(voltages_1, angles)
+    cal = compute_linear_fit(voltages, angles)
 
-    if cal0 is None or cal1 is None:
+    if cal is None:
         print("\nCalibration failed. Exiting.", file=sys.stderr)
         sys.exit(1)
 
     cal_data = {
-        "pot_el": list(cal0),
-        "pot_az": list(cal1),
+        "pot_az": list(cal),
         "metadata": {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "turns": float(args.turns),
             "total_degrees": total_degrees,
             "mode": args.mode,
             "n_points": len(angles),
-            "pot_el_voltages": [float(v) for v in voltages_0],
-            "pot_az_voltages": [float(v) for v in voltages_1],
+            "pot_az_voltages": [float(v) for v in voltages],
             "angles": [float(a) for a in angles],
             "n_samples": args.n_samples,
         },
@@ -293,8 +284,7 @@ def main():
     try:
         pot_proxy.send_command(
             "set_calibration",
-            pot_el_params=list(cal0),
-            pot_az_params=list(cal1),
+            pot_az_params=list(cal),
         )
         print("Live PicoPotentiometer updated with new calibration.")
     except (TimeoutError, RuntimeError) as e:
@@ -304,8 +294,7 @@ def main():
             file=sys.stderr,
         )
 
-    print(f"  pot_el: angle = {cal0[0]:.4f} * V + {cal0[1]:.4f}")
-    print(f"  pot_az: angle = {cal1[0]:.4f} * V + {cal1[1]:.4f}")
+    print(f"  pot_az: angle = {cal[0]:.4f} * V + {cal[1]:.4f}")
     if args.mode == "turns":
         print(f"  ({len(angles)} points used for least-squares fit)")
 

--- a/picohost/src/picohost/emulators/potmon.py
+++ b/picohost/src/picohost/emulators/potmon.py
@@ -10,27 +10,17 @@ class PotMonEmulator(PicoEmulator):
     """Emulates src/potmon.c firmware."""
 
     def __init__(self, app_id=2, **kwargs):
-        self._base_voltage_el = 1.5  # midrange default
         self._base_voltage_az = 1.5
-        self.voltage_el = self._base_voltage_el
         self.voltage_az = self._base_voltage_az
         super().__init__(app_id=app_id, **kwargs)
 
     def init(self):
-        self.voltage_el = self._base_voltage_el
         self.voltage_az = self._base_voltage_az
 
     def server(self, cmd):
         pass  # potmon does not handle commands
 
     def op(self):
-        self.voltage_el = float(
-            np.clip(
-                self._base_voltage_el + np.random.normal(0, NOISE_STDDEV),
-                0.0,
-                VREF,
-            )
-        )
         self.voltage_az = float(
             np.clip(
                 self._base_voltage_az + np.random.normal(0, NOISE_STDDEV),
@@ -44,6 +34,5 @@ class PotMonEmulator(PicoEmulator):
             "sensor_name": "potmon",
             "app_id": self.app_id,
             "status": "update",
-            "pot_el_voltage": self.voltage_el,
             "pot_az_voltage": self.voltage_az,
         }

--- a/picohost/tests/test_potentiometer.py
+++ b/picohost/tests/test_potentiometer.py
@@ -28,17 +28,14 @@ class TestPicoPotentiometer:
         """Potentiometer status should contain voltage fields from emulator."""
         pot = _make_pot()
         assert pot.last_status.get("sensor_name") == "potmon"
-        assert "pot_el_voltage" in pot.last_status
         assert "pot_az_voltage" in pot.last_status
         pot.disconnect()
 
     def test_read_voltage(self):
-        """read_voltage() returns dict with both voltage readings."""
+        """read_voltage() returns dict with az voltage reading."""
         pot = _make_pot()
         volts = pot.read_voltage()
-        assert "pot_el_voltage" in volts
         assert "pot_az_voltage" in volts
-        assert 0.0 <= volts["pot_el_voltage"] <= 3.3
         assert 0.0 <= volts["pot_az_voltage"] <= 3.3
         pot.disconnect()
 
@@ -50,26 +47,19 @@ class TestPicoPotentiometer:
         pot.disconnect()
 
     def test_set_calibration_and_read_angle(self):
-        """After set_calibration(), read_angle() returns computed angles."""
+        """After set_calibration(), read_angle() returns computed angle."""
         pot = _make_pot()
-        pot.set_calibration(
-            pot_el_params=(1000.0, 0.0),
-            pot_az_params=(1000.0, 0.0),
-        )
+        pot.set_calibration(pot_az_params=(1000.0, 0.0))
         angles = pot.read_angle()
-        assert "pot_el" in angles
         assert "pot_az" in angles
         # Emulator base voltage is ~1.5V, so angle should be ~1500
-        assert 1000.0 < angles["pot_el"] < 2000.0
         assert 1000.0 < angles["pot_az"] < 2000.0
         pot.disconnect()
 
     def test_is_calibrated_property(self):
-        """is_calibrated reflects whether both pots have parameters."""
+        """is_calibrated reflects whether the az pot has parameters."""
         pot = _make_pot()
         assert pot.is_calibrated is False
-        pot.set_calibration(pot_el_params=(1.0, 0.0))
-        assert pot.is_calibrated is False  # only pot_el set
         pot.set_calibration(pot_az_params=(1.0, 0.0))
         assert pot.is_calibrated is True
         pot.disconnect()
@@ -77,7 +67,7 @@ class TestPicoPotentiometer:
     def test_load_calibration_from_file(self):
         """load_calibration() reads (m, b) from a JSON file."""
         pot = _make_pot()
-        cal_data = {"pot_el": [100.0, -50.0], "pot_az": [200.0, -100.0]}
+        cal_data = {"pot_az": [200.0, -100.0]}
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".json", delete=False
         ) as f:
@@ -85,7 +75,6 @@ class TestPicoPotentiometer:
             f.flush()
             pot.load_calibration(f.name)
         assert pot.is_calibrated is True
-        assert pot._cal["pot_el"] == (100.0, -50.0)
         assert pot._cal["pot_az"] == (200.0, -100.0)
         pot.disconnect()
 
@@ -93,10 +82,10 @@ class TestPicoPotentiometer:
         """Verify angle = m * voltage + b."""
         pot = _make_pot()
         m, b = 1000.0, -500.0
-        pot.set_calibration(pot_el_params=(m, b), pot_az_params=(m, b))
-        v = pot.last_status["pot_el_voltage"]
+        pot.set_calibration(pot_az_params=(m, b))
+        v = pot.last_status["pot_az_voltage"]
         angles = pot.read_angle()
-        assert angles["pot_el"] == pytest.approx(m * v + b, abs=0.01)
+        assert angles["pot_az"] == pytest.approx(m * v + b, abs=0.01)
         pot.disconnect()
 
 
@@ -126,35 +115,23 @@ class TestPotRedisHandler:
         """Uncalibrated pot publishes voltage + None for cal/angle."""
         pot = _make_pot()
         published = self._capture(pot)
-        for key in ("pot_el", "pot_az"):
-            assert isinstance(published[f"{key}_voltage"], float)
-            assert published[f"{key}_cal_slope"] is None
-            assert published[f"{key}_cal_intercept"] is None
-            assert published[f"{key}_angle"] is None
+        assert isinstance(published["pot_az_voltage"], float)
+        assert published["pot_az_cal_slope"] is None
+        assert published["pot_az_cal_intercept"] is None
+        assert published["pot_az_angle"] is None
         pot.disconnect()
 
     def test_calibrated_publishes_scalar_slope_intercept_angle(self):
         """After set_calibration, slope/intercept/angle are floats."""
         pot = _make_pot()
-        pot.set_calibration(
-            pot_el_params=(100.0, -50.0),
-            pot_az_params=(200.0, -100.0),
-        )
+        pot.set_calibration(pot_az_params=(200.0, -100.0))
         published = self._capture(pot)
-        assert published["pot_el_cal_slope"] == 100.0
-        assert published["pot_el_cal_intercept"] == -50.0
         assert published["pot_az_cal_slope"] == 200.0
         assert published["pot_az_cal_intercept"] == -100.0
-        for key in ("pot_el", "pot_az"):
-            assert isinstance(published[f"{key}_cal_slope"], float)
-            assert isinstance(published[f"{key}_cal_intercept"], float)
-            assert isinstance(published[f"{key}_angle"], float)
-        # angle = m * v + b for each pot
-        v_el = published["pot_el_voltage"]
+        assert isinstance(published["pot_az_cal_slope"], float)
+        assert isinstance(published["pot_az_cal_intercept"], float)
+        assert isinstance(published["pot_az_angle"], float)
         v_az = published["pot_az_voltage"]
-        assert published["pot_el_angle"] == pytest.approx(
-            100.0 * v_el - 50.0, abs=1e-6
-        )
         assert published["pot_az_angle"] == pytest.approx(
             200.0 * v_az - 100.0, abs=1e-6
         )
@@ -168,9 +145,9 @@ class TestPotRedisHandler:
         Both calibrated and uncalibrated states are checked.
         """
         pot = _make_pot()
-        for cal in (None, ((100.0, -50.0), (200.0, -100.0))):
+        for cal in (None, (200.0, -100.0)):
             if cal is not None:
-                pot.set_calibration(pot_el_params=cal[0], pot_az_params=cal[1])
+                pot.set_calibration(pot_az_params=cal)
             published = self._capture(pot)
             for k, v in published.items():
                 assert isinstance(v, self._SCALAR_TYPES), (
@@ -182,14 +159,11 @@ class TestPotRedisHandler:
         """Field set is identical whether calibrated or not."""
         pot = _make_pot()
         before = set(self._capture(pot))
-        pot.set_calibration(pot_el_params=(1.0, 0.0), pot_az_params=(1.0, 0.0))
+        pot.set_calibration(pot_az_params=(1.0, 0.0))
         after = set(self._capture(pot))
         assert before == after
         # And specifically the new flat field names are present
         expected_added = {
-            "pot_el_cal_slope",
-            "pot_el_cal_intercept",
-            "pot_el_angle",
             "pot_az_cal_slope",
             "pot_az_cal_intercept",
             "pot_az_angle",
@@ -203,7 +177,6 @@ class TestPotCalStore:
 
     def _cal_payload(self):
         return {
-            "pot_el": [100.0, -50.0],
             "pot_az": [200.0, -100.0],
             "metadata": {"port": "/dev/ttyACM0", "turns": 10},
         }
@@ -218,7 +191,6 @@ class TestPotCalStore:
         payload = self._cal_payload()
         store.upload(payload)
         loaded = store.get()
-        assert loaded["pot_el"] == payload["pot_el"]
         assert loaded["pot_az"] == payload["pot_az"]
         assert loaded["metadata"] == payload["metadata"]
         # Transport.upload_dict injects an upload_time field on every write.
@@ -250,7 +222,6 @@ class TestPicoPotentiometerCalSource:
 
     def _redis_cal(self):
         return {
-            "pot_el": [100.0, -50.0],
             "pot_az": [200.0, -100.0],
         }
 
@@ -265,7 +236,7 @@ class TestPicoPotentiometerCalSource:
         transport = DummyTransport()
         store = PotCalStore(transport)
         store.upload(self._redis_cal())
-        file_cal = {"pot_el": [1.0, 2.0], "pot_az": [3.0, 4.0]}
+        file_cal = {"pot_az": [3.0, 4.0]}
         pot = DummyPicoPotentiometer(
             "/dev/dummy",
             calibration_file=self._json_cal_file(tmp_path, file_cal),
@@ -273,7 +244,6 @@ class TestPicoPotentiometerCalSource:
         )
         try:
             assert pot.is_calibrated
-            assert pot._cal["pot_el"] == (100.0, -50.0)
             assert pot._cal["pot_az"] == (200.0, -100.0)
         finally:
             pot.disconnect()
@@ -281,7 +251,7 @@ class TestPicoPotentiometerCalSource:
     def test_json_fallback_when_redis_empty(self, tmp_path):
         """Redis miss + JSON present → JSON cal is applied."""
         store = PotCalStore(DummyTransport())
-        file_cal = {"pot_el": [1.0, 2.0], "pot_az": [3.0, 4.0]}
+        file_cal = {"pot_az": [3.0, 4.0]}
         pot = DummyPicoPotentiometer(
             "/dev/dummy",
             calibration_file=self._json_cal_file(tmp_path, file_cal),
@@ -289,7 +259,6 @@ class TestPicoPotentiometerCalSource:
         )
         try:
             assert pot.is_calibrated
-            assert pot._cal["pot_el"] == (1.0, 2.0)
             assert pot._cal["pot_az"] == (3.0, 4.0)
         finally:
             pot.disconnect()
@@ -299,7 +268,7 @@ class TestPicoPotentiometerCalSource:
         pot = DummyPicoPotentiometer("/dev/dummy")
         try:
             assert pot.is_calibrated is False
-            assert pot._cal == {"pot_el": None, "pot_az": None}
+            assert pot._cal == {"pot_az": None}
         finally:
             pot.disconnect()
 
@@ -307,7 +276,7 @@ class TestPicoPotentiometerCalSource:
         """Garbage in Redis → PotCalStore.get returns None → JSON wins."""
         transport = DummyTransport()
         transport.r.set(POT_CAL_KEY, b"not-json-{")
-        file_cal = {"pot_el": [1.0, 2.0], "pot_az": [3.0, 4.0]}
+        file_cal = {"pot_az": [3.0, 4.0]}
         pot = DummyPicoPotentiometer(
             "/dev/dummy",
             calibration_file=self._json_cal_file(tmp_path, file_cal),
@@ -315,7 +284,6 @@ class TestPicoPotentiometerCalSource:
         )
         try:
             assert pot.is_calibrated
-            assert pot._cal["pot_el"] == (1.0, 2.0)
             assert pot._cal["pot_az"] == (3.0, 4.0)
         finally:
             pot.disconnect()

--- a/src/potmon.c
+++ b/src/potmon.c
@@ -4,7 +4,6 @@
 #include "cJSON.h"
 #include <math.h>
 
-static PotSensor pot_el;
 static PotSensor pot_az;
 
 /*helper func to init one pot sensor*/
@@ -20,10 +19,6 @@ static void pot_sensor_init(PotSensor *pot, uint gpio_pin, uint adc_channel)
 static void pot_sensor_read(PotSensor *pot)
 {
     adc_select_input(pot->adc_channel);
-    /* Discard one sample to let the shared S/H cap settle after the
-       mux switch — otherwise a low-impedance neighbour channel bleeds
-       into a high-impedance/floating one (e.g. an unconnected pot). */
-    (void)adc_read();
     uint16_t raw = adc_read();
     pot->voltage = ((float)raw / (float)POTMON_ADC_MAX) * POTMON_VREF;
 }
@@ -33,30 +28,25 @@ static void pot_sensor_read(PotSensor *pot)
 void potmon_init(uint8_t app_id)
 {
     adc_init();
-    pot_sensor_init(&pot_el, POTMON_GPIO0, POTMON_ADC_CH0);
-    pot_sensor_init(&pot_az, POTMON_GPIO1, POTMON_ADC_CH1);
+    pot_sensor_init(&pot_az, POTMON_GPIO_AZ, POTMON_ADC_CH_AZ);
 }
 
 void potmon_server(uint8_t app_id, const char *json_str)
 {
     //potmon does not handle json commands
 }
-/*read both ADC channels on every loop iteration*/
 void potmon_op(uint8_t app_id)
 {
-    pot_sensor_read(&pot_el);
     pot_sensor_read(&pot_az);
 }
 
-/*send status json with voltage, resistance, r_ref, and valid status*/
 void potmon_status(uint8_t app_id)
 {
-    send_json(5,
-        KV_STR,   "sensor_name",     "potmon",
-        KV_INT,   "app_id",          (int)app_id,
-        KV_STR,   "status",          "update",
-        KV_FLOAT, "pot_el_voltage",  pot_el.voltage,
-        KV_FLOAT, "pot_az_voltage",  pot_az.voltage
+    send_json(4,
+        KV_STR,   "sensor_name",    "potmon",
+        KV_INT,   "app_id",         (int)app_id,
+        KV_STR,   "status",         "update",
+        KV_FLOAT, "pot_az_voltage", pot_az.voltage
     );
 }
 

--- a/src/potmon.h
+++ b/src/potmon.h
@@ -6,11 +6,9 @@
 #include "hardware/adc.h"
 #include "eigsep_command.h"
 
-#define POTMON_ADC_CH0          0
-#define POTMON_ADC_CH1          1
+#define POTMON_ADC_CH_AZ        1
 
-#define POTMON_GPIO0            26
-#define POTMON_GPIO1            27
+#define POTMON_GPIO_AZ          27
 
 #define POTMON_ADC_BITS         12
 #define POTMON_ADC_MAX          ((1 << POTMON_ADC_BITS) - 1)


### PR DESCRIPTION
## Summary

- El pot is not connected in field deployments; a floating ADC input on the RP2350's shared sample-and-hold mux bleeds charge from the previous (az) channel, causing `pot_el_voltage` to track `pot_az_voltage` even with the existing discard-sample workaround
- Reading only az eliminates the mux switch entirely — the S/H cap stays on channel 1 permanently, making az clean with no hardware change required
- Removes all `pot_el` references from firmware, emulator, `PicoPotentiometer`, `calibrate-pot`, and tests; renames `POTMON_ADC_CH0/GPIO0` → `POTMON_ADC_CH_AZ/GPIO_AZ`

## Test plan

- [x] `pytest picohost/tests/test_potentiometer.py` — 19/19 passing
- [x] Full suite `pytest` — 507 passed, 0 failures
- [ ] Flash to a Pico and confirm `pot_az_voltage` streams cleanly; confirm `pot_el_voltage` is absent from serial output
- [ ] Run `calibrate-pot` to verify az-only calibration flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)