### PR TITLE
fix(potmon): read az pot from GP26/ADC0 (the pin it's actually wired to)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Azimuth potentiometer for position feedback, read via the RP2350 ADC:
 
 | Channel | GPIO | ADC Channel | JSON Key |
 |---------|------|-------------|----------|
-| **AZ** (azimuth) | 27 | 1 | `pot_az_voltage` |
+| **AZ** (azimuth) | 26 | 0 | `pot_az_voltage` |
 
 ### IMU Wiring (APP_IMU_EL / APP_IMU_AZ)
 

--- a/src/potmon.h
+++ b/src/potmon.h
@@ -6,9 +6,9 @@
 #include "hardware/adc.h"
 #include "eigsep_command.h"
 
-#define POTMON_ADC_CH_AZ        1
+#define POTMON_ADC_CH_AZ        0
 
-#define POTMON_GPIO_AZ          27
+#define POTMON_GPIO_AZ          26
 
 #define POTMON_ADC_BITS         12
 #define POTMON_ADC_MAX          ((1 << POTMON_ADC_BITS) - 1)


### PR DESCRIPTION
## Problem

The azimuth pot read **~0.7 V drifting regardless of knob position** — the textbook signature of a floating ADC input. Reproduced live on `eigsep@10.10.10.11`.

## Root cause

The pot is **physically wired to GP26 / ADC channel 0 (pin 31)**, but the firmware reads **GP27 / ADC1 (pin 32)** — an unconnected pin that floats at ~0.7 V.

Commit `400e002` ("drop el channel, read az only") assumed `az` was on GP27 and dropped the GP26/CH0 "el" channel — but **that was the live channel**. It kept the floating pin and deleted the connected one.

## Evidence (two-channel diagnostic build, 30 s sweep)

| Channel | Pin | min | max | range |
|---------|-----|-----|-----|-------|
| **GP26 / CH0** | 31 | 0.001 V | 3.300 V | **3.299 V** ✅ full sweep |
| GP27 / CH1 | 32 | 0.664 V | 1.035 V | 0.371 V (floating) |

## Fix

Point `POTMON_ADC_CH_AZ` / `POTMON_GPIO_AZ` at CH0 / GP26. The single-channel design and the `pot_az_voltage` key are unchanged, so host / emulator / tests are unaffected. README wiring table updated to match.

## Verification

Built and flashed to the bench Pico: schema correct (single channel, no phantom field), and `pot_az_voltage` reads the real pot (railed 3.300 V at the end-stop where the diagnostic left it; floating inputs can't do that).

## ⚠️ Deploy note

This makes **all** potmon units read GP26. Correct if every azimuth-pot Pico is wired like this bench — confirm no field unit is genuinely on GP27 before rolling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)