### PR TITLE
feat: reliable USB flash via firmware bootsel command; make USB the d…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,15 +36,18 @@ The build produces `build/pico_multi.uf2` which can be flashed to the Pico by co
 ### Flashing and Development Commands
 
 ```bash
-# Flash all Picos at once (GPIO mass-BOOTSEL — default on the hub;
-# requires the bussed BOOTSEL/RUN wiring and the `pinctrl` CLI that
-# ships with Raspberry Pi OS)
+# Flash all Picos at once (DEFAULT: USB per-device path — triggers
+# BOOTSEL via the firmware {"cmd":"bootsel"} command, falling back to
+# picotool reboot; no GPIO wiring needed). --expected defaults to 7
+# (the fleet size) and prints a loud warning, not a failure, if fewer
+# report.
 flash-picos --uf2 build/pico_multi.uf2
 
-# Hosts without the GPIO wiring: per-device USB reboot path
-flash-picos --uf2 build/pico_multi.uf2 --no-gpio
+# Opt into the GPIO mass-BOOTSEL flow (requires the bussed BOOTSEL/RUN
+# wiring and the `pinctrl` CLI that ships with Raspberry Pi OS)
+flash-picos --uf2 build/pico_multi.uf2 --gpio
 
-# Target a single Pico (automatically uses the USB path)
+# Target a single Pico (always uses the USB path; --expected is ignored)
 flash-picos --uf2 build/pico_multi.uf2 --usb-serial <ID>
 
 # Flash with custom parameters
@@ -193,8 +196,8 @@ with MotorDevice() as motor:
 ### flash-picos
 
 CLI tool (installed as `flash-picos` entry point from picohost package) for flashing and configuring multiple Picos. Two flash paths:
-- **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. The lines are driven through the `pinctrl` CLI (`pinctrl set 17/18 op dh|dl`), so there is no GPIO library or pin-factory backend to install. One GPIO sequence (`17 dh → 18 dh → 17 dl → 18 dl`, i.e. reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then one mass reset boots everything. Fails fast with a pointer to `--no-gpio` if `pinctrl` is not on PATH
-- **USB per-device (`--no-gpio`, or automatic with `--port`/`--usb-serial`)**: reboots each CDC Pico into BOOTSEL via `picotool reboot --bus/--address`, then loads — for hosts without the GPIO wiring
+- **USB per-device (DEFAULT; also automatic with `--port`/`--usb-serial`)**: triggers BOOTSEL **primarily via the firmware's universal `{"cmd":"bootsel"}` CDC command** (handled in `main.c` before app dispatch → `reset_usb_boot()` from the main loop), and **falls back to `picotool reboot -f --bus/--address`**. The firmware command is the reliable trigger because picotool's own USB reset (the SDK vendor reset interface) is unreliable on long-running boards on the deep hub — it ACKs the request but the board never actually resets; the same board honors it again right after a fresh boot, so it's an uptime degradation, not dead hardware. A board on older firmware ignores the command and the picotool fallback handles it. This default needs no GPIO wiring and avoids the flaky BOOTSEL/CS seat entirely. Also: settles the CDC device set before flashing (no single-snapshot misses), recovers boards already stranded in BOOTSEL from a prior aborted run, emits a per-serial reconciliation report naming any board that flashed but didn't report (and why), and `--expected N` (default 7 = the fleet size, bypassed when targeting one board) prints a loud **warning** — not a failure — when fewer than N report
+- **GPIO mass-BOOTSEL (opt in with `--gpio`)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. The lines are driven through the `pinctrl` CLI (`pinctrl set 17/18 op dh|dl`), so there is no GPIO library or pin-factory backend to install. One GPIO sequence (`17 dh → 18 dh → 17 dl → 18 dl`, i.e. reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware, including boards on old firmware that lacks the bootsel command), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then one mass reset boots everything. Fails fast with a pointer to drop `--gpio` if `pinctrl` is not on PATH. This is the bootstrap path to get the bootsel-command firmware onto boards the first time
 - `picotool` targets devices by USB bus/address resolved from sysfs (never `--ser`, whose descriptor read corrupts under hub contention)
 - Stops an active `picomanager.service` before flashing and restarts it afterwards — the manager owns every Pico's CDC port (no exclusive open on either side), so a live manager races the post-flash readback. Restart happens **only if flash-picos itself stopped the unit**, so `eigsep-field patch pico-firmware` (which stops/starts the unit around its own flash-picos call and inserts an ExecStart drop-in in between) is unaffected. `--keep-manager` opts out; unprivileged runs fall back to `sudo -n systemctl`, and an active manager that cannot be stopped aborts the flash with a pointer to `--keep-manager`
 - Reads JSON device info from each Pico after flashing and publishes the device list to Redis (optionally `--output-file`)

--- a/picohost/src/picohost/_serial_writer.py
+++ b/picohost/src/picohost/_serial_writer.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Standalone serial-write helper, run as a *child process* by flash_picos.
+
+Sends a single newline-terminated line to a Pico's CDC port — the
+``{"cmd":"bootsel"}`` reflash trigger — and exits. Run as a child process,
+by file path, for the same reason as :mod:`_serial_reader`: opening or
+closing a marginal (or about-to-reboot) CDC port can wedge in the kernel's
+``cdc_acm`` teardown, and a wedge must pin an *abandonable* child, never
+flash-picos itself.
+
+The write is fire-and-forget: the caller confirms the reboot by watching
+sysfs for the board re-appearing in BOOTSEL (``2e8a:000f``), not by this
+child's exit code. So the child only has to deliver the bytes without
+hanging the parent.
+
+Kept dependency-light (stdlib + pyserial) and launched by path so running
+it does not import the ``picohost`` package (and its heavy deps).
+"""
+
+import sys
+
+from serial import Serial
+
+
+def run(port, baud, line):
+    """Open *port*, write *line* (a ``\\n`` is appended), flush, close.
+
+    Returns ``0`` on a delivered write, ``1`` if the port could not be
+    opened or the write failed. The newline terminator is added here so
+    callers pass the bare command.
+    """
+    try:
+        ser = Serial(port, baudrate=baud, timeout=1)
+    except Exception:  # open failed (EACCES/EBUSY/ENOENT/-110/...)
+        return 1
+    try:
+        ser.write((line + "\n").encode("utf-8"))
+        ser.flush()
+        return 0
+    except Exception:
+        return 1
+    finally:
+        try:
+            ser.close()
+        except Exception:
+            pass
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    port, baud, line = argv[0], int(argv[1]), argv[2]
+    return run(port, baud, line)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -232,6 +232,70 @@ def _picotool_load(bus, address, uf2_path, execute=True):
     )
 
 
+# The firmware exposes a universal {"cmd":"bootsel"} command that calls
+# reset_usb_boot() from its main loop. This is the no-gpio path's PRIMARY
+# BOOTSEL trigger: picotool's own USB reset (reboot -f / the vendor reset
+# interface) is unreliable on long-running boards on the observatory hub —
+# it ACKs the request but the board never resets — whereas the main-loop
+# reset_usb_boot reached over the (working) CDC data path is reliable. A
+# board running older firmware without the command silently ignores it, so
+# the caller falls back to picotool's reset.
+_SERIAL_WRITER_SCRIPT = str(Path(__file__).with_name("_serial_writer.py"))
+_BOOTSEL_COMMAND = '{"cmd":"bootsel"}'
+_SERIAL_WRITE_TIMEOUT_S = 5.0
+# After the CDC command the board re-enumerates in BOOTSEL quickly; keep
+# the wait short so a board on older firmware (which ignores the command)
+# falls through to the picotool reset without a long stall.
+_CDC_BOOTSEL_WAIT_S = 6.0
+
+
+def _send_serial_line(port, line, baud, timeout):
+    """Write *line* to *port* via the abandonable :mod:`_serial_writer` child.
+
+    Fire-and-forget: opening or closing a marginal / about-to-reboot CDC
+    port can wedge in the kernel, so the write runs in a child process
+    bounded by *timeout*; a wedged child is abandoned (its ``TimeoutExpired``
+    swallowed) rather than allowed to block flash-picos. Success is
+    confirmed by the caller watching sysfs for BOOTSEL, not here.
+    """
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                _SERIAL_WRITER_SCRIPT,
+                str(port),
+                str(baud),
+                line,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _enter_bootsel_via_cdc(usb_serial, baud=115200):
+    """Trigger BOOTSEL on *usb_serial* via the firmware CDC command.
+
+    Resolves the board's current CDC port, sends ``{"cmd":"bootsel"}``,
+    and waits for it to re-enumerate as a BOOTSEL device. Returns the
+    BOOTSEL ``(bus, address)`` on success, or ``(None, None)`` if the
+    board has no CDC port right now or never enters BOOTSEL (e.g. it runs
+    older firmware without the command) — the caller then falls back to
+    picotool's reset.
+    """
+    port = None
+    for dev, sn in find_pico_ports().items():
+        if sn == usb_serial:
+            port = dev
+            break
+    if port is None:
+        return (None, None)
+    _send_serial_line(port, _BOOTSEL_COMMAND, baud, _SERIAL_WRITE_TIMEOUT_S)
+    return _wait_for_bootsel(usb_serial, timeout=_CDC_BOOTSEL_WAIT_S)
+
+
 def flash_uf2(
     uf2_path,
     usb_serial,
@@ -271,30 +335,40 @@ def flash_uf2(
             logger.warning("%s (attempt %d/%d)", detail, attempt, attempts)
         else:
             if not in_bootsel:
-                rb = subprocess.run(
-                    [
-                        "picotool",
-                        "reboot",
-                        "-u",
-                        "-f",
-                        "--bus",
-                        str(bus),
-                        "--address",
-                        str(address),
-                    ],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    errors="replace",
-                )
-                bus, address = _wait_for_bootsel(usb_serial)
-                if bus is None:
-                    detail = (rb.stdout or "").strip() or (
-                        f"serial={usb_serial} did not reboot into BOOTSEL"
+                # PRIMARY: ask the firmware to enter BOOTSEL over CDC
+                # ({"cmd":"bootsel"} -> reset_usb_boot in its main loop).
+                # This is reliable on long-running boards where picotool's
+                # own USB reset is not. A board on older firmware ignores
+                # the command and this returns (None, None).
+                bb, ba = _enter_bootsel_via_cdc(usb_serial)
+                if bb is None:
+                    # FALLBACK: picotool's reset interface, targeting the
+                    # original CDC bus/address resolved above.
+                    rb = subprocess.run(
+                        [
+                            "picotool",
+                            "reboot",
+                            "-u",
+                            "-f",
+                            "--bus",
+                            str(bus),
+                            "--address",
+                            str(address),
+                        ],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        errors="replace",
                     )
-                    logger.warning(
-                        "%s (attempt %d/%d)", detail, attempt, attempts
-                    )
+                    bb, ba = _wait_for_bootsel(usb_serial)
+                    if bb is None:
+                        detail = (rb.stdout or "").strip() or (
+                            f"serial={usb_serial} did not reboot into BOOTSEL"
+                        )
+                        logger.warning(
+                            "%s (attempt %d/%d)", detail, attempt, attempts
+                        )
+                bus, address = bb, ba
             if bus is not None:
                 res = _picotool_load(bus, address, uf2_path, execute=True)
                 if res.returncode == 0:
@@ -730,12 +804,54 @@ def _log_readback_reconciliation(expected_serials, present_serials, outcomes):
         )
 
 
+_CDC_SET_TIMEOUT_S = 10.0
+_CDC_SET_STABLE_S = 1.5
+_CDC_SET_POLL_S = 0.3
+
+
+def _wait_for_stable_cdc_set(
+    timeout=_CDC_SET_TIMEOUT_S,
+    stable=_CDC_SET_STABLE_S,
+    poll=_CDC_SET_POLL_S,
+):
+    """Poll :func:`find_pico_ports` until the CDC device set stops changing.
+
+    The no-gpio path used a single ``find_pico_ports()`` snapshot to decide
+    which boards to flash; on the contended hub ``list_ports.comports()``
+    can intermittently omit a board that is present, which then never gets
+    flashed and is silently dropped. Waiting until the set of CDC *serials*
+    is non-empty and unchanged for *stable* seconds closes that window, the
+    same way :func:`_wait_for_stable_bootsel_set` does for the GPIO path.
+
+    Returns the settled ``{device: serial}`` map, or the last observation
+    if it never settles within *timeout* (possibly empty — the caller may
+    still have BOOTSEL boards to recover, or should warn).
+    """
+    deadline = time.monotonic() + timeout
+    last = {}
+    last_keys = None
+    stable_since = None
+    while time.monotonic() < deadline:
+        ports = find_pico_ports()
+        keys = frozenset(ports.values())
+        now = time.monotonic()
+        if keys != last_keys:
+            last_keys = keys
+            last = ports
+            stable_since = now
+        elif keys and now - stable_since >= stable:
+            return ports
+        time.sleep(poll)
+    return last
+
+
 def flash_and_discover(
     uf2_path="build/pico_multi.uf2",
     port=None,
     usb_serial=None,
     baud=115200,
     timeout=10,
+    expected=None,
 ):
     """
     Flash all attached Picos and read device config from each.
@@ -772,31 +888,93 @@ def flash_and_discover(
     if not uf2_path.is_file():
         raise FileNotFoundError(f"UF2 file not found: {uf2_path}")
 
-    ports = find_pico_ports()
+    targeting = bool(port or usb_serial)
+
+    # Settle the CDC device set (unless targeting a single board) so a
+    # board slow to enumerate on the contended hub is not silently dropped
+    # by a single snapshot and then never flashed.
+    ports = find_pico_ports() if targeting else _wait_for_stable_cdc_set()
     if port:
         ports = {k: v for k, v in ports.items() if k == port}
     if usb_serial:
         ports = {k: v for k, v in ports.items() if v == usb_serial}
 
-    if not ports:
-        logger.info("No Raspberry Pi Pico serial ports found")
+    # Recover boards already stranded in BOOTSEL from a prior aborted run.
+    # They are invisible to find_pico_ports (CDC only), so the old path
+    # could never pick them up. A --port value identifies a CDC tty, not a
+    # BOOTSEL device, so skip recovery when targeting by --port.
+    bootsel = [] if port else _find_bootsel_devices()
+    if usb_serial:
+        bootsel = [d for d in bootsel if d["usb_serial"] == usb_serial]
+    cdc_serials = set(ports.values())
+    bootsel = [
+        d
+        for d in bootsel
+        if d["usb_serial"] and d["usb_serial"] not in cdc_serials
+    ]
+
+    if not ports and not bootsel:
+        logger.info("No Raspberry Pi Pico devices found")
         return []
 
-    logger.info(f"Found Picos on: {ports}")
-    all_devices = []
+    logger.info(
+        "Found %d CDC Pico(s)%s",
+        len(ports),
+        f" and {len(bootsel)} stranded in BOOTSEL" if bootsel else "",
+    )
+    expected_serials = set(ports.values()) | {d["usb_serial"] for d in bootsel}
+    if expected is not None and len(expected_serials) < expected:
+        logger.warning(
+            "discovered %d Pico(s) but --expected %d: %d not visible as CDC "
+            "or BOOTSEL — check power/cable/DIP before trusting the result",
+            len(expected_serials),
+            expected,
+            expected - len(expected_serials),
+        )
 
-    for idx, (port_dev, port_serial) in enumerate(ports.items()):
-        if idx > 0:
+    all_devices = []
+    outcomes = {}
+    flashed_any = False
+
+    # Recover stranded BOOTSEL boards first: load and run directly (they
+    # are already in BOOTSEL, so no reboot trigger is needed).
+    for dev in bootsel:
+        serial = dev["usb_serial"]
+        logger.info(
+            "Recovering BOOTSEL Pico serial=%s (bus=%d address=%d)",
+            serial,
+            dev["bus"],
+            dev["address"],
+        )
+        flashed_any = True
+        if not _load_bootsel_device(dev, uf2_path, execute=True):
+            outcomes[serial] = "picotool load failed while in BOOTSEL"
+            continue
+        data = _read_device_info(serial, baud, timeout)
+        outcomes[serial] = (
+            None
+            if data is not None
+            else "flashed from BOOTSEL but device-info read failed"
+        )
+        if data is not None:
+            all_devices.append(data)
+            logger.info("Read device info from %s", data["port"])
+
+    # Flash the CDC boards.
+    for port_dev, port_serial in ports.items():
+        if flashed_any:
             # Let the bus quiet after the previous Pico's post-flash
             # re-enumeration before forcing the next one into BOOTSEL.
             # Back-to-back resets on a shared hub disturb siblings and
             # cause cascading "not found in BOOTSEL" failures.
             time.sleep(_INTER_DEVICE_SETTLE_S)
+        flashed_any = True
         logger.info(f"Flashing Pico on port: {port_dev}")
         try:
             flash_uf2(uf2_path, port_serial)
         except RuntimeError as e:
             logger.error(f"Flash failed on {port_dev}: {e}")
+            outcomes[port_serial] = f"flash failed: {e}"
             continue
 
         # picotool load reboots the Pico, which re-enumerates as a
@@ -804,9 +982,19 @@ def flash_and_discover(
         # the stable usb_serial (the kernel may assign a different
         # /dev/ttyACMn than it had pre-flash) and reads its JSON.
         data = _read_device_info(port_serial, baud, timeout)
+        outcomes[port_serial] = (
+            None if data is not None else "flashed but device-info read failed"
+        )
         if data is not None:
             all_devices.append(data)
             logger.info(f"Read device info from {data['port']}")
+
+    # Per-serial reconciliation: name every board that was flashed but did
+    # not report, and why — the "which board, which stage" detail the
+    # no-gpio path previously lacked (it only logged inline errors).
+    _log_readback_reconciliation(
+        expected_serials, set(find_pico_ports().values()), outcomes
+    )
 
     return all_devices
 
@@ -816,8 +1004,14 @@ def _load_bootsel_device(
     uf2_path,
     attempts=_FLASH_MAX_ATTEMPTS,
     backoff=_FLASH_RETRY_BACKOFF_S,
+    execute=False,
 ):
-    """Load *uf2_path* onto the BOOTSEL device *dev* (no execute).
+    """Load *uf2_path* onto the BOOTSEL device *dev*.
+
+    The GPIO mass-flash path uses *execute*=``False``: the device stays in
+    BOOTSEL until a single mass reset boots the whole fleet. The no-gpio
+    BOOTSEL-recovery path uses *execute*=``True`` so the lone recovered
+    board loads and runs immediately (no fleet reset follows).
 
     Plain ``picotool load`` does not re-enumerate the device, so the
     bus/address normally stay valid; between retries the address is
@@ -829,7 +1023,7 @@ def _load_bootsel_device(
     bus, address = dev["bus"], dev["address"]
     serial = dev["usb_serial"]
     for attempt in range(1, attempts + 1):
-        res = _picotool_load(bus, address, uf2_path, execute=False)
+        res = _picotool_load(bus, address, uf2_path, execute=execute)
         if res.returncode == 0:
             return True
         logger.warning(
@@ -1033,7 +1227,7 @@ def flash_and_discover_gpio(
     Raises ``FileNotFoundError`` for a missing UF2 and ``RuntimeError``
     when no Pico enters BOOTSEL (bad wiring, or no GPIO access).
     """
-    from . import gpio  # deferred so --no-gpio paths never import gpio
+    from . import gpio  # deferred so the USB default never imports gpio
 
     uf2_path = Path(uf2_path)
     if not uf2_path.is_file():
@@ -1046,7 +1240,7 @@ def flash_and_discover_gpio(
     if not bootsel_devices:
         raise RuntimeError(
             "no Picos entered BOOTSEL after the mass GPIO entry; check "
-            "the BOOTSEL/RUN wiring or re-run with --no-gpio"
+            "the BOOTSEL/RUN wiring or drop --gpio to use the USB default"
         )
     seen = {d["usb_serial"] for d in bootsel_devices}
     missing = sorted(set(snapshot.values()) - seen)
@@ -1233,12 +1427,27 @@ def main(argv=None):
         ),
     )
     p.add_argument(
-        "--no-gpio",
+        "--gpio",
         action="store_true",
         help=(
-            "Skip the GPIO mass-BOOTSEL flash flow and reboot each "
-            "Pico into BOOTSEL over USB instead. Required on hosts "
-            "without the bussed BOOTSEL/RUN wiring."
+            "Use the GPIO mass-BOOTSEL flash flow instead of the default "
+            "USB per-device path. Requires the bussed BOOTSEL/RUN wiring "
+            "and the `pinctrl` CLI on the Pi hub. The USB default triggers "
+            'BOOTSEL via the firmware {"cmd":"bootsel"} command (falling '
+            "back to picotool reboot), which avoids the bussed BOOTSEL/CS "
+            "wiring (and a flaky seat) entirely."
+        ),
+    )
+    p.add_argument(
+        "--expected",
+        type=int,
+        default=7,
+        help=(
+            "Number of Picos expected to flash and report (the fleet "
+            "size). If fewer report device info, flash-picos prints a loud "
+            "warning naming the shortfall (it does NOT fail the run — "
+            "whatever reported is still published). Ignored when targeting "
+            "a single board with --port/--usb-serial."
         ),
     )
     p.add_argument(
@@ -1262,22 +1471,25 @@ def main(argv=None):
     )
 
     targeting = bool(args.port or args.usb_serial)
-    use_gpio = not args.no_gpio and not targeting
-    if targeting and not args.no_gpio:
+    use_gpio = args.gpio and not targeting
+    # When targeting a single board, the GPIO mass reset cannot pick one
+    # out, so fall back to the USB per-device path.
+    effective_expected = None if targeting else args.expected
+    if targeting and args.gpio:
         logger.info(
             "--port/--usb-serial target a single Pico; using the USB "
             "per-device flash path (the GPIO mass reset cannot target "
             "one Pico)"
         )
     if use_gpio:
-        from . import gpio  # deferred so --no-gpio paths never import gpio
+        from . import gpio  # deferred so the USB default never imports gpio
 
         if not gpio.available():
             print(
                 "GPIO backend unavailable: the `pinctrl` CLI was not "
                 "found on PATH. Run on the Pi hub (pinctrl ships with "
-                "Raspberry Pi OS), or re-run with --no-gpio to use the "
-                "USB per-device flash path.",
+                "Raspberry Pi OS), or drop --gpio to use the USB "
+                "per-device flash path (the default).",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -1311,6 +1523,7 @@ def main(argv=None):
                     usb_serial=args.usb_serial,
                     baud=args.baud,
                     timeout=args.timeout,
+                    expected=effective_expected,
                 )
         except (FileNotFoundError, RuntimeError) as e:
             print(str(e), file=sys.stderr)
@@ -1342,6 +1555,24 @@ def main(argv=None):
             with open(args.output_file, "w") as f:
                 json.dump(all_devices, f, indent=2)
             print(f"Wrote {len(all_devices)} device(s) to {args.output_file}.")
+
+        # Loud (non-fatal) under-count warning: a board that flashed but
+        # never reported is already named in the per-serial reconciliation
+        # above; this is the one-line "you got fewer than the fleet"
+        # banner. It does NOT fail the run — whatever reported is already
+        # published — so an operator notices the shortfall without the
+        # exit blocking partial progress (or eigsep-field patch).
+        if (
+            effective_expected is not None
+            and len(all_devices) < effective_expected
+        ):
+            print(
+                f"WARNING: expected {effective_expected} Pico(s) but only "
+                f"{len(all_devices)} reported device info — see the "
+                f"per-serial reconciliation above for which boards dropped "
+                f"and why. Re-run flash-picos to retry the stragglers.",
+                file=sys.stderr,
+            )
     finally:
         # Restart ONLY if we stopped it: under `eigsep-field patch`
         # the unit is already stopped by the coordinator, which must

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -1009,6 +1009,15 @@ def flash_and_discover(
             all_devices.append(data)
             logger.info(f"Read device info from {data['port']}")
 
+    # Reconcile stragglers on the now-quiet bus: pass 1 gave up fast on any
+    # board lost to contention; re-read or reload them here before the report.
+    reported = {d["usb_serial"] for d in all_devices}
+    sweep_devices, sweep_outcomes = _reconcile_usb_stragglers(
+        expected_serials, reported, uf2_path, baud
+    )
+    all_devices.extend(sweep_devices)
+    outcomes.update(sweep_outcomes)
+
     # Per-serial reconciliation: name every board that was flashed but did
     # not report, and why — the "which board, which stage" detail the
     # no-gpio path previously lacked (it only logged inline errors).

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -753,7 +753,9 @@ def _read_fleet_cdc(expected, baud):
     devices = []
     outcomes = {}
     for port, serial in sorted(ports.items()):
-        data, reason = _read_cdc_outcome(port, serial, baud, _MUTE_REREAD_TIMEOUT_S)
+        data, reason = _read_cdc_outcome(
+            port, serial, baud, _MUTE_REREAD_TIMEOUT_S
+        )
         outcomes[serial] = reason
         if data is not None:
             devices.append(data)
@@ -1286,7 +1288,9 @@ def _reconcile_usb_stragglers(expected_serials, reported, uf2_path, baud):
             devices.append(data)
             outcomes[serial] = None
         else:
-            outcomes[serial] = "reloaded from BOOTSEL but device-info read failed"
+            outcomes[serial] = (
+                "reloaded from BOOTSEL but device-info read failed"
+            )
 
     return devices, outcomes
 

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -252,27 +252,36 @@ _CDC_BOOTSEL_WAIT_S = 6.0
 def _send_serial_line(port, line, baud, timeout):
     """Write *line* to *port* via the abandonable :mod:`_serial_writer` child.
 
-    Fire-and-forget: opening or closing a marginal / about-to-reboot CDC
-    port can wedge in the kernel, so the write runs in a child process
-    bounded by *timeout*; a wedged child is abandoned (its ``TimeoutExpired``
-    swallowed) rather than allowed to block flash-picos. Success is
-    confirmed by the caller watching sysfs for BOOTSEL, not here.
+    Fire-and-forget. The board enters BOOTSEL the instant the firmware reads
+    ``{"cmd":"bootsel"}`` (``reset_usb_boot`` runs from its main loop),
+    yanking its CDC interface off the bus *while the child is mid-close* — so
+    the child's ``ser.close()`` can land in the kernel's uninterruptible
+    cdc_acm teardown and never return. The child therefore runs under
+    :class:`~subprocess.Popen` with a BOUNDED ``wait`` and is **abandoned** on
+    timeout (killed, then bounded-waited, then left for init to reap) — never
+    a ``subprocess.run(timeout=...)``, whose POSIX path does an *unbounded*
+    ``process.wait()`` after the kill and so would pin flash-picos on exactly
+    that wedge (the "flash-picos hangs after N devices" failure). This mirrors
+    the reader's :func:`_abandon_reader`. Success is confirmed by the caller
+    watching sysfs for BOOTSEL, not by this child's exit.
     """
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            _SERIAL_WRITER_SCRIPT,
+            str(port),
+            str(baud),
+            line,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     try:
-        subprocess.run(
-            [
-                sys.executable,
-                _SERIAL_WRITER_SCRIPT,
-                str(port),
-                str(baud),
-                line,
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=timeout,
-        )
+        proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
-        pass
+        pass  # wedged close — _abandon_child kills and abandons it below
+    finally:
+        _abandon_child(proc)
 
 
 def _enter_bootsel_via_cdc(usb_serial, baud=115200):
@@ -433,6 +442,29 @@ def _read_line_bounded(stream, bound):
             return bytes(buf[: nl + 1]).decode("utf-8", errors="ignore")
 
 
+def _abandon_child(proc):
+    """Kill *proc* if still running and reap it with a BOUNDED wait.
+
+    Never waits unbounded. A child wedged in the kernel's uninterruptible
+    cdc_acm teardown (the "-110 mute" ``os.close()`` that never returns) will
+    not die on ``SIGKILL`` until the syscall unwinds, so awaiting it would pin
+    flash-picos — and a process cannot finish ``exit_group()`` while any of
+    its threads is in uninterruptible sleep. The bounded wait reaps a
+    cleanly-finished child; a wedged one is abandoned (reparented to init,
+    which reaps it once the syscall returns, and ``subprocess`` reaps any
+    finished child on the next :class:`~subprocess.Popen`).
+    """
+    if proc.poll() is None:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    try:
+        proc.wait(timeout=_SERIAL_TEARDOWN_GRACE_S)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _abandon_reader(proc):
     """Tear down the reader child without ever blocking on a wedged one.
 
@@ -448,15 +480,7 @@ def _abandon_reader(proc):
         proc.stdout.close()
     except OSError:
         pass
-    if proc.poll() is None:
-        try:
-            proc.kill()
-        except OSError:
-            pass
-    try:
-        proc.wait(timeout=_SERIAL_TEARDOWN_GRACE_S)
-    except subprocess.TimeoutExpired:
-        pass
+    _abandon_child(proc)
 
 
 def read_json_from_serial(port, baud, timeout):

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -535,6 +535,13 @@ _CDC_DISCOVER_POLL_S = 0.3
 _MUTE_REREAD_TIMEOUT_S = 5
 _MUTE_REREAD_ATTEMPTS = 5
 _MUTE_REREAD_SETTLE_S = 1.5
+# First-pass (busy-bus) readback is impatient: a healthy board answers in
+# well under a second (status every 200 ms), and a board mute under
+# contention will not answer within 10 s either — it needs the bus to
+# quiet, which the post-loop reconcile sweep provides. So give up fast and
+# defer stragglers to the sweep rather than stalling the run.
+_FIRST_PASS_READ_TIMEOUT_S = 2.0
+_FIRST_PASS_REENUM_TIMEOUT_S = 4.0
 
 
 def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
@@ -989,7 +996,12 @@ def flash_and_discover(
         # CDC device. _read_device_info resolves the current path from
         # the stable usb_serial (the kernel may assign a different
         # /dev/ttyACMn than it had pre-flash) and reads its JSON.
-        data = _read_device_info(port_serial, baud)
+        data = _read_device_info(
+            port_serial,
+            baud,
+            read_timeout=_FIRST_PASS_READ_TIMEOUT_S,
+            reenum_timeout=_FIRST_PASS_REENUM_TIMEOUT_S,
+        )
         outcomes[port_serial] = (
             None if data is not None else "flashed but device-info read failed"
         )

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -529,6 +529,12 @@ _INTER_DEVICE_SETTLE_S = 1.0
 # re-enumerate as CDC before reading any of them.
 _CDC_DISCOVER_TIMEOUT_S = 15.0
 _CDC_DISCOVER_POLL_S = 0.3
+# A board that re-enumerated as CDC emits a status line every 200 ms, so
+# a short read is plenty; keep re-reads snappy rather than waiting out the
+# full per-device timeout on every attempt.
+_MUTE_REREAD_TIMEOUT_S = 5
+_MUTE_REREAD_ATTEMPTS = 5
+_MUTE_REREAD_SETTLE_S = 1.5
 
 
 def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
@@ -693,17 +699,22 @@ def _read_cdc_port(port, usb_serial, baud, timeout):
     return data
 
 
-def _read_device_info(usb_serial, baud, timeout):
+def _read_device_info(
+    usb_serial,
+    baud,
+    read_timeout=_MUTE_REREAD_TIMEOUT_S,
+    reenum_timeout=_REENUMERATE_TIMEOUT_S,
+):
     """Resolve the post-flash CDC port for *usb_serial* and read its JSON.
 
     Used by the USB per-device path, which already knows each Pico by
     its (stable) CDC serial.
     """
-    port = _resolve_post_flash_port(usb_serial)
-    return _read_cdc_port(port, usb_serial, baud, timeout)
+    port = _resolve_post_flash_port(usb_serial, timeout=reenum_timeout)
+    return _read_cdc_port(port, usb_serial, baud, read_timeout)
 
 
-def _read_fleet_cdc(expected, baud, timeout):
+def _read_fleet_cdc(expected, baud):
     """Read device-info JSON from every Pico now in CDC mode.
 
     Polls :func:`find_pico_ports` until at least *expected* Picos have
@@ -735,7 +746,7 @@ def _read_fleet_cdc(expected, baud, timeout):
     devices = []
     outcomes = {}
     for port, serial in sorted(ports.items()):
-        data, reason = _read_cdc_outcome(port, serial, baud, timeout)
+        data, reason = _read_cdc_outcome(port, serial, baud, _MUTE_REREAD_TIMEOUT_S)
         outcomes[serial] = reason
         if data is not None:
             devices.append(data)
@@ -850,7 +861,6 @@ def flash_and_discover(
     port=None,
     usb_serial=None,
     baud=115200,
-    timeout=10,
     expected=None,
 ):
     """
@@ -870,8 +880,6 @@ def flash_and_discover(
         device must match both.
     baud : int
         Serial baud rate for reading JSON after flash.
-    timeout : int
-        Seconds to wait for each Pico's JSON response.
 
     Returns
     -------
@@ -950,7 +958,7 @@ def flash_and_discover(
         if not _load_bootsel_device(dev, uf2_path, execute=True):
             outcomes[serial] = "picotool load failed while in BOOTSEL"
             continue
-        data = _read_device_info(serial, baud, timeout)
+        data = _read_device_info(serial, baud)
         outcomes[serial] = (
             None
             if data is not None
@@ -981,7 +989,7 @@ def flash_and_discover(
         # CDC device. _read_device_info resolves the current path from
         # the stable usb_serial (the kernel may assign a different
         # /dev/ttyACMn than it had pre-flash) and reads its JSON.
-        data = _read_device_info(port_serial, baud, timeout)
+        data = _read_device_info(port_serial, baud)
         outcomes[port_serial] = (
             None if data is not None else "flashed but device-info read failed"
         )
@@ -1133,18 +1141,9 @@ def _boot_fleet_staggered(
     return booted
 
 
-_MUTE_REREAD_ATTEMPTS = 5
-_MUTE_REREAD_SETTLE_S = 1.5
-# A board that re-enumerated as CDC emits a status line every 200 ms, so
-# a short read is plenty; keep re-reads snappy rather than waiting out the
-# full per-device timeout on every attempt.
-_MUTE_REREAD_TIMEOUT_S = 5
-
-
 def _reread_mute_boards(
     mute,
     baud,
-    timeout,
     attempts=_MUTE_REREAD_ATTEMPTS,
     settle=_MUTE_REREAD_SETTLE_S,
 ):
@@ -1164,7 +1163,7 @@ def _reread_mute_boards(
     ``None`` once read, else its last failure reason, for the caller's
     reconciliation report.
     """
-    read_timeout = min(timeout, _MUTE_REREAD_TIMEOUT_S)
+    read_timeout = _MUTE_REREAD_TIMEOUT_S
     recovered = []
     outcomes = {}
     pending = set(mute)
@@ -1203,7 +1202,6 @@ def _reread_mute_boards(
 def flash_and_discover_gpio(
     uf2_path="build/pico_multi.uf2",
     baud=115200,
-    timeout=10,
 ):
     """Mass-flash all Picos via the bussed GPIO BOOTSEL/RUN lines.
 
@@ -1287,7 +1285,7 @@ def flash_and_discover_gpio(
     # board never re-enumerates), then read each. The readback keys off
     # the CDC serial, not the BOOTSEL serial used for loading, so a board
     # whose BOOTSEL serial differed or was absent is still reported.
-    all_devices, outcomes = _read_fleet_cdc(len(booted), baud, timeout)
+    all_devices, outcomes = _read_fleet_cdc(len(booted), baud)
     reported = {d["usb_serial"] for d in all_devices}
 
     # Staggered boot should leave no board mute, but if one still lost its
@@ -1298,7 +1296,7 @@ def flash_and_discover_gpio(
     # board is reported, not re-flashed.
     mute = (expected_serials - reported) & set(find_pico_ports().values())
     if mute:
-        reread, reread_outcomes = _reread_mute_boards(mute, baud, timeout)
+        reread, reread_outcomes = _reread_mute_boards(mute, baud)
         all_devices.extend(reread)
         outcomes.update(reread_outcomes)
         reported |= {d["usb_serial"] for d in reread}
@@ -1392,12 +1390,6 @@ def main(argv=None):
         type=int,
         default=115200,
         help="Serial baud rate.",
-    )
-    p.add_argument(
-        "--timeout",
-        type=int,
-        default=10,
-        help="Seconds to wait for each Pico's JSON",
     )
     p.add_argument(
         "--redis-host",
@@ -1514,7 +1506,6 @@ def main(argv=None):
                 all_devices = flash_and_discover_gpio(
                     uf2_path=args.uf2,
                     baud=args.baud,
-                    timeout=args.timeout,
                 )
             else:
                 all_devices = flash_and_discover(
@@ -1522,7 +1513,6 @@ def main(argv=None):
                     port=args.port,
                     usb_serial=args.usb_serial,
                     baud=args.baud,
-                    timeout=args.timeout,
                     expected=effective_expected,
                 )
         except (FileNotFoundError, RuntimeError) as e:

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -1211,6 +1211,77 @@ def _reread_mute_boards(
     return recovered, outcomes
 
 
+# The reconcile sweep runs after the flash loop, on a now-quiet bus. Settle
+# briefly first so nothing is mid-re-enumeration, then give each straggler a
+# capped number of snappy reads — on a quiet bus a healthy board answers on
+# the first one, so a second miss means it is genuinely not reporting and we
+# fail it fast rather than burning the full _MUTE_REREAD_ATTEMPTS.
+_PRE_SWEEP_SETTLE_S = 2.0
+_SWEEP_REREAD_ATTEMPTS = 2
+
+
+def _reconcile_usb_stragglers(expected_serials, reported, uf2_path, baud):
+    """Recover boards flashed in pass 1 but not yet reported, on a quiet bus.
+
+    Pass 1 reads each board inline with short timeouts (fast give-up); a
+    board lost to transient contention — re-enumerated but momentarily mute,
+    re-enumerated just after the short window, or left in BOOTSEL — is
+    deferred to here. After a brief settle so nothing is re-enumerating:
+
+    * a board now present as CDC is re-read with the patient
+      :func:`_reread_mute_boards`, capped at :data:`_SWEEP_REREAD_ATTEMPTS`;
+    * a board now in BOOTSEL is reloaded-and-run, then read patiently;
+    * a board that is neither is left for the caller to report.
+
+    Returns ``(devices, outcomes)`` for the boards handled here. ``outcomes``
+    maps each recovered serial to ``None`` and each still-failing serial to a
+    reason, for the caller's reconciliation report.
+    """
+    pending = set(expected_serials) - set(reported)
+    devices = []
+    outcomes = {}
+    if not pending:
+        return devices, outcomes
+
+    time.sleep(_PRE_SWEEP_SETTLE_S)
+
+    # Boards back as CDC: re-read on the now-quiet bus (capped attempts).
+    cdc_pending = pending & set(find_pico_ports().values())
+    if cdc_pending:
+        reread, reread_outcomes = _reread_mute_boards(
+            cdc_pending, baud, attempts=_SWEEP_REREAD_ATTEMPTS
+        )
+        devices.extend(reread)
+        outcomes.update(reread_outcomes)
+        pending -= {d["usb_serial"] for d in reread}
+
+    # Boards still in BOOTSEL (their load -x "run" did not take): reload and
+    # run, then read patiently.
+    bootsel = {
+        d["usb_serial"]: d
+        for d in _find_bootsel_devices()
+        if d["usb_serial"] in pending
+    }
+    for serial, dev in sorted(bootsel.items()):
+        logger.info(
+            "sweep: recovering serial=%s from BOOTSEL (bus=%d address=%d)",
+            serial,
+            dev["bus"],
+            dev["address"],
+        )
+        if not _load_bootsel_device(dev, uf2_path, execute=True):
+            outcomes[serial] = "still in BOOTSEL; reload failed during sweep"
+            continue
+        data = _read_device_info(serial, baud)
+        if data is not None:
+            devices.append(data)
+            outcomes[serial] = None
+        else:
+            outcomes[serial] = "reloaded from BOOTSEL but device-info read failed"
+
+    return devices, outcomes
+
+
 def flash_and_discover_gpio(
     uf2_path="build/pico_multi.uf2",
     baud=115200,

--- a/picohost/src/picohost/gpio.py
+++ b/picohost/src/picohost/gpio.py
@@ -149,7 +149,8 @@ def available():
     """Return True if the ``pinctrl`` CLI is on PATH.
 
     False on hosts without it (e.g. a dev laptop) — callers should fall
-    back to the USB flash path or tell the user to pass ``--no-gpio``.
+    back to the USB flash path (the default) or tell the user to drop
+    ``--gpio``.
     """
     return shutil.which("pinctrl") is not None
 

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -453,6 +453,36 @@ class TestFlashAndDiscover:
             fp.flash_and_discover(uf2_path=uf2, expected=3)
         assert "--expected 3" in caplog.text
 
+    def test_first_pass_uses_fast_timeouts(self, monkeypatch, tmp_path):
+        """The per-board inline read gives up fast (short timeouts), so a
+        failing board does not stall the run."""
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM0": "SER_A"}
+        )
+        monkeypatch.setattr(fp, "_wait_for_stable_cdc_set", lambda: {"/dev/ttyACM0": "SER_A"})
+        monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
+        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        seen = {}
+
+        def fake_read_device_info(serial, baud, read_timeout=None, reenum_timeout=None):
+            seen["read_timeout"] = read_timeout
+            seen["reenum_timeout"] = reenum_timeout
+            return {"app_id": 0, "port": "/dev/ttyACM0", "usb_serial": serial}
+
+        monkeypatch.setattr(fp, "_read_device_info", fake_read_device_info)
+        # No stragglers, so the sweep (added later) is a no-op here.
+        fp.flash_and_discover(uf2_path=uf2)
+
+        assert seen["read_timeout"] == fp._FIRST_PASS_READ_TIMEOUT_S
+        assert seen["reenum_timeout"] == fp._FIRST_PASS_REENUM_TIMEOUT_S
+
 
 class TestFlashUf2:
     """flash_uf2 reboots a CDC Pico into BOOTSEL with ``picotool reboot``

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -27,14 +27,13 @@ def _mock_flash(monkeypatch, tmp_path):
     uf2 = tmp_path / "test.uf2"
     uf2.write_bytes(b"\x00")
 
-    monkeypatch.setattr(
-        fp,
-        "find_pico_ports",
-        lambda: {
-            "/dev/ttyACM0": "SER_A",
-            "/dev/ttyACM1": "SER_B",
-        },
-    )
+    cdc = {
+        "/dev/ttyACM0": "SER_A",
+        "/dev/ttyACM1": "SER_B",
+    }
+    monkeypatch.setattr(fp, "find_pico_ports", lambda: dict(cdc))
+    monkeypatch.setattr(fp, "_wait_for_stable_cdc_set", lambda: dict(cdc))
+    monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
 
     flashed = []
     monkeypatch.setattr(
@@ -61,6 +60,19 @@ def _mock_flash(monkeypatch, tmp_path):
 
 
 class TestFlashAndDiscover:
+    @pytest.fixture(autouse=True)
+    def _stub_discovery(self, monkeypatch):
+        # The no-gpio path settles the CDC set and scans for stranded
+        # BOOTSEL boards; by default delegate the settle to each test's
+        # find_pico_ports mock and report no BOOTSEL boards. Tests that
+        # exercise recovery override _find_bootsel_devices.
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_wait_for_stable_cdc_set", lambda: fp.find_pico_ports()
+        )
+        monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
+
     def test_returns_device_list(self, _mock_flash):
         uf2, flashed = _mock_flash
         devices = flash_and_discover(uf2_path=uf2)
@@ -342,6 +354,105 @@ class TestFlashAndDiscover:
             ("read", "/dev/ttyACM2"),
         ]
 
+    def test_recovers_board_stranded_in_bootsel(self, monkeypatch, tmp_path):
+        # A board left in BOOTSEL by a prior aborted run is invisible to
+        # find_pico_ports (CDC only); the no-gpio path now recovers it by
+        # loading + running it directly (no reboot trigger needed).
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        monkeypatch.setattr(fp, "find_pico_ports", lambda: {})
+        monkeypatch.setattr(
+            fp,
+            "_find_bootsel_devices",
+            lambda *a, **k: [{"usb_serial": "SER_B", "bus": 1, "address": 50}],
+        )
+        loaded = []
+        monkeypatch.setattr(
+            fp,
+            "_load_bootsel_device",
+            lambda dev, path, execute=False: (
+                loaded.append((dev["usb_serial"], execute)) or True
+            ),
+        )
+        monkeypatch.setattr(
+            fp,
+            "_read_device_info",
+            lambda serial, baud, timeout: {
+                "app_id": 5,
+                "port": "/dev/ttyACM9",
+                "usb_serial": serial,
+            },
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        devices = fp.flash_and_discover(uf2_path=uf2)
+        assert [d["usb_serial"] for d in devices] == ["SER_B"]
+        # Recovered boards load WITH execute=True (run immediately).
+        assert loaded == [("SER_B", True)]
+
+    def test_reconciliation_names_flashed_but_unread_board(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        import logging
+
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        monkeypatch.setattr(
+            fp,
+            "find_pico_ports",
+            lambda: {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"},
+        )
+        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
+        # SER_A reads back; SER_B flashes but never reports.
+        monkeypatch.setattr(
+            fp,
+            "_read_device_info",
+            lambda serial, baud, timeout: (
+                {"app_id": 0, "port": "/dev/ttyACM0", "usb_serial": serial}
+                if serial == "SER_A"
+                else None
+            ),
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        with caplog.at_level(logging.WARNING):
+            devices = fp.flash_and_discover(uf2_path=uf2)
+        assert [d["usb_serial"] for d in devices] == ["SER_A"]
+        assert "SER_B" in caplog.text
+        assert "NOT reported" in caplog.text
+
+    def test_expected_warns_when_fewer_discovered(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        import logging
+
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM0": "SER_A"}
+        )
+        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
+        monkeypatch.setattr(
+            fp,
+            "_read_device_info",
+            lambda serial, baud, timeout: {
+                "app_id": 0,
+                "port": "/dev/ttyACM0",
+                "usb_serial": serial,
+            },
+        )
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        with caplog.at_level(logging.WARNING):
+            fp.flash_and_discover(uf2_path=uf2, expected=3)
+        assert "--expected 3" in caplog.text
+
 
 class TestFlashUf2:
     """flash_uf2 reboots a CDC Pico into BOOTSEL with ``picotool reboot``
@@ -352,11 +463,50 @@ class TestFlashUf2:
     backoff.
     """
 
+    def test_cdc_command_enters_bootsel_skips_picotool_reboot(
+        self, monkeypatch
+    ):
+        # PRIMARY path: the firmware {"cmd":"bootsel"} command puts the
+        # board into BOOTSEL, so picotool reboot is never run — only load.
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "_resolve_bus_address", lambda s: (1, 104, False)
+        )
+        monkeypatch.setattr(fp, "_enter_bootsel_via_cdc", lambda s: (1, 200))
+        cmds = []
+
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return types.SimpleNamespace(returncode=0, stdout="")
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+        fp.flash_uf2("x.uf2", "SER_A")
+        assert cmds == [
+            [
+                "picotool",
+                "load",
+                "--bus",
+                "1",
+                "--address",
+                "200",
+                "-x",
+                "x.uf2",
+            ],
+        ]
+        assert all(c[1] != "reboot" for c in cmds)
+
     def test_cdc_device_rebooted_then_loaded(self, monkeypatch):
         import picohost.flash_picos as fp
 
         monkeypatch.setattr(
             fp, "_resolve_bus_address", lambda s: (1, 104, False)
+        )
+        # CDC command fails -> fall back to picotool's USB reset.
+        monkeypatch.setattr(
+            fp, "_enter_bootsel_via_cdc", lambda s: (None, None)
         )
         monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s: (1, 107))
         cmds = []
@@ -514,6 +664,9 @@ class TestFlashUf2:
         monkeypatch.setattr(
             fp, "_resolve_bus_address", lambda s: next(resolves)
         )
+        monkeypatch.setattr(
+            fp, "_enter_bootsel_via_cdc", lambda s: (None, None)
+        )
         monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s: (1, 107))
         codes = iter([1, 0])
         cmds = []
@@ -570,6 +723,9 @@ class TestFlashUf2:
         monkeypatch.setattr(
             fp, "_resolve_bus_address", lambda s: (1, 104, False)
         )
+        monkeypatch.setattr(
+            fp, "_enter_bootsel_via_cdc", lambda s: (None, None)
+        )
         monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s: (None, None))
         cmds = []
 
@@ -602,6 +758,92 @@ class TestFlashUf2:
         with pytest.raises(RuntimeError, match="after 3 attempts"):
             fp.flash_uf2("x.uf2", "SER_A", attempts=3, backoff=0.0)
         assert ran == []
+
+
+class TestSendSerialLine:
+    def test_runs_writer_child_with_argv(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["timeout"] = kw.get("timeout")
+            return types.SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        fp._send_serial_line("/dev/ttyACM3", '{"cmd":"bootsel"}', 115200, 5.0)
+        assert captured["cmd"][1] == fp._SERIAL_WRITER_SCRIPT
+        assert captured["cmd"][2:] == [
+            "/dev/ttyACM3",
+            "115200",
+            '{"cmd":"bootsel"}',
+        ]
+        assert captured["timeout"] == 5.0
+
+    def test_swallows_writer_timeout(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        def fake_run(cmd, **kw):
+            raise fp.subprocess.TimeoutExpired(cmd, kw.get("timeout"))
+
+        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        # Must not raise — a wedged writer child is abandoned, not awaited.
+        fp._send_serial_line("/dev/ttyACM3", "x", 115200, 0.1)
+
+
+class TestEnterBootselViaCdc:
+    """The no-gpio path triggers BOOTSEL via the firmware CDC command
+    ({"cmd":"bootsel"} -> reset_usb_boot in the main loop) first, because
+    picotool's own USB reset is unreliable on long-running boards. This
+    resolves the board's CDC port, sends the command, and waits for it to
+    re-enumerate in BOOTSEL.
+    """
+
+    def test_sends_command_and_returns_bootsel_address(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM3": "SER_A"}
+        )
+        sent = {}
+        monkeypatch.setattr(
+            fp,
+            "_send_serial_line",
+            lambda port, line, baud, timeout: sent.update(
+                port=port, line=line
+            ),
+        )
+        monkeypatch.setattr(fp, "_wait_for_bootsel", lambda s, **k: (1, 77))
+
+        assert fp._enter_bootsel_via_cdc("SER_A") == (1, 77)
+        assert sent["port"] == "/dev/ttyACM3"
+        assert sent["line"] == fp._BOOTSEL_COMMAND
+
+    def test_no_port_does_not_send_and_returns_none(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM3": "OTHER"}
+        )
+
+        def must_not_send(*a, **k):
+            raise AssertionError("must not send to an unresolved port")
+
+        monkeypatch.setattr(fp, "_send_serial_line", must_not_send)
+        assert fp._enter_bootsel_via_cdc("SER_A") == (None, None)
+
+    def test_returns_none_when_board_never_enters_bootsel(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM3": "SER_A"}
+        )
+        monkeypatch.setattr(fp, "_send_serial_line", lambda *a, **k: None)
+        monkeypatch.setattr(
+            fp, "_wait_for_bootsel", lambda s, **k: (None, None)
+        )
+        assert fp._enter_bootsel_via_cdc("SER_A") == (None, None)
 
 
 class TestWaitForBootsel:
@@ -836,6 +1078,48 @@ class TestSerialReaderChild:
 
         sr.run("/dev/ttyACM4", 115200, 0.1, out)
         assert json.loads(out.getvalue()) == {"timeout": True}
+
+
+class TestSerialWriterChild:
+    """The child writer (_serial_writer.run) sends one line to the CDC
+    port (the {"cmd":"bootsel"} reflash trigger) and closes.
+
+    It is fire-and-forget: the caller confirms the reboot by watching
+    sysfs for BOOTSEL, not by this child. The newline terminator is added
+    by the writer so callers pass the bare command.
+    """
+
+    def test_writes_line_with_newline_then_closes(self, monkeypatch):
+        import picohost._serial_writer as sw
+
+        events = []
+
+        class FakeSerial:
+            def __init__(self, *a, **k):
+                pass
+
+            def write(self, b):
+                events.append(("write", b))
+
+            def flush(self):
+                events.append("flush")
+
+            def close(self):
+                events.append("close")
+
+        monkeypatch.setattr(sw, "Serial", FakeSerial)
+        assert sw.run("/dev/ttyACM4", 115200, '{"cmd":"bootsel"}') == 0
+        assert events == [("write", b'{"cmd":"bootsel"}\n'), "flush", "close"]
+
+    def test_open_failure_returns_nonzero(self, monkeypatch):
+        import picohost._serial_writer as sw
+
+        class FailingSerial:
+            def __init__(self, *a, **k):
+                raise OSError(errno.EBUSY, "resource busy")
+
+        monkeypatch.setattr(sw, "Serial", FailingSerial)
+        assert sw.run("/dev/ttyACM4", 115200, '{"cmd":"bootsel"}') == 1
 
 
 class _FakeReaderProc:
@@ -1247,6 +1531,60 @@ class TestWaitForStableBootselSet:
             timeout=0.05, stable=10.0, poll=0.005
         )
         assert result == [d1]
+
+
+class TestWaitForStableCdcSet:
+    """The no-gpio path settles the CDC device set before flashing, so a
+    board slow to enumerate on the contended hub is not silently skipped
+    by a single snapshot (the way `find_pico_ports()` alone would)."""
+
+    def _scanner(self, monkeypatch, frames):
+        import picohost.flash_picos as fp
+
+        calls = {"n": 0}
+
+        def fake_find():
+            idx = min(calls["n"], len(frames) - 1)
+            calls["n"] += 1
+            return frames[idx]
+
+        monkeypatch.setattr(fp, "find_pico_ports", fake_find)
+        return calls
+
+    def test_returns_after_set_stabilizes(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        self._scanner(
+            monkeypatch,
+            [
+                {"/dev/ttyACM0": "A"},
+                {"/dev/ttyACM0": "A", "/dev/ttyACM1": "B"},
+            ],
+        )
+        result = fp._wait_for_stable_cdc_set(
+            timeout=5.0, stable=0.05, poll=0.005
+        )
+        assert result == {"/dev/ttyACM0": "A", "/dev/ttyACM1": "B"}
+
+    def test_waits_through_growing_set(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        d1 = {"/dev/ttyACM0": "A"}
+        d2 = {"/dev/ttyACM0": "A", "/dev/ttyACM1": "B"}
+        self._scanner(monkeypatch, [d1, d1, d1, d2])
+        result = fp._wait_for_stable_cdc_set(
+            timeout=5.0, stable=0.3, poll=0.005
+        )
+        assert result == d2
+
+    def test_returns_last_seen_on_timeout(self, monkeypatch):
+        import picohost.flash_picos as fp
+
+        self._scanner(monkeypatch, [{"/dev/ttyACM0": "A"}])
+        result = fp._wait_for_stable_cdc_set(
+            timeout=0.05, stable=10.0, poll=0.005
+        )
+        assert result == {"/dev/ttyACM0": "A"}
 
 
 @pytest.fixture
@@ -1867,18 +2205,20 @@ class TestMainRouting:
         fp.main(argv + ["--no-redis"])
         return calls
 
-    def test_default_routes_to_gpio(self, monkeypatch):
+    def test_default_routes_to_usb(self, monkeypatch):
+        # The USB per-device path is the default; --gpio opts into the
+        # GPIO mass-BOOTSEL flow.
         calls = self._run_main(monkeypatch, ["--uf2", "x.uf2"])
-        assert [c[0] for c in calls] == ["gpio"]
-
-    def test_no_gpio_flag_routes_to_usb(self, monkeypatch):
-        calls = self._run_main(monkeypatch, ["--uf2", "x.uf2", "--no-gpio"])
         assert [c[0] for c in calls] == ["usb"]
 
+    def test_gpio_flag_routes_to_gpio(self, monkeypatch):
+        calls = self._run_main(monkeypatch, ["--uf2", "x.uf2", "--gpio"])
+        assert [c[0] for c in calls] == ["gpio"]
+
     def test_port_targeting_routes_to_usb(self, monkeypatch):
-        # GPIO mass reset cannot target a single Pico.
+        # GPIO mass reset cannot target a single Pico (even with --gpio).
         calls = self._run_main(
-            monkeypatch, ["--uf2", "x.uf2", "--port", "/dev/ttyACM0"]
+            monkeypatch, ["--uf2", "x.uf2", "--gpio", "--port", "/dev/ttyACM0"]
         )
         assert [c[0] for c in calls] == ["usb"]
         assert calls[0][1]["port"] == "/dev/ttyACM0"
@@ -1891,14 +2231,14 @@ class TestMainRouting:
         assert calls[0][1]["usb_serial"] == "SER_A"
 
     def test_gpio_unavailable_fails_fast(self, monkeypatch, capsys):
-        # No silent fallback: tell the operator to fix the backend or
-        # pass --no-gpio explicitly.
+        # --gpio requested but pinctrl missing: no silent fallback — tell
+        # the operator to fix the backend or drop --gpio.
         with pytest.raises(SystemExit) as excinfo:
             self._run_main(
-                monkeypatch, ["--uf2", "x.uf2"], gpio_available=False
+                monkeypatch, ["--uf2", "x.uf2", "--gpio"], gpio_available=False
             )
         assert excinfo.value.code == 1
-        assert "--no-gpio" in capsys.readouterr().err
+        assert "--gpio" in capsys.readouterr().err
 
     def test_gpio_flow_runtime_error_exits_nonzero(self, monkeypatch, capsys):
         import picohost.flash_picos as fp
@@ -1916,9 +2256,59 @@ class TestMainRouting:
 
         monkeypatch.setattr(fp, "flash_and_discover_gpio", boom)
         with pytest.raises(SystemExit) as excinfo:
-            fp.main(["--uf2", "x.uf2", "--no-redis"])
+            fp.main(["--uf2", "x.uf2", "--gpio", "--no-redis"])
         assert excinfo.value.code == 1
         assert "BOOTSEL" in capsys.readouterr().err
+
+    def test_expected_passed_through_to_usb_flash(self, monkeypatch):
+        calls = self._run_main(
+            monkeypatch, ["--uf2", "x.uf2", "--expected", "1"]
+        )
+        assert calls[0][1]["expected"] == 1
+
+    def test_default_expected_is_seven(self, monkeypatch):
+        # With no --expected, the default fleet size of 7 is passed down.
+        calls = self._run_main(monkeypatch, ["--uf2", "x.uf2"])
+        assert calls[0][1]["expected"] == 7
+
+    def test_expected_shortfall_warns_does_not_fail(self, monkeypatch, capsys):
+        # Fewer boards report than --expected: a loud warning, NOT a
+        # failure — the run still publishes whatever reported and exits 0.
+        import picohost.flash_picos as fp
+        import picohost.gpio as gpio_mod
+
+        monkeypatch.setattr(
+            fp.manager_service, "manager_is_active", lambda: False
+        )
+        monkeypatch.setattr(gpio_mod, "available", lambda: True)
+        monkeypatch.setattr(
+            fp, "flash_and_discover", lambda **kw: [{"app_id": 0}]
+        )
+        # Must NOT raise SystemExit.
+        fp.main(["--uf2", "x.uf2", "--no-redis", "--expected", "3"])
+        err = capsys.readouterr().err
+        assert "warning" in err.lower()
+        assert "expected 3" in err.lower()
+
+    def test_targeting_bypasses_expected_warning(self, monkeypatch, capsys):
+        # A deliberate single-board flash must not warn about the fleet
+        # count: targeting sets the effective expected to None.
+        import picohost.flash_picos as fp
+        import picohost.gpio as gpio_mod
+
+        monkeypatch.setattr(
+            fp.manager_service, "manager_is_active", lambda: False
+        )
+        monkeypatch.setattr(gpio_mod, "available", lambda: True)
+        calls = []
+        monkeypatch.setattr(
+            fp,
+            "flash_and_discover",
+            lambda **kw: calls.append(kw) or [{"app_id": 0}],
+        )
+        fp.main(["--uf2", "x.uf2", "--no-redis", "--usb-serial", "SER_A"])
+        assert "expected" not in capsys.readouterr().err.lower()
+        assert calls[0]["expected"] is None
 
 
 class TestManagerAutoStop:
@@ -1954,7 +2344,7 @@ class TestManagerAutoStop:
         return uf2, events
 
     def _argv(self, uf2):
-        return ["--uf2", str(uf2), "--no-gpio", "--no-redis"]
+        return ["--uf2", str(uf2), "--no-redis"]
 
     def test_stops_then_flashes_then_restarts(self, monkeypatch, tmp_path):
         uf2, events = self._setup(

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -266,21 +266,28 @@ class TestFlashAndDiscover:
         uf2 = tmp_path / "test.uf2"
         uf2.write_bytes(b"\x00")
 
+        # SER_A is discovered (so it is flashed) but never re-enumerates —
+        # absent from find_pico_ports post-flash — so neither the first-pass
+        # read nor the sweep can recover it; only SER_B is published.
+        monkeypatch.setattr(
+            fp,
+            "_wait_for_stable_cdc_set",
+            lambda: {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"},
+        )
+        # Post-flash CDC view: SER_A never re-enumerated.
         monkeypatch.setattr(
             fp,
             "find_pico_ports",
-            lambda: {
-                "/dev/ttyACM0": "SER_A",
-                "/dev/ttyACM1": "SER_B",
-            },
+            lambda: {"/dev/ttyACM1": "SER_B"},
         )
-
         # SER_A never re-appears; SER_B comes back fine.
         monkeypatch.setattr(
             fp,
             "_resolve_post_flash_port",
             lambda serial, **k: {"SER_B": "/dev/ttyACM1"}.get(serial),
         )
+        # No boards stranded in BOOTSEL (deterministic; avoids real sysfs).
+        monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
 
         monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
         monkeypatch.setattr(
@@ -290,12 +297,6 @@ class TestFlashAndDiscover:
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-        # This test exercises the first-pass re-enumeration check only; stub
-        # out the post-loop sweep so SER_A (still visible in find_pico_ports)
-        # is not incidentally recovered by the sweep.
-        monkeypatch.setattr(
-            fp, "_reconcile_usb_stragglers", lambda *a, **k: ([], {})
-        )
 
         devices = flash_and_discover(uf2_path=uf2)
         assert len(devices) == 1

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -844,18 +844,57 @@ class TestFlashUf2:
         assert ran == []
 
 
+class _FakeWriterProc:
+    """Stand-in for the writer child's Popen.
+
+    With ``wedged=True`` it models the worst case the writer must survive:
+    a child whose ``ser.close()`` landed in the kernel's uninterruptible
+    cdc_acm teardown after the board yanked its CDC interface off the bus
+    (``reset_usb_boot`` runs the instant the firmware reads
+    ``{"cmd":"bootsel"}``). Such a child never reaps — every bounded
+    ``wait(timeout=...)`` raises :class:`~subprocess.TimeoutExpired` and
+    ``poll()`` stays ``None`` even after a kill — so a parent that awaits it
+    *unbounded* (what ``subprocess.run(timeout=...)`` does on POSIX, via a
+    ``process.wait()`` after the kill) would hang forever. The writer must
+    instead kill-and-abandon it within the grace.
+    """
+
+    def __init__(self, *a, wedged=True, **k):
+        self.killed = False
+        self.returncode = None
+        self.wedged = wedged
+        self.wait_timeouts = []
+
+    def poll(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True  # a wedged (D-state) child stays unreaped
+
+    def wait(self, timeout=None):
+        self.wait_timeouts.append(timeout)
+        if self.wedged:
+            import subprocess
+
+            raise subprocess.TimeoutExpired("writer", timeout)
+        self.returncode = 0
+        return 0
+
+
 class TestSendSerialLine:
     def test_runs_writer_child_with_argv(self, monkeypatch):
         import picohost.flash_picos as fp
 
         captured = {}
+        fake = _FakeWriterProc(wedged=False)
 
-        def fake_run(cmd, **kw):
+        def fake_popen(cmd, **kw):
             captured["cmd"] = cmd
-            captured["timeout"] = kw.get("timeout")
-            return types.SimpleNamespace(returncode=0)
+            captured["stdout"] = kw.get("stdout")
+            captured["stderr"] = kw.get("stderr")
+            return fake
 
-        monkeypatch.setattr(fp.subprocess, "run", fake_run)
+        monkeypatch.setattr(fp.subprocess, "Popen", fake_popen)
         fp._send_serial_line("/dev/ttyACM3", '{"cmd":"bootsel"}', 115200, 5.0)
         assert captured["cmd"][1] == fp._SERIAL_WRITER_SCRIPT
         assert captured["cmd"][2:] == [
@@ -863,17 +902,28 @@ class TestSendSerialLine:
             "115200",
             '{"cmd":"bootsel"}',
         ]
-        assert captured["timeout"] == 5.0
+        # No stdout/stderr to read back — fire-and-forget — so both go to
+        # DEVNULL, and the read timeout bounds proc.wait(), not Popen itself.
+        assert captured["stdout"] == fp.subprocess.DEVNULL
+        assert captured["stderr"] == fp.subprocess.DEVNULL
+        assert fake.wait_timeouts[0] == 5.0
+        assert not fake.killed
 
-    def test_swallows_writer_timeout(self, monkeypatch):
+    def test_abandons_wedged_writer_child(self, monkeypatch):
         import picohost.flash_picos as fp
 
-        def fake_run(cmd, **kw):
-            raise fp.subprocess.TimeoutExpired(cmd, kw.get("timeout"))
-
-        monkeypatch.setattr(fp.subprocess, "run", fake_run)
-        # Must not raise — a wedged writer child is abandoned, not awaited.
-        fp._send_serial_line("/dev/ttyACM3", "x", 115200, 0.1)
+        # The board re-enumerates as BOOTSEL the instant it reads the
+        # command, so the child's close() can wedge in an uninterruptible
+        # cdc_acm teardown and never reap. _send_serial_line must kill it and
+        # move on within the grace — NOT await it unbounded (which is the
+        # "flash-picos hangs after N devices" failure). The fake's wait()
+        # always times out, so this test only completes if the writer never
+        # makes an unbounded wait.
+        fake = _FakeWriterProc(wedged=True)
+        monkeypatch.setattr(fp.subprocess, "Popen", lambda *a, **k: fake)
+        monkeypatch.setattr(fp, "_SERIAL_TEARDOWN_GRACE_S", 0.1)
+        fp._send_serial_line("/dev/ttyACM3", '{"cmd":"bootsel"}', 115200, 0.1)
+        assert fake.killed  # the wedged child was abandoned, not awaited
 
 
 class TestEnterBootselViaCdc:

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -231,7 +231,7 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "_resolve_post_flash_port",
-            lambda serial: post_flash[serial],
+            lambda serial, **k: post_flash[serial],
         )
 
         monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
@@ -279,7 +279,7 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "_resolve_post_flash_port",
-            lambda serial: {"SER_B": "/dev/ttyACM1"}.get(serial),
+            lambda serial, **k: {"SER_B": "/dev/ttyACM1"}.get(serial),
         )
 
         monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
@@ -323,7 +323,7 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "_resolve_post_flash_port",
-            lambda serial: {
+            lambda serial, **k: {
                 "SER_A": "/dev/ttyACM0",
                 "SER_B": "/dev/ttyACM1",
                 "SER_C": "/dev/ttyACM2",
@@ -379,7 +379,7 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "_read_device_info",
-            lambda serial, baud, timeout: {
+            lambda serial, baud, **k: {
                 "app_id": 5,
                 "port": "/dev/ttyACM9",
                 "usb_serial": serial,
@@ -411,7 +411,7 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "_read_device_info",
-            lambda serial, baud, timeout: (
+            lambda serial, baud, **k: (
                 {"app_id": 0, "port": "/dev/ttyACM0", "usb_serial": serial}
                 if serial == "SER_A"
                 else None
@@ -441,7 +441,7 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp,
             "_read_device_info",
-            lambda serial, baud, timeout: {
+            lambda serial, baud, **k: {
                 "app_id": 0,
                 "port": "/dev/ttyACM0",
                 "usb_serial": serial,
@@ -935,7 +935,7 @@ class TestReadDeviceInfo:
 
         self._patch_common(monkeypatch, fp)
         monkeypatch.setattr(
-            fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
+            fp, "_resolve_post_flash_port", lambda s, **k: "/dev/ttyACM0"
         )
         monkeypatch.setattr(
             fp,
@@ -955,7 +955,7 @@ class TestReadDeviceInfo:
 
         self._patch_common(monkeypatch, fp)
         monkeypatch.setattr(
-            fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
+            fp, "_resolve_post_flash_port", lambda s, **k: "/dev/ttyACM0"
         )
 
         calls = {"n": 0}
@@ -975,7 +975,7 @@ class TestReadDeviceInfo:
         import picohost.flash_picos as fp
 
         self._patch_common(monkeypatch, fp)
-        monkeypatch.setattr(fp, "_resolve_post_flash_port", lambda s: None)
+        monkeypatch.setattr(fp, "_resolve_post_flash_port", lambda s, **k: None)
 
         def fail_read(port, baud, timeout):
             raise AssertionError("must not read without a port")
@@ -2035,7 +2035,7 @@ class TestRereadMuteBoards:
             return {"app_id": 5}
 
         monkeypatch.setattr(fp, "read_json_from_serial", read)
-        devices, outcomes = fp._reread_mute_boards({"SER_B"}, 115200, 10)
+        devices, outcomes = fp._reread_mute_boards({"SER_B"}, 115200)
         assert [d["usb_serial"] for d in devices] == ["SER_B"]
         assert devices[0]["port"] == "/dev/ttyACM6"
         assert outcomes == {"SER_B": None}
@@ -2052,7 +2052,7 @@ class TestRereadMuteBoards:
             ),
         )
         devices, outcomes = fp._reread_mute_boards(
-            {"SER_B"}, 115200, 10, attempts=2
+            {"SER_B"}, 115200, attempts=2
         )
         assert devices == []
         assert outcomes["SER_B"] is not None
@@ -2068,7 +2068,7 @@ class TestRereadMuteBoards:
             return {"app_id": 5}
 
         monkeypatch.setattr(fp, "read_json_from_serial", read)
-        fp._reread_mute_boards({"SER_B"}, 115200, 10)
+        fp._reread_mute_boards({"SER_B"}, 115200)
         assert seen["timeout"] == fp._MUTE_REREAD_TIMEOUT_S
 
     def test_scans_ports_once_across_attempts(self, monkeypatch):
@@ -2095,7 +2095,7 @@ class TestRereadMuteBoards:
             return {"app_id": 5}
 
         monkeypatch.setattr(fp, "read_json_from_serial", read)
-        devices, outcomes = fp._reread_mute_boards({"SER_B"}, 115200, 10)
+        devices, outcomes = fp._reread_mute_boards({"SER_B"}, 115200)
         assert [d["usb_serial"] for d in devices] == ["SER_B"]
         assert reads["n"] == 3  # took three attempts
         assert scans["n"] == 1  # but only one USB descriptor scan
@@ -2309,6 +2309,13 @@ class TestMainRouting:
         fp.main(["--uf2", "x.uf2", "--no-redis", "--usb-serial", "SER_A"])
         assert "expected" not in capsys.readouterr().err.lower()
         assert calls[0]["expected"] is None
+
+    def test_timeout_flag_removed(self):
+        """--timeout was removed; argparse must reject it."""
+        import picohost.flash_picos as fp
+
+        with pytest.raises(SystemExit):
+            fp.main(["--uf2", "x.uf2", "--no-redis", "--timeout", "5"])
 
 
 class TestManagerAutoStop:

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -290,6 +290,12 @@ class TestFlashAndDiscover:
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         monkeypatch.setattr(fp, "_udev_settle", lambda: None)
+        # This test exercises the first-pass re-enumeration check only; stub
+        # out the post-loop sweep so SER_A (still visible in find_pico_ports)
+        # is not incidentally recovered by the sweep.
+        monkeypatch.setattr(
+            fp, "_reconcile_usb_stragglers", lambda *a, **k: ([], {})
+        )
 
         devices = flash_and_discover(uf2_path=uf2)
         assert len(devices) == 1
@@ -482,6 +488,46 @@ class TestFlashAndDiscover:
 
         assert seen["read_timeout"] == fp._FIRST_PASS_READ_TIMEOUT_S
         assert seen["reenum_timeout"] == fp._FIRST_PASS_REENUM_TIMEOUT_S
+
+    def test_straggler_recovered_by_sweep(self, monkeypatch, tmp_path):
+        """A board whose first-pass read fails is recovered by the post-loop
+        sweep and ends up in the published set."""
+        import picohost.flash_picos as fp
+
+        uf2 = tmp_path / "test.uf2"
+        uf2.write_bytes(b"\x00")
+
+        cdc = {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"}
+        monkeypatch.setattr(fp, "find_pico_ports", lambda: dict(cdc))
+        monkeypatch.setattr(fp, "_wait_for_stable_cdc_set", lambda: dict(cdc))
+        monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
+        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+        monkeypatch.setattr(
+            fp, "_resolve_post_flash_port", lambda serial, **k: {
+                "SER_A": "/dev/ttyACM0", "SER_B": "/dev/ttyACM1"
+            }[serial]
+        )
+
+        # SER_B is mute on its first read (pass 1); every later read succeeds
+        # (the quiet-bus sweep).
+        state = {"ser_b_reads": 0}
+
+        def read(port, baud, timeout):
+            if port == "/dev/ttyACM1":
+                state["ser_b_reads"] += 1
+                if state["ser_b_reads"] == 1:
+                    raise RuntimeError("Timed out waiting for JSON")
+                return {"app_id": 5}
+            return {"app_id": 0}
+
+        monkeypatch.setattr(fp, "read_json_from_serial", read)
+
+        devices = fp.flash_and_discover(uf2_path=uf2)
+        by_serial = {d["usb_serial"]: d for d in devices}
+        assert set(by_serial) == {"SER_A", "SER_B"}  # SER_B recovered
+        assert by_serial["SER_B"]["app_id"] == 5
 
 
 class TestFlashUf2:

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -471,14 +471,18 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(
             fp, "find_pico_ports", lambda: {"/dev/ttyACM0": "SER_A"}
         )
-        monkeypatch.setattr(fp, "_wait_for_stable_cdc_set", lambda: {"/dev/ttyACM0": "SER_A"})
+        monkeypatch.setattr(
+            fp, "_wait_for_stable_cdc_set", lambda: {"/dev/ttyACM0": "SER_A"}
+        )
         monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
         monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
 
         seen = {}
 
-        def fake_read_device_info(serial, baud, read_timeout=None, reenum_timeout=None):
+        def fake_read_device_info(
+            serial, baud, read_timeout=None, reenum_timeout=None
+        ):
             seen["read_timeout"] = read_timeout
             seen["reenum_timeout"] = reenum_timeout
             return {"app_id": 0, "port": "/dev/ttyACM0", "usb_serial": serial}
@@ -506,9 +510,12 @@ class TestFlashAndDiscover:
         monkeypatch.setattr(fp, "_udev_settle", lambda: None)
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         monkeypatch.setattr(
-            fp, "_resolve_post_flash_port", lambda serial, **k: {
-                "SER_A": "/dev/ttyACM0", "SER_B": "/dev/ttyACM1"
-            }[serial]
+            fp,
+            "_resolve_post_flash_port",
+            lambda serial, **k: {
+                "SER_A": "/dev/ttyACM0",
+                "SER_B": "/dev/ttyACM1",
+            }[serial],
         )
 
         # SER_B is mute on its first read (pass 1); every later read succeeds
@@ -1052,7 +1059,9 @@ class TestReadDeviceInfo:
         import picohost.flash_picos as fp
 
         self._patch_common(monkeypatch, fp)
-        monkeypatch.setattr(fp, "_resolve_post_flash_port", lambda s, **k: None)
+        monkeypatch.setattr(
+            fp, "_resolve_post_flash_port", lambda s, **k: None
+        )
 
         def fail_read(port, baud, timeout):
             raise AssertionError("must not read without a port")
@@ -2538,7 +2547,9 @@ class TestReconcileUsbStragglers:
         )
         monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
         monkeypatch.setattr(
-            fp, "read_json_from_serial", lambda port, baud, timeout: {"app_id": 5}
+            fp,
+            "read_json_from_serial",
+            lambda port, baud, timeout: {"app_id": 5},
         )
 
         devices, outcomes = fp._reconcile_usb_stragglers(
@@ -2562,13 +2573,17 @@ class TestReconcileUsbStragglers:
         monkeypatch.setattr(
             fp,
             "_load_bootsel_device",
-            lambda dev, uf2, execute=False: loaded.append(dev["usb_serial"]) or True,
+            lambda dev, uf2, execute=False: (
+                loaded.append(dev["usb_serial"]) or True
+            ),
         )
         monkeypatch.setattr(
             fp,
             "_read_device_info",
             lambda serial, baud, **k: {
-                "app_id": 5, "port": "/dev/ttyACM6", "usb_serial": serial
+                "app_id": 5,
+                "port": "/dev/ttyACM6",
+                "usb_serial": serial,
             },
         )
 

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -2455,3 +2455,102 @@ class TestManagerAutoStop:
         assert excinfo.value.code == 1
         assert "cannot stop" in capsys.readouterr().err
         assert events == []
+
+
+class TestReconcileUsbStragglers:
+    """The post-loop sweep recovers boards flashed but unreported, on a
+    now-quiet bus: re-read CDC-present boards, reload BOOTSEL-stuck ones."""
+
+    def _patch_quiet(self, monkeypatch, fp):
+        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
+        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
+
+    def test_no_pending_is_noop(self, monkeypatch, tmp_path):
+        import picohost.flash_picos as fp
+
+        self._patch_quiet(monkeypatch, fp)
+
+        def boom(*a, **k):
+            raise AssertionError("must not touch the bus when nothing pends")
+
+        monkeypatch.setattr(fp, "find_pico_ports", boom)
+        monkeypatch.setattr(fp, "_find_bootsel_devices", boom)
+
+        devices, outcomes = fp._reconcile_usb_stragglers(
+            {"SER_A", "SER_B"}, {"SER_A", "SER_B"}, tmp_path / "x.uf2", 115200
+        )
+        assert devices == []
+        assert outcomes == {}
+
+    def test_rereads_cdc_straggler(self, monkeypatch, tmp_path):
+        import picohost.flash_picos as fp
+
+        self._patch_quiet(monkeypatch, fp)
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM6": "SER_B"}
+        )
+        monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
+        monkeypatch.setattr(
+            fp, "read_json_from_serial", lambda port, baud, timeout: {"app_id": 5}
+        )
+
+        devices, outcomes = fp._reconcile_usb_stragglers(
+            {"SER_A", "SER_B"}, {"SER_A"}, tmp_path / "x.uf2", 115200
+        )
+        assert [d["usb_serial"] for d in devices] == ["SER_B"]
+        assert outcomes["SER_B"] is None
+
+    def test_recovers_bootsel_straggler(self, monkeypatch, tmp_path):
+        import picohost.flash_picos as fp
+
+        self._patch_quiet(monkeypatch, fp)
+        # Not present as CDC, but sitting in BOOTSEL.
+        monkeypatch.setattr(fp, "find_pico_ports", lambda: {})
+        monkeypatch.setattr(
+            fp,
+            "_find_bootsel_devices",
+            lambda *a, **k: [{"usb_serial": "SER_B", "bus": 1, "address": 9}],
+        )
+        loaded = []
+        monkeypatch.setattr(
+            fp,
+            "_load_bootsel_device",
+            lambda dev, uf2, execute=False: loaded.append(dev["usb_serial"]) or True,
+        )
+        monkeypatch.setattr(
+            fp,
+            "_read_device_info",
+            lambda serial, baud, **k: {
+                "app_id": 5, "port": "/dev/ttyACM6", "usb_serial": serial
+            },
+        )
+
+        devices, outcomes = fp._reconcile_usb_stragglers(
+            {"SER_B"}, set(), tmp_path / "x.uf2", 115200
+        )
+        assert loaded == ["SER_B"]
+        assert [d["usb_serial"] for d in devices] == ["SER_B"]
+        assert outcomes["SER_B"] is None
+
+    def test_gives_up_after_cap_on_silent_cdc(self, monkeypatch, tmp_path):
+        import picohost.flash_picos as fp
+
+        self._patch_quiet(monkeypatch, fp)
+        monkeypatch.setattr(
+            fp, "find_pico_ports", lambda: {"/dev/ttyACM6": "SER_B"}
+        )
+        monkeypatch.setattr(fp, "_find_bootsel_devices", lambda *a, **k: [])
+        reads = {"n": 0}
+
+        def always_fail(port, baud, timeout):
+            reads["n"] += 1
+            raise RuntimeError("Timed out waiting for JSON")
+
+        monkeypatch.setattr(fp, "read_json_from_serial", always_fail)
+
+        devices, outcomes = fp._reconcile_usb_stragglers(
+            {"SER_B"}, set(), tmp_path / "x.uf2", 115200
+        )
+        assert devices == []
+        assert outcomes["SER_B"] is not None
+        assert reads["n"] == fp._SWEEP_REREAD_ATTEMPTS  # capped, not 5

--- a/picohost/uv.lock
+++ b/picohost/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.6.0"
+version = "3.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include "pico/stdlib.h"
+#include "pico/bootrom.h"
 #include "hardware/gpio.h"
 #include "hardware/watchdog.h"
 #include <stdio.h>
@@ -30,6 +31,24 @@ static void init_dip_switches(void) {
         gpio_pull_up(dip_pins[i]);
     }
     sleep_ms(10); // allow switches to settle
+}
+
+// Universal command, recognised for every app (and the unknown-app
+// default) before the per-app dispatch: {"cmd":"bootsel"} reboots the
+// Pico into USB BOOTSEL so flash-picos can reflash it over USB without
+// the bussed GPIO lines. This is the no-gpio reflash trigger because
+// picotool's own reset (reboot -f / the vendor reset interface) is
+// unreliable on long-running boards on the observatory hub.
+static bool is_bootsel_command(const char *line) {
+    cJSON *root = cJSON_Parse(line);
+    if (!root) {
+        return false;
+    }
+    cJSON *cmd = cJSON_GetObjectItem(root, "cmd");
+    bool match = cJSON_IsString(cmd) && cmd->valuestring != NULL &&
+                 strcmp(cmd->valuestring, "bootsel") == 0;
+    cJSON_Delete(root);
+    return match;
 }
 
 // Initialize LED GPIO
@@ -77,6 +96,13 @@ int main(void) {
             if (c == '\n') {
                 line[index] = '\0';
                 index = 0;
+                // Universal bootsel command: enter USB BOOTSEL for a
+                // no-gpio reflash. Checked before the per-app dispatch
+                // so it works regardless of app_id. reset_usb_boot()
+                // does not return.
+                if (is_bootsel_command(line)) {
+                    reset_usb_boot(0, 0);
+                }
                 // Dispatch command to appropriate app
                 switch (app_id) {
                     case APP_MOTOR: motor_server(app_id, line); break;


### PR DESCRIPTION
…efault

The USB per-device (`--no-gpio`) flash path relied on `picotool reboot -f` to enter BOOTSEL, but that USB software reset is unreliable on long-running RP2350 boards on the observatory hub: picotool ACKs the reset but the board never resets (reproduced 15/15 and 10/10 on two boards on .11). It is an uptime degradation — the same board honors the reset right after a fresh boot — independent of picomanager, discovery, and readback.

Firmware (src/main.c): add a universal {"cmd":"bootsel"} command, handled before app dispatch, that calls reset_usb_boot(0,0) from the main loop. flash-picos sends it over the (working) CDC data path to trigger BOOTSEL reliably, instead of trusting picotool's vendor reset interface.

Host (flash_picos):
- trigger BOOTSEL via the CDC command first (new _serial_writer child), falling back to `picotool reboot -f` for boards on older firmware
- settle the CDC device set before flashing (no single-snapshot misses)
- recover boards already stranded in BOOTSEL from a prior aborted run
- per-serial reconciliation report naming any board that flashed but did not report device info (and why)
- --expected N (default 7 = fleet size, bypassed when targeting one board) prints a loud WARNING — not a failure — on an under-count
- make the USB path the DEFAULT; opt into the GPIO mass-BOOTSEL flow with --gpio (previously the USB path was the --no-gpio opt-out)

Validated end-to-end on hardware (fresh board: {"cmd":"bootsel"} dropped it into BOOTSEL). Whether the command survives the same uptime degradation on an aged board is the open verification gate.