### PR TITLE
feat: whole-system current monitor (ACS724 on lidar Pico GP26/ADC0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(pico_multi
     src/temp_simple.c
     src/imu.c
     src/lidar.c
+    src/currentmon.c
 )
 
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,29 @@ Two BNO08x IMUs in UART RVC mode, one per axis. Each runs on a separate Pico wit
 | 3 | `imu_el` | Elevation |
 | 6 | `imu_az` | Azimuth |
 
+### System Current Monitor Wiring (co-located on the APP_LIDAR Pico)
+
+A whole-system current monitor (ACS724-10AB, bidirectional, 200 mV/A) sampled on the lidar Pico — lidar is I2C-only, so the sensor is the sole occupant of that Pico's ADC mux (no `adc_select_input` swapping, no potmon-style crosstalk). It publishes to Redis under `metadata['system_current']` (never names "lidar").
+
+| Signal | GPIO | ADC Channel | JSON Key |
+|--------|------|-------------|----------|
+| Current sense | **26** | **0** | `current_voltage` (raw ADC volts) → host derives `current_a` |
+
+The ACS724 OUT pin feeds GP26 through a resistive divider that keeps the 5 V sensor under the 3.3 V ADC ceiling:
+
+```
+ACS724 OUT ──[ R1 = 3.3 kΩ ]──┬── GP26 (ADC0)
+                              │
+                          [ R2 = 4.7 kΩ ]   to GND
+                              │
+                             GND
+```
+
+- Divider ratio `k = R2/(R1+R2) = 4.7/(3.3+4.7) = 0.5875`. Maps `0 A → 1.47 V`, `10 A → 2.64 V` at the ADC pin.
+- Zero point `Vq = 2.5 V` (Vcc/2, bidirectional); sensitivity `S = 0.2 V/A`. Host conversion: `I = (V_adc/k − Vq)/S` (`PicoLidar` in `picohost/src/picohost/base.py`).
+- Wire `IP+ → IP−` so output rises **above** 2.5 V (forward half); if reversed, flip the sign in the conversion.
+- No decoupling capacitor is currently fitted. An optional 100 nF from GP26 to GND would anti-alias ACS724 noise if a reading proves jittery, but it is not required.
+
 ## 5. Install Python Host Library (Optional)
 
 For controlling devices from a host computer:

--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -29,6 +29,7 @@ flash-picos = "picohost.flash_picos:main"
 flash-test = "picohost.flash_test:main"
 pico-manager = "picohost.manager:main"
 calibrate-pot = "picohost.calibrate_pot:main"
+calibrate-current = "picohost.calibrate_current:main"
 picohost-resolve = "picohost.resolve:main"
 pico-gpio = "picohost.gpio:main"
 

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -853,20 +853,63 @@ class PicoLidar(PicoDevice):
     """
 
     # ACS724-10AB (bidirectional, Vcc/2 zero point, 200 mV/A) read through a
-    # 3.3k (top) / 4.7k (bottom) divider into GP26. Nominal conversion only;
-    # a measured zero-offset calibration is deferred (see design doc).
+    # 3.3k (top) / 4.7k (bottom) divider into GP26. These constants give the
+    # nominal transfer function used until a measured calibration is uploaded.
     _DIVIDER_RATIO = 4.7 / (3.3 + 4.7)   # = 0.5875
     _SENSOR_VQ = 2.5                     # volts at 0 A (Vcc/2)
     _SENSOR_SENSITIVITY = 0.2            # volts per amp
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, current_cal_store=None, **kwargs):
+        """
+        Parameters
+        ----------
+        current_cal_store : picohost.buses.CurrentCalStore, optional
+            Redis-backed two-point current calibration. When provided and
+            the store holds a cal, ``(V0, slope)`` is applied before the
+            first status tick, so a rebooted lidar Pico comes up calibrated
+            from Redis. Falls back to the nominal transfer function when
+            absent. Other args/kwargs pass through to :class:`PicoDevice`.
+        """
+        # (V0, slope) at the ADC pin: I = (V_adc - V0) / slope. None ⇒
+        # nominal conversion. Set before super().__init__ so the handler
+        # never sees an undefined attribute.
+        self._current_cal = None
         super().__init__(*args, **kwargs)
+        if current_cal_store is not None:
+            cal = current_cal_store.get()
+            if cal is not None and "system_current" in cal:
+                self._current_cal = tuple(cal["system_current"])
         if self.redis_handler is not None:
             self._base_redis_handler = self.redis_handler
             self.redis_handler = self._lidar_redis_handler
 
+    @property
+    def is_current_calibrated(self):
+        """True when a measured two-point current cal is loaded."""
+        return self._current_cal is not None
+
+    def set_calibration(self, system_current_params=None):
+        """Set the two-point current calibration.
+
+        Parameters
+        ----------
+        system_current_params : sequence of (float, float), optional
+            ``(V0, slope)`` such that ``I = (V_adc - V0) / slope``.
+            ``calibrate-current`` pushes this to the running device so a new
+            cal takes effect on the next status tick without a restart.
+        """
+        if system_current_params is not None:
+            self._current_cal = tuple(system_current_params)
+
     def _v_to_current(self, v_adc):
-        """Convert the raw ADC-pin voltage to amps (nominal, no zero cal)."""
+        """Convert the raw ADC-pin voltage to amps.
+
+        Uses the measured two-point cal ``(V0, slope)`` when one is loaded,
+        otherwise the nominal ACS724 + divider transfer function.
+        """
+        if self._current_cal is not None:
+            v0, slope = self._current_cal
+            return (v_adc - v0) / slope
         v_sensor = v_adc / self._DIVIDER_RATIO
         return (v_sensor - self._SENSOR_VQ) / self._SENSOR_SENSITIVITY
 

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -874,6 +874,10 @@ class PicoLidar(PicoDevice):
         # nominal conversion. Set before super().__init__ so the handler
         # never sees an undefined attribute.
         self._current_cal = None
+        # Warn-once latch: trips if a lidar status line ever arrives without
+        # current_voltage (firmware field renamed/dropped → system_current
+        # silently goes stale). Set before super().__init__ for the same reason.
+        self._warned_no_current = False
         super().__init__(*args, **kwargs)
         if current_cal_store is not None:
             cal = current_cal_store.get()
@@ -933,6 +937,15 @@ class PicoLidar(PicoDevice):
                     "current_voltage": v,
                     "current_a": self._v_to_current(v),
                 }
+            )
+        elif data.get("sensor_name") == "lidar" and not self._warned_no_current:
+            # The firmware↔host contract for current rides on this field name.
+            # If it vanishes, system_current stops updating with no other
+            # symptom — surface it once rather than failing silently.
+            self._warned_no_current = True
+            self.logger.warning(
+                "lidar status line missing 'current_voltage'; system_current "
+                "will go stale. Firmware field renamed or dropped?"
             )
 
 

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -857,8 +857,8 @@ class PicoLidar(PicoDevice):
     # These constants give the nominal transfer function used until a measured
     # calibration is uploaded.
     _DIVIDER_RATIO = 4.64 / (3.32 + 4.64)  # = 0.5829 (measured)
-    _SENSOR_VQ = 2.5                     # volts at 0 A (Vcc/2)
-    _SENSOR_SENSITIVITY = 0.2            # volts per amp
+    _SENSOR_VQ = 2.5  # volts at 0 A (Vcc/2)
+    _SENSOR_SENSITIVITY = 0.2  # volts per amp
 
     def __init__(self, *args, current_cal_store=None, **kwargs):
         """
@@ -939,7 +939,9 @@ class PicoLidar(PicoDevice):
                     "current_a": self._v_to_current(v),
                 }
             )
-        elif data.get("sensor_name") == "lidar" and not self._warned_no_current:
+        elif (
+            data.get("sensor_name") == "lidar" and not self._warned_no_current
+        ):
             # The firmware↔host contract for current rides on this field name.
             # If it vanishes, system_current stops updating with no other
             # symptom — surface it once rather than failing silently.

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -844,7 +844,7 @@ class PicoIMU(PicoDevice):
 class PicoLidar(PicoDevice):
     """Lidar distance sensor; also hosts the whole-system current monitor.
 
-    The lidar Pico carries an ACS724 current sensor on GP28/ADC2 (it uses no
+    The lidar Pico carries an ACS724 current sensor on GP26/ADC0 (it uses no
     other ADC). The firmware merges the raw ``current_voltage`` into the lidar
     status line; this class fans that out into a separate
     ``metadata['system_current']`` entry so the user-facing key never names
@@ -853,7 +853,7 @@ class PicoLidar(PicoDevice):
     """
 
     # ACS724-10AB (bidirectional, Vcc/2 zero point, 200 mV/A) read through a
-    # 3.3k (top) / 4.7k (bottom) divider into GP28. Nominal conversion only;
+    # 3.3k (top) / 4.7k (bottom) divider into GP26. Nominal conversion only;
     # a measured zero-offset calibration is deferred (see design doc).
     _DIVIDER_RATIO = 4.7 / (3.3 + 4.7)   # = 0.5875
     _SENSOR_VQ = 2.5                     # volts at 0 A (Vcc/2)

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -853,9 +853,10 @@ class PicoLidar(PicoDevice):
     """
 
     # ACS724-10AB (bidirectional, Vcc/2 zero point, 200 mV/A) read through a
-    # 3.3k (top) / 4.7k (bottom) divider into GP26. These constants give the
-    # nominal transfer function used until a measured calibration is uploaded.
-    _DIVIDER_RATIO = 4.7 / (3.3 + 4.7)   # = 0.5875
+    # 3.32k (top) / 4.64k (bottom) divider into GP26 (DMM-measured values).
+    # These constants give the nominal transfer function used until a measured
+    # calibration is uploaded.
+    _DIVIDER_RATIO = 4.64 / (3.32 + 4.64)  # = 0.5829 (measured)
     _SENSOR_VQ = 2.5                     # volts at 0 A (Vcc/2)
     _SENSOR_SENSITIVITY = 0.2            # volts per amp
 

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -842,9 +842,55 @@ class PicoIMU(PicoDevice):
 
 
 class PicoLidar(PicoDevice):
-    """Specialized class for lidar distance sensor devices."""
+    """Lidar distance sensor; also hosts the whole-system current monitor.
 
-    pass
+    The lidar Pico carries an ACS724 current sensor on GP28/ADC2 (it uses no
+    other ADC). The firmware merges the raw ``current_voltage`` into the lidar
+    status line; this class fans that out into a separate
+    ``metadata['system_current']`` entry so the user-facing key never names
+    lidar. The publish stays additive (raw ``current_voltage`` + derived
+    ``current_a``) and scalar-only.
+    """
+
+    # ACS724-10AB (bidirectional, Vcc/2 zero point, 200 mV/A) read through a
+    # 3.3k (top) / 4.7k (bottom) divider into GP28. Nominal conversion only;
+    # a measured zero-offset calibration is deferred (see design doc).
+    _DIVIDER_RATIO = 4.7 / (3.3 + 4.7)   # = 0.5875
+    _SENSOR_VQ = 2.5                     # volts at 0 A (Vcc/2)
+    _SENSOR_SENSITIVITY = 0.2            # volts per amp
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.redis_handler is not None:
+            self._base_redis_handler = self.redis_handler
+            self.redis_handler = self._lidar_redis_handler
+
+    def _v_to_current(self, v_adc):
+        """Convert the raw ADC-pin voltage to amps (nominal, no zero cal)."""
+        v_sensor = v_adc / self._DIVIDER_RATIO
+        return (v_sensor - self._SENSOR_VQ) / self._SENSOR_SENSITIVITY
+
+    def _lidar_redis_handler(self, data):
+        """Split the merged lidar line into two metadata keys.
+
+        ``metadata['lidar']`` keeps the distance reading (current stripped);
+        ``metadata['system_current']`` carries the current. The current
+        entry's status is hard-set to ``"update"`` — the ADC read is
+        independent of lidar's I2C result, so a lidar failure must not mark
+        the current reading errored.
+        """
+        data = data.copy()
+        v = data.pop("current_voltage", None)
+        self._base_redis_handler(data)
+        if v is not None:
+            self._base_redis_handler(
+                {
+                    "sensor_name": "system_current",
+                    "status": "update",
+                    "current_voltage": v,
+                    "current_a": self._v_to_current(v),
+                }
+            )
 
 
 class PicoPotentiometer(PicoDevice):

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -45,6 +45,7 @@ import logging
 from eigsep_redis import SingleStreamReader, SingleStreamWriter
 
 from .keys import (
+    CURRENT_CAL_KEY,
     MOTOR_POS_KEY,
     PICO_CMD_STREAM,
     PICO_CONFIG_KEY,
@@ -176,6 +177,67 @@ class PotCalStore:
     def clear(self):
         """Delete the stored calibration."""
         self.transport.r.delete(POT_CAL_KEY)
+
+
+class CurrentCalStore:
+    """
+    Persistent single-key store for the whole-system current monitor.
+
+    The value under :data:`CURRENT_CAL_KEY` is a JSON object shaped like
+    ``{"system_current": [V0, slope], "metadata": {...},
+    "upload_time": ...}`` — the canonical ``upload_time`` field is injected
+    by :meth:`Transport.upload_dict` at the top level. ``system_current`` is
+    the two-point calibration: ``V0`` is the raw ADC voltage at 0 A and
+    ``slope`` is V/A *at the ADC pin* (it absorbs both the divider ratio and
+    the ACS724 sensitivity), so ``I = (V_adc - V0) / slope``.
+
+    ``calibrate-current`` uploads after each calibration run. A fresh
+    :class:`picohost.PicoLidar` reads this store at ``__init__`` time when
+    given a :class:`CurrentCalStore` and applies the cal before the first
+    status tick — so the lidar Pico hosting the current sensor comes up
+    calibrated from Redis after a reboot, with no on-disk file.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload(self, cal):
+        """Upload calibration parameters.
+
+        Parameters
+        ----------
+        cal : dict
+            Must carry a ``system_current`` entry, a ``(V0, slope)`` pair
+            (list or tuple). Extra fields (e.g. ``metadata``) are preserved
+            verbatim.
+        """
+        self.transport.upload_dict(cal, CURRENT_CAL_KEY)
+
+    def get(self):
+        """Return the stored calibration dict.
+
+        Returns
+        -------
+        dict or None
+            ``None`` if no calibration has been uploaded, or if the stored
+            JSON fails to decode. The caller falls back to the nominal
+            transfer function.
+        """
+        raw = self.transport.get_raw(CURRENT_CAL_KEY)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Corrupted {CURRENT_CAL_KEY} in Redis ({e}); "
+                "falling back to nominal current conversion."
+            )
+            return None
+
+    def clear(self):
+        """Delete the stored calibration."""
+        self.transport.r.delete(CURRENT_CAL_KEY)
 
 
 class MotorPositionStore:

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -1,0 +1,249 @@
+"""
+Manual whole-system current-monitor calibration entry point.
+
+Reads raw ADC voltages from the running PicoManager's metadata stream
+(``stream:system_current``, produced by the current sensor on the lidar
+Pico), walks the user through a **two-point** calibration, and publishes
+the fit to two places:
+
+  1. :class:`picohost.buses.CurrentCalStore` — canonical Redis store, so a
+     rebooted :class:`picohost.PicoLidar` picks the cal up at ``__init__``
+     time. Followed by a ``BGSAVE`` to fsync the RDB snapshot, since the
+     default ``save 3600 1`` policy would otherwise leave a single-key
+     write unsnapshotted for up to an hour.
+  2. The running lidar device via :class:`picohost.proxy.PicoProxy`
+     (``set_calibration``) — the new cal takes effect on the next status
+     tick without restarting the manager.
+
+The two-point fit folds both the ACS724's untrimmed zero offset and the
+divider/resistor tolerance into a single measured ``(V0, slope)`` at the
+ADC pin, so ``I = (V_adc - V0) / slope`` — no reliance on nominal resistor
+values. Point 1 is the system at 0 A (load off); point 2 is a known
+reference current read from an inline ammeter.
+
+Requires PicoManager to be running and the ``lidar`` device healthy. The
+script never touches the serial port itself, so it can be invoked
+alongside the manager.
+
+Usage:
+    calibrate-current
+    calibrate-current --n-samples 20
+"""
+
+from argparse import ArgumentParser
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+
+import numpy as np
+from eigsep_redis import Transport
+
+from .buses import CurrentCalStore
+from .proxy import PicoProxy
+
+logger = logging.getLogger(__name__)
+
+# The current sensor is hosted on the lidar Pico, so commands target the
+# "lidar" device; its raw current voltage is published to a clean,
+# app-agnostic stream that never names lidar.
+LIDAR_NAME = "lidar"
+CURRENT_STREAM = "stream:system_current"
+# Producer cadence is 200 ms (STATUS_CADENCE_MS), so a 5 s budget per
+# entry is ~25x — long enough to ride out a single reconnect blip but
+# short enough to fail fast when the manager isn't actually publishing.
+SAMPLE_TIMEOUT_S = 5.0
+# Nominal slope at the ADC pin (S * k = 0.2 * 0.5875). A measured slope
+# wildly off this hints at reversed sensor wiring or a wrong reference
+# current — warn, but don't refuse (the operator may know better).
+_NOMINAL_SLOPE = 0.2 * (4.7 / (3.3 + 4.7))
+
+
+def collect_samples(transport, n):
+    """Average ``n`` consecutive ``current_voltage`` entries from the stream.
+
+    Reads only entries published after this call starts (``$``), so
+    repeated calls within one calibration sweep don't double-count the
+    same firmware tick.
+    """
+    samples = []
+    last_id = "$"
+    while len(samples) < n:
+        remaining = n - len(samples)
+        resp = transport.r.xread(
+            {CURRENT_STREAM: last_id},
+            block=int(SAMPLE_TIMEOUT_S * 1000),
+            count=remaining,
+        )
+        if not resp:
+            raise RuntimeError(
+                f"No new entries on {CURRENT_STREAM} within "
+                f"{SAMPLE_TIMEOUT_S}s. Is PicoManager publishing?"
+            )
+        _stream, messages = resp[0]
+        for msg_id, fields in messages:
+            value = json.loads(fields[b"value"])
+            samples.append(value["current_voltage"])
+            last_id = msg_id
+    return float(np.mean(samples))
+
+
+def compute_two_point(v0, v1, i_ref):
+    """Compute ``(V0, slope)`` for ``I = (V_adc - V0) / slope``.
+
+    ``v0`` is the raw ADC voltage at 0 A, ``v1`` at the known reference
+    current ``i_ref``. The slope absorbs the divider ratio and the sensor
+    sensitivity. Returns ``None`` (and prints why) when the inputs can't
+    define a gain.
+    """
+    if abs(i_ref) < 1e-9:
+        print("  ERROR: reference current is 0 A. Cannot fit a slope.")
+        return None
+    if abs(v1 - v0) < 1e-6:
+        print(
+            f"  ERROR: the two voltages are identical ({v0:.4f} V). "
+            "No swing to fit a slope — check the reference load."
+        )
+        return None
+    slope = (v1 - v0) / i_ref
+    if slope < 0:
+        print(
+            f"  WARNING: negative slope ({slope:.4f} V/A) — the sensor "
+            "output dropped under load. Wire IP+ -> IP- so it rises, or "
+            "flip the reference-current sign."
+        )
+    elif not (0.5 * _NOMINAL_SLOPE <= slope <= 2.0 * _NOMINAL_SLOPE):
+        print(
+            f"  WARNING: slope {slope:.4f} V/A is far from nominal "
+            f"{_NOMINAL_SLOPE:.4f} V/A — double-check the reference current."
+        )
+    return (float(v0), float(slope))
+
+
+def collect_two_point(transport, n_samples):
+    """Collect the 0 A point and one known-reference-current point."""
+    input(
+        "\nDisconnect/disable the load so the system draws 0 A, "
+        "then press Enter."
+    )
+    print("  averaging samples...")
+    v0 = collect_samples(transport, n_samples)
+    print(f"  0 A voltage: {v0:.4f} V")
+
+    raw = input(
+        "\nApply a known load and enter the measured current in amps "
+        "(from an inline reference ammeter): "
+    )
+    try:
+        i_ref = float(raw)
+    except ValueError:
+        raise RuntimeError(f"'{raw}' is not a number.")
+    print("  averaging samples...")
+    v1 = collect_samples(transport, n_samples)
+    print(f"  {i_ref:.4f} A voltage: {v1:.4f} V")
+
+    return v0, v1, i_ref
+
+
+def main():
+    parser = ArgumentParser(
+        description="Calibrate the whole-system current monitor (two-point).",
+    )
+    parser.add_argument(
+        "-n",
+        "--n-samples",
+        type=int,
+        default=10,
+        help=(
+            "Number of voltage samples to average at each point "
+            "(default: 10, ~2 s at the 200 ms producer cadence)"
+        ),
+    )
+    parser.add_argument(
+        "--redis-host",
+        default="localhost",
+        help="Redis host for the running PicoManager",
+    )
+    parser.add_argument(
+        "--redis-port",
+        type=int,
+        default=6379,
+        help="Redis port for the running PicoManager",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    transport = Transport(host=args.redis_host, port=args.redis_port)
+    lidar_proxy = PicoProxy(LIDAR_NAME, transport, source="calibrate-current")
+
+    if not lidar_proxy.is_available:
+        print(
+            f"{LIDAR_NAME} is not reachable via PicoManager. "
+            "Start the manager and confirm the lidar Pico is enumerated.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(
+        f"Two-point current calibration ({args.n_samples} samples/point).\n"
+        f"Reading voltages from {CURRENT_STREAM}."
+    )
+
+    try:
+        v0, v1, i_ref = collect_two_point(transport, args.n_samples)
+    except (RuntimeError, ConnectionError) as exc:
+        print(f"Calibration sample collection failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    cal = compute_two_point(v0, v1, i_ref)
+    if cal is None:
+        print("\nCalibration failed. Exiting.", file=sys.stderr)
+        sys.exit(1)
+
+    cal_data = {
+        "system_current": list(cal),
+        "metadata": {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "v0": float(v0),
+            "v1": float(v1),
+            "i_ref": float(i_ref),
+            "n_samples": args.n_samples,
+        },
+    }
+
+    # Persist to Redis first — if the live push later fails, the cal is
+    # still stored and will load on the next PicoManager restart.
+    CurrentCalStore(transport).upload(cal_data)
+    # Force an RDB snapshot now so the cal survives a power loss before
+    # the next scheduled save (default policy is `save 3600 1`).
+    transport.r.bgsave()
+    print(
+        f"\nPublished calibration to Redis at "
+        f"{args.redis_host}:{args.redis_port} (key: current_calibration); "
+        "BGSAVE triggered."
+    )
+
+    # Push to the running PicoLidar so the new cal takes effect on the
+    # next status tick.
+    try:
+        lidar_proxy.send_command(
+            "set_calibration",
+            system_current_params=list(cal),
+        )
+        print("Live PicoLidar updated with new calibration.")
+    except (TimeoutError, RuntimeError) as e:
+        print(
+            f"Live cal push failed: {e}\n"
+            "Calibration is stored in Redis; restart PicoManager to apply.",
+            file=sys.stderr,
+        )
+
+    print(f"  system_current: I = (V_adc - {cal[0]:.4f}) / {cal[1]:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -26,7 +26,9 @@ script never touches the serial port itself, so it can be invoked
 alongside the manager.
 
 Usage:
-    calibrate-current
+    calibrate-current                      # two-point (default)
+    calibrate-current --mode multi         # N-point, loop until done
+    calibrate-current --currents 0,1,2,5,8 # N-point preset sweep
     calibrate-current --n-samples 20
 """
 
@@ -106,6 +108,16 @@ def compute_two_point(v0, v1, i_ref):
         )
         return None
     slope = (v1 - v0) / i_ref
+    _warn_on_slope(slope)
+    return (float(v0), float(slope))
+
+
+def _warn_on_slope(slope):
+    """Print a heuristic warning when the fitted slope looks wrong.
+
+    Shared by the two-point and multi-point fits. Never raises and never
+    blocks — the operator may legitimately know better.
+    """
     if slope < 0:
         print(
             f"  WARNING: negative slope ({slope:.4f} V/A) — the sensor "
@@ -117,7 +129,64 @@ def compute_two_point(v0, v1, i_ref):
             f"  WARNING: slope {slope:.4f} V/A is far from nominal "
             f"{_NOMINAL_SLOPE:.4f} V/A — double-check the reference current."
         )
-    return (float(v0), float(slope))
+
+
+def _parse_currents(raw):
+    """Parse a comma-separated current list like ``'0,1,2,5,8'`` to floats."""
+    return [float(x) for x in raw.split(",") if x.strip() != ""]
+
+
+def _residual_threshold_a(currents):
+    """Acceptable fit residual (A): 20 mA floor, or 2% of the max current."""
+    max_current = max((abs(c) for c in currents), default=0.0)
+    return max(0.020, 0.02 * max_current)
+
+
+def compute_multi_point(currents, voltages):
+    """Least-squares ``(V0, slope)`` fit of ``V_adc = slope * I + V0``.
+
+    Parameters
+    ----------
+    currents : sequence of float
+        Known reference currents (A) at each calibration point.
+    voltages : sequence of float
+        Averaged raw ADC-pin voltage (V) at each point.
+
+    Returns
+    -------
+    tuple or None
+        ``((V0, slope), quality)`` where ``quality`` is a dict with
+        ``residual_rms_v``, ``residual_rms_a`` and ``r_squared``; or
+        ``None`` (with a printed reason) when the points cannot define a
+        gain. Downstream conversion is ``I = (V_adc - V0) / slope``.
+    """
+    currents = np.asarray(currents, dtype=float)
+    voltages = np.asarray(voltages, dtype=float)
+    if np.unique(currents).size < 2:
+        print("  ERROR: need at least 2 distinct reference currents to fit.")
+        return None
+    if np.ptp(voltages) < 1e-6:
+        print(
+            f"  ERROR: voltage spread < 1 uV ({voltages.min():.4f} V). "
+            "No swing to fit a slope — check the reference loads."
+        )
+        return None
+    slope, v0 = np.polyfit(currents, voltages, 1)
+    residuals = voltages - (slope * currents + v0)
+    residual_rms_v = float(np.sqrt(np.mean(residuals ** 2)))
+    ss_res = float(np.sum(residuals ** 2))
+    ss_tot = float(np.sum((voltages - voltages.mean()) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    residual_rms_a = (
+        abs(residual_rms_v / slope) if slope != 0 else float("inf")
+    )
+    _warn_on_slope(slope)
+    quality = {
+        "residual_rms_v": residual_rms_v,
+        "residual_rms_a": residual_rms_a,
+        "r_squared": r_squared,
+    }
+    return ((float(v0), float(slope)), quality)
 
 
 def collect_two_point(transport, n_samples):
@@ -145,9 +214,96 @@ def collect_two_point(transport, n_samples):
     return v0, v1, i_ref
 
 
+def collect_multi_point(transport, n_samples, currents=None):
+    """Collect ``(currents, voltages)`` for a multi-point calibration.
+
+    With ``currents`` given, walk that preset list, prompting at each
+    target (blank Enter accepts the target as the reading). Otherwise loop
+    until the operator enters a blank line, requiring at least 3 points.
+    Each point averages ``n_samples`` ADC voltages via ``collect_samples``.
+    """
+    measured_currents = []
+    voltages = []
+
+    if currents is not None:
+        for target in currents:
+            raw = input(
+                f"\nDial load to ~{target:g} A; enter measured current "
+                f"[{target:g}]: "
+            ).strip()
+            i_ref = target if raw == "" else float(raw)
+            print("  averaging samples...")
+            v = collect_samples(transport, n_samples)
+            print(f"  {i_ref:.4f} A: {v:.4f} V")
+            measured_currents.append(float(i_ref))
+            voltages.append(v)
+        return measured_currents, voltages
+
+    print(
+        "\nEnter the measured current (A) at each point; blank line when "
+        "done (need >= 3 points). Include a 0 A point (load off)."
+    )
+    while True:
+        raw = input(
+            f"\nPoint {len(measured_currents) + 1} current [A] "
+            "(blank to finish): "
+        ).strip()
+        if raw == "":
+            if len(measured_currents) >= 3:
+                break
+            print(
+                f"  need >= 3 points, have {len(measured_currents)}; "
+                "keep going."
+            )
+            continue
+        try:
+            i_ref = float(raw)
+        except ValueError:
+            print(f"  '{raw}' is not a number; try again.")
+            continue
+        print("  averaging samples...")
+        v = collect_samples(transport, n_samples)
+        print(f"  {i_ref:.4f} A: {v:.4f} V")
+        measured_currents.append(i_ref)
+        voltages.append(v)
+
+    return measured_currents, voltages
+
+
+def _print_point_table(currents, voltages, cal):
+    """Print a per-point I / V / residual table so a bad point is obvious."""
+    v0, slope = cal
+    print("\n  point  I_ref [A]  V_adc [V]  resid [mV]  resid [mA]")
+    for idx, (i, v) in enumerate(zip(currents, voltages), start=1):
+        fit_v = slope * i + v0
+        dv = v - fit_v
+        di = dv / slope if slope else float("inf")
+        print(
+            f"  {idx:>5}{i:11.4f}{v:11.4f}{dv * 1e3:12.2f}{di * 1e3:12.2f}"
+        )
+
+
+def _build_multi_cal_data(cal, n_samples, currents, voltages, quality):
+    """Assemble the Redis payload (system_current + metadata) for multi mode."""
+    return {
+        "system_current": list(cal),
+        "metadata": {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "mode": "multi",
+            "n_samples": n_samples,
+            "n_points": len(currents),
+            "currents": [float(c) for c in currents],
+            "voltages": [float(v) for v in voltages],
+            "residual_rms_v": quality["residual_rms_v"],
+            "residual_rms_a": quality["residual_rms_a"],
+            "r_squared": quality["r_squared"],
+        },
+    }
+
+
 def main():
     parser = ArgumentParser(
-        description="Calibrate the whole-system current monitor (two-point).",
+        description="Calibrate the whole-system current monitor.",
     )
     parser.add_argument(
         "-n",
@@ -157,6 +313,24 @@ def main():
         help=(
             "Number of voltage samples to average at each point "
             "(default: 10, ~2 s at the 200 ms producer cadence)"
+        ),
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        choices=["two-point", "multi"],
+        default="two-point",
+        help=(
+            "Calibration mode: 'two-point' (default) for the 0 A + one "
+            "reference flow, 'multi' for an N-point least-squares fit."
+        ),
+    )
+    parser.add_argument(
+        "--currents",
+        default=None,
+        help=(
+            "Comma-separated known currents (A) for a preset multi-point "
+            "sweep, e.g. '0,1,2,5,8'. Implies --mode multi (>= 3 points)."
         ),
     )
     parser.add_argument(
@@ -177,6 +351,9 @@ def main():
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
+    preset = _parse_currents(args.currents) if args.currents else None
+    mode = "multi" if preset is not None else args.mode
+
     transport = Transport(host=args.redis_host, port=args.redis_port)
     lidar_proxy = PicoProxy(LIDAR_NAME, transport, source="calibrate-current")
 
@@ -189,31 +366,70 @@ def main():
         sys.exit(1)
 
     print(
-        f"Two-point current calibration ({args.n_samples} samples/point).\n"
+        f"{mode} current calibration ({args.n_samples} samples/point).\n"
         f"Reading voltages from {CURRENT_STREAM}."
     )
 
     try:
-        v0, v1, i_ref = collect_two_point(transport, args.n_samples)
+        if mode == "multi":
+            if preset is not None and len(preset) < 3:
+                print(
+                    "--currents needs >= 3 points for a multi-point fit.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            currents, voltages = collect_multi_point(
+                transport, args.n_samples, preset
+            )
+        else:
+            v0, v1, i_ref = collect_two_point(transport, args.n_samples)
     except (RuntimeError, ConnectionError) as exc:
         print(f"Calibration sample collection failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    cal = compute_two_point(v0, v1, i_ref)
-    if cal is None:
-        print("\nCalibration failed. Exiting.", file=sys.stderr)
-        sys.exit(1)
-
-    cal_data = {
-        "system_current": list(cal),
-        "metadata": {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "v0": float(v0),
-            "v1": float(v1),
-            "i_ref": float(i_ref),
-            "n_samples": args.n_samples,
-        },
-    }
+    if mode == "multi":
+        result = compute_multi_point(currents, voltages)
+        if result is None:
+            print("\nCalibration failed. Exiting.", file=sys.stderr)
+            sys.exit(1)
+        cal, quality = result
+        _print_point_table(currents, voltages, cal)
+        print(
+            f"\n  residual RMS: {quality['residual_rms_v'] * 1e3:.2f} mV "
+            f"({quality['residual_rms_a'] * 1e3:.2f} mA), "
+            f"r^2 = {quality['r_squared']:.5f}"
+        )
+        threshold = _residual_threshold_a(currents)
+        if quality["residual_rms_a"] > threshold:
+            print(
+                f"\n  WARNING: residual "
+                f"{quality['residual_rms_a'] * 1e3:.2f} mA exceeds "
+                f"{threshold * 1e3:.1f} mA — possible bad point or sensor "
+                "nonlinearity."
+            )
+            ans = input("  Store this calibration anyway? [y/N]: ").strip()
+            if ans.lower() not in ("y", "yes"):
+                print("Aborted; calibration not stored.", file=sys.stderr)
+                sys.exit(1)
+        cal_data = _build_multi_cal_data(
+            cal, args.n_samples, currents, voltages, quality
+        )
+    else:
+        cal = compute_two_point(v0, v1, i_ref)
+        if cal is None:
+            print("\nCalibration failed. Exiting.", file=sys.stderr)
+            sys.exit(1)
+        cal_data = {
+            "system_current": list(cal),
+            "metadata": {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "mode": "two-point",
+                "v0": float(v0),
+                "v1": float(v1),
+                "i_ref": float(i_ref),
+                "n_samples": args.n_samples,
+            },
+        }
 
     # Persist to Redis first — if the live push later fails, the cal is
     # still stored and will load on the next PicoManager restart.

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -173,8 +173,8 @@ def compute_multi_point(currents, voltages):
         return None
     slope, v0 = np.polyfit(currents, voltages, 1)
     residuals = voltages - (slope * currents + v0)
-    residual_rms_v = float(np.sqrt(np.mean(residuals ** 2)))
-    ss_res = float(np.sum(residuals ** 2))
+    residual_rms_v = float(np.sqrt(np.mean(residuals**2)))
+    ss_res = float(np.sum(residuals**2))
     ss_tot = float(np.sum((voltages - voltages.mean()) ** 2))
     r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
     residual_rms_a = (
@@ -286,9 +286,7 @@ def _print_point_table(currents, voltages, cal):
         fit_v = slope * i + v0
         dv = v - fit_v
         di = dv / slope if slope else float("inf")
-        print(
-            f"  {idx:>5}{i:11.4f}{v:11.4f}{dv * 1e3:12.2f}{di * 1e3:12.2f}"
-        )
+        print(f"  {idx:>5}{i:11.4f}{v:11.4f}{dv * 1e3:12.2f}{di * 1e3:12.2f}")
 
 
 def _build_multi_cal_data(cal, n_samples, currents, voltages, quality):

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -178,7 +178,7 @@ def compute_multi_point(currents, voltages):
     ss_tot = float(np.sum((voltages - voltages.mean()) ** 2))
     r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
     residual_rms_a = (
-        abs(residual_rms_v / slope) if slope != 0 else float("inf")
+        abs(residual_rms_v / float(slope)) if slope != 0 else float("inf")
     )
     _warn_on_slope(slope)
     quality = {
@@ -227,11 +227,19 @@ def collect_multi_point(transport, n_samples, currents=None):
 
     if currents is not None:
         for target in currents:
-            raw = input(
-                f"\nDial load to ~{target:g} A; enter measured current "
-                f"[{target:g}]: "
-            ).strip()
-            i_ref = target if raw == "" else float(raw)
+            while True:
+                raw = input(
+                    f"\nDial load to ~{target:g} A; enter measured current "
+                    f"[{target:g}]: "
+                ).strip()
+                if raw == "":
+                    i_ref = target
+                    break
+                try:
+                    i_ref = float(raw)
+                    break
+                except ValueError:
+                    print(f"  '{raw}' is not a number; try again.")
             print("  averaging samples...")
             v = collect_samples(transport, n_samples)
             print(f"  {i_ref:.4f} A: {v:.4f} V")

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -55,10 +55,10 @@ CURRENT_STREAM = "stream:system_current"
 # entry is ~25x — long enough to ride out a single reconnect blip but
 # short enough to fail fast when the manager isn't actually publishing.
 SAMPLE_TIMEOUT_S = 5.0
-# Nominal slope at the ADC pin (S * k = 0.2 * 0.5875). A measured slope
+# Nominal slope at the ADC pin (S * k = 0.2 * 0.5829). A measured slope
 # wildly off this hints at reversed sensor wiring or a wrong reference
 # current — warn, but don't refuse (the operator may know better).
-_NOMINAL_SLOPE = 0.2 * (4.7 / (3.3 + 4.7))
+_NOMINAL_SLOPE = 0.2 * (4.64 / (3.32 + 4.64))
 
 
 def collect_samples(transport, n):

--- a/picohost/src/picohost/emulators/lidar.py
+++ b/picohost/src/picohost/emulators/lidar.py
@@ -4,6 +4,15 @@ from .base import PicoEmulator
 
 NOISE_STDDEV = 0.01  # meters
 
+# ACS724-10AB current monitor co-located on the lidar Pico (GP28/ADC2),
+# read through a 3.3k/4.7k divider. The firmware reports the raw ADC-pin
+# voltage; emulate that for a representative whole-system current draw.
+CURRENT_VQ = 2.5                              # sensor volts at 0 A (Vcc/2)
+CURRENT_SENSITIVITY = 0.2                     # sensor volts per amp
+CURRENT_DIVIDER_RATIO = 4.7 / (3.3 + 4.7)     # = 0.5875
+CURRENT_NOISE_STDDEV = 0.002                  # volts at the ADC pin
+BASE_CURRENT_A = 2.0                          # representative system draw
+
 
 class LidarEmulator(PicoEmulator):
     """Emulates src/lidar.c firmware."""
@@ -16,6 +25,11 @@ class LidarEmulator(PicoEmulator):
         # Per-cycle freshness flag: True iff op() refreshed the
         # distance reading since the last get_status() call.
         self.last_op_ok = False
+        # Raw ADC-pin voltage the firmware would report for BASE_CURRENT_A.
+        self._base_current_v = (
+            CURRENT_VQ + CURRENT_SENSITIVITY * BASE_CURRENT_A
+        ) * CURRENT_DIVIDER_RATIO
+        self.current_voltage = self._base_current_v
         super().__init__(app_id=app_id, **kwargs)
 
     def init(self):
@@ -33,6 +47,16 @@ class LidarEmulator(PicoEmulator):
         self._sensor_failed = False
 
     def op(self):
+        # currentmon_op() runs as its own dispatch call, independent of the
+        # lidar I2C result — refresh current every cycle, even on failure.
+        self.current_voltage = float(
+            np.clip(
+                self._base_current_v
+                + np.random.normal(0, CURRENT_NOISE_STDDEV),
+                0.0,
+                3.3,
+            )
+        )
         if self._sensor_failed:
             # Matches firmware: i2c_read_timeout or dist_cm==0 → reset+return,
             # leaving previous distance unchanged and last_op_ok at False.
@@ -48,4 +72,5 @@ class LidarEmulator(PicoEmulator):
             "status": status,
             "app_id": self.app_id,
             "distance_m": self.distance,
+            "current_voltage": self.current_voltage,
         }

--- a/picohost/src/picohost/emulators/lidar.py
+++ b/picohost/src/picohost/emulators/lidar.py
@@ -5,11 +5,11 @@ from .base import PicoEmulator
 NOISE_STDDEV = 0.01  # meters
 
 # ACS724-10AB current monitor co-located on the lidar Pico (GP26/ADC0),
-# read through a 3.3k/4.7k divider. The firmware reports the raw ADC-pin
-# voltage; emulate that for a representative whole-system current draw.
+# read through a 3.32k/4.64k divider (DMM-measured). The firmware reports the
+# raw ADC-pin voltage; emulate that for a representative whole-system draw.
 CURRENT_VQ = 2.5                              # sensor volts at 0 A (Vcc/2)
 CURRENT_SENSITIVITY = 0.2                     # sensor volts per amp
-CURRENT_DIVIDER_RATIO = 4.7 / (3.3 + 4.7)     # = 0.5875
+CURRENT_DIVIDER_RATIO = 4.64 / (3.32 + 4.64)  # = 0.5829 (measured)
 CURRENT_NOISE_STDDEV = 0.002                  # volts at the ADC pin
 BASE_CURRENT_A = 2.0                          # representative system draw
 

--- a/picohost/src/picohost/emulators/lidar.py
+++ b/picohost/src/picohost/emulators/lidar.py
@@ -7,11 +7,11 @@ NOISE_STDDEV = 0.01  # meters
 # ACS724-10AB current monitor co-located on the lidar Pico (GP26/ADC0),
 # read through a 3.32k/4.64k divider (DMM-measured). The firmware reports the
 # raw ADC-pin voltage; emulate that for a representative whole-system draw.
-CURRENT_VQ = 2.5                              # sensor volts at 0 A (Vcc/2)
-CURRENT_SENSITIVITY = 0.2                     # sensor volts per amp
+CURRENT_VQ = 2.5  # sensor volts at 0 A (Vcc/2)
+CURRENT_SENSITIVITY = 0.2  # sensor volts per amp
 CURRENT_DIVIDER_RATIO = 4.64 / (3.32 + 4.64)  # = 0.5829 (measured)
-CURRENT_NOISE_STDDEV = 0.002                  # volts at the ADC pin
-BASE_CURRENT_A = 2.0                          # representative system draw
+CURRENT_NOISE_STDDEV = 0.002  # volts at the ADC pin
+BASE_CURRENT_A = 2.0  # representative system draw
 
 
 class LidarEmulator(PicoEmulator):

--- a/picohost/src/picohost/emulators/lidar.py
+++ b/picohost/src/picohost/emulators/lidar.py
@@ -4,7 +4,7 @@ from .base import PicoEmulator
 
 NOISE_STDDEV = 0.01  # meters
 
-# ACS724-10AB current monitor co-located on the lidar Pico (GP28/ADC2),
+# ACS724-10AB current monitor co-located on the lidar Pico (GP26/ADC0),
 # read through a 3.3k/4.7k divider. The firmware reports the raw ADC-pin
 # voltage; emulate that for a representative whole-system current draw.
 CURRENT_VQ = 2.5                              # sensor volts at 0 A (Vcc/2)

--- a/picohost/src/picohost/keys.py
+++ b/picohost/src/picohost/keys.py
@@ -11,6 +11,7 @@ or eigsep_observing (``stream:corr``, ``corr_config``, …).
 
 PICO_CONFIG_KEY = "pico_config"
 POT_CAL_KEY = "pot_calibration"
+CURRENT_CAL_KEY = "current_calibration"
 MOTOR_POS_KEY = "motor_position"
 PICO_CMD_STREAM = "stream:pico_cmd"
 PICO_RESP_STREAM = "stream:pico_resp"

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -52,6 +52,7 @@ from .base import (
     PicoRFSwitch,
 )
 from .buses import (
+    CurrentCalStore,
     MotorPositionStore,
     PicoClaimStore,
     PicoCmdReader,
@@ -145,6 +146,7 @@ class PicoManager:
             per-device :class:`HeartbeatWriter`,
             :class:`StatusWriter`, :class:`PicoConfigStore`,
             :class:`PotCalStore` (passed to ``PicoPotentiometer``),
+            :class:`CurrentCalStore` (passed to ``PicoLidar``),
             :class:`PicoCmdReader`, :class:`PicoRespWriter`, and
             :class:`PicoClaimStore`.
         """
@@ -154,6 +156,7 @@ class PicoManager:
         self._metadata_writer = MetadataWriter(transport)
         self._config_store = PicoConfigStore(transport)
         self._pot_cal_store = PotCalStore(transport)
+        self._current_cal_store = CurrentCalStore(transport)
         self._motor_pos_store = MotorPositionStore(transport)
         self._cmd_reader = PicoCmdReader(transport)
         self._resp_writer = PicoRespWriter(transport)
@@ -245,6 +248,8 @@ class PicoManager:
             }
             if cls is PicoPotentiometer:
                 kwargs["pot_cal_store"] = self._pot_cal_store
+            elif cls is PicoLidar:
+                kwargs["current_cal_store"] = self._current_cal_store
             elif cls is PicoMotor:
                 kwargs["motor_pos_store"] = self._motor_pos_store
             try:

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -1093,7 +1093,7 @@ class TestLidarRedisHandler:
                     "status": "update",
                     "app_id": 4,
                     "distance_m": 1.23,
-                    "current_voltage": 1.46875,  # = Vq * k → 0 A
+                    "current_voltage": 2.5 * (4.64 / 7.96),  # = Vq * k → 0 A
                 },
             )
             assert [p["sensor_name"] for p in pub] == ["lidar", "system_current"]
@@ -1101,7 +1101,7 @@ class TestLidarRedisHandler:
             assert pub[0]["distance_m"] == 1.23
             assert "current_voltage" not in pub[0]
             # system_current entry carries raw + derived
-            assert pub[1]["current_voltage"] == 1.46875
+            assert pub[1]["current_voltage"] == 2.5 * (4.64 / 7.96)
             assert pub[1]["current_a"] == pytest.approx(0.0, abs=1e-6)
         finally:
             lidar.disconnect()
@@ -1109,7 +1109,7 @@ class TestLidarRedisHandler:
     def test_current_conversion_at_five_amps(self):
         lidar = DummyPicoLidar("/dev/dummy")
         try:
-            # 5 A → Vsensor = 2.5 + 0.2*5 = 3.5 V → Vadc = 3.5 * 0.5875
+            # 5 A → Vsensor = 2.5 + 0.2*5 = 3.5 V → Vadc = 3.5 * (4.64/7.96)
             pub = self._capture(
                 lidar,
                 {
@@ -1117,7 +1117,7 @@ class TestLidarRedisHandler:
                     "status": "update",
                     "app_id": 4,
                     "distance_m": 0.0,
-                    "current_voltage": 3.5 * (4.7 / 8.0),
+                    "current_voltage": 3.5 * (4.64 / 7.96),
                 },
             )
             assert pub[1]["current_a"] == pytest.approx(5.0, abs=1e-6)
@@ -1134,7 +1134,7 @@ class TestLidarRedisHandler:
                     "status": "error",        # lidar I2C failed this cycle
                     "app_id": 4,
                     "distance_m": 9.9,
-                    "current_voltage": 2.9 * (4.7 / 8.0),  # 2 A
+                    "current_voltage": 2.9 * (4.64 / 7.96),  # 2 A
                 },
             )
             assert pub[0]["status"] == "error"     # lidar half still errors

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -1096,7 +1096,10 @@ class TestLidarRedisHandler:
                     "current_voltage": 2.5 * (4.64 / 7.96),  # = Vq * k → 0 A
                 },
             )
-            assert [p["sensor_name"] for p in pub] == ["lidar", "system_current"]
+            assert [p["sensor_name"] for p in pub] == [
+                "lidar",
+                "system_current",
+            ]
             # lidar entry keeps distance, drops the current field
             assert pub[0]["distance_m"] == 1.23
             assert "current_voltage" not in pub[0]
@@ -1131,14 +1134,14 @@ class TestLidarRedisHandler:
                 lidar,
                 {
                     "sensor_name": "lidar",
-                    "status": "error",        # lidar I2C failed this cycle
+                    "status": "error",  # lidar I2C failed this cycle
                     "app_id": 4,
                     "distance_m": 9.9,
                     "current_voltage": 2.9 * (4.64 / 7.96),  # 2 A
                 },
             )
-            assert pub[0]["status"] == "error"     # lidar half still errors
-            assert pub[1]["status"] == "update"    # current half independent
+            assert pub[0]["status"] == "error"  # lidar half still errors
+            assert pub[1]["status"] == "update"  # current half independent
             assert pub[1]["current_a"] == pytest.approx(2.0, abs=1e-6)
         finally:
             lidar.disconnect()
@@ -1150,8 +1153,12 @@ class TestLidarRedisHandler:
         try:
             pub = self._capture(
                 lidar,
-                {"sensor_name": "lidar", "status": "update", "app_id": 4,
-                 "distance_m": 2.0},
+                {
+                    "sensor_name": "lidar",
+                    "status": "update",
+                    "app_id": 4,
+                    "distance_m": 2.0,
+                },
             )
             assert [p["sensor_name"] for p in pub] == ["lidar"]
         finally:

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -13,6 +13,7 @@ from picohost.testing import (
     DummyPicoMotor,
     DummyPicoRFSwitch,
     DummyPicoPeltier,
+    DummyPicoLidar,
 )
 
 
@@ -1062,3 +1063,96 @@ class TestPicoPeltierRedisHandler:
             assert lna["watchdog_timeout_ms"] is None
         finally:
             peltier.disconnect()
+
+
+class TestLidarRedisHandler:
+    """PicoLidar fans the merged lidar status line into two metadata
+    publishes: distance under 'lidar', current under 'system_current'.
+
+    The current entry is decoupled from the lidar I2C status, and its
+    derived current_a follows the nominal ACS724 + 3.3k/4.7k divider
+    transfer function. Every added field is a scalar (scalar-only contract
+    on picohost.base.redis_handler).
+    """
+
+    def _capture(self, lidar, data):
+        """Run the handler and return the list of dicts the base handler
+        would publish, in order."""
+        published = []
+        lidar._base_redis_handler = lambda d: published.append(dict(d))
+        lidar._lidar_redis_handler(data)
+        return published
+
+    def test_splits_into_lidar_and_system_current(self):
+        lidar = DummyPicoLidar("/dev/dummy")
+        try:
+            pub = self._capture(
+                lidar,
+                {
+                    "sensor_name": "lidar",
+                    "status": "update",
+                    "app_id": 4,
+                    "distance_m": 1.23,
+                    "current_voltage": 1.46875,  # = Vq * k → 0 A
+                },
+            )
+            assert [p["sensor_name"] for p in pub] == ["lidar", "system_current"]
+            # lidar entry keeps distance, drops the current field
+            assert pub[0]["distance_m"] == 1.23
+            assert "current_voltage" not in pub[0]
+            # system_current entry carries raw + derived
+            assert pub[1]["current_voltage"] == 1.46875
+            assert pub[1]["current_a"] == pytest.approx(0.0, abs=1e-6)
+        finally:
+            lidar.disconnect()
+
+    def test_current_conversion_at_five_amps(self):
+        lidar = DummyPicoLidar("/dev/dummy")
+        try:
+            # 5 A → Vsensor = 2.5 + 0.2*5 = 3.5 V → Vadc = 3.5 * 0.5875
+            pub = self._capture(
+                lidar,
+                {
+                    "sensor_name": "lidar",
+                    "status": "update",
+                    "app_id": 4,
+                    "distance_m": 0.0,
+                    "current_voltage": 3.5 * (4.7 / 8.0),
+                },
+            )
+            assert pub[1]["current_a"] == pytest.approx(5.0, abs=1e-6)
+        finally:
+            lidar.disconnect()
+
+    def test_current_status_decoupled_from_lidar_error(self):
+        lidar = DummyPicoLidar("/dev/dummy")
+        try:
+            pub = self._capture(
+                lidar,
+                {
+                    "sensor_name": "lidar",
+                    "status": "error",        # lidar I2C failed this cycle
+                    "app_id": 4,
+                    "distance_m": 9.9,
+                    "current_voltage": 2.9 * (4.7 / 8.0),  # 2 A
+                },
+            )
+            assert pub[0]["status"] == "error"     # lidar half still errors
+            assert pub[1]["status"] == "update"    # current half independent
+            assert pub[1]["current_a"] == pytest.approx(2.0, abs=1e-6)
+        finally:
+            lidar.disconnect()
+
+    def test_no_current_field_publishes_only_lidar(self):
+        """A status line without current_voltage (e.g. pre-feature firmware)
+        publishes only the lidar entry — no system_current."""
+        lidar = DummyPicoLidar("/dev/dummy")
+        try:
+            pub = self._capture(
+                lidar,
+                {"sensor_name": "lidar", "status": "update", "app_id": 4,
+                 "distance_m": 2.0},
+            )
+            assert [p["sensor_name"] for p in pub] == ["lidar"]
+        finally:
+            lidar.disconnect()

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -1,0 +1,130 @@
+"""
+Tests for the whole-system current-monitor calibration.
+
+Covers three layers, mirroring the potentiometer calibration suite:
+  - ``compute_two_point``: the (V0, slope) fit from a 0 A point and a
+    known-reference-current point.
+  - ``CurrentCalStore``: the Redis-backed cal store round-trip / error paths.
+  - ``PicoLidar``: cal loaded at __init__, applied in ``_v_to_current`` and
+    the redis handler, and updated live via ``set_calibration``.
+"""
+
+import pytest
+from eigsep_redis.testing import DummyTransport
+
+from picohost.buses import CurrentCalStore
+from picohost.calibrate_current import compute_two_point
+from picohost.keys import CURRENT_CAL_KEY
+from picohost.testing import DummyPicoLidar
+
+
+class TestComputeTwoPoint:
+    """The two-point fit folds offset and gain into (V0, slope)."""
+
+    def test_fit_returns_v0_and_slope(self):
+        # 0 A → 1.0 V, 5 A → 2.0 V  ⇒  V0 = 1.0, slope = (2-1)/5 = 0.2 V/A
+        cal = compute_two_point(1.0, 2.0, 5.0)
+        assert cal == pytest.approx((1.0, 0.2))
+
+    def test_zero_reference_current_rejected(self):
+        """A 0 A 'reference' can't define a slope → None (caller aborts)."""
+        assert compute_two_point(1.0, 2.0, 0.0) is None
+
+    def test_identical_voltages_rejected(self):
+        """No voltage swing between the two points → can't fit gain → None."""
+        assert compute_two_point(1.5, 1.5, 5.0) is None
+
+
+class TestCurrentCalStore:
+    """Round-trip and error-path coverage for the Redis cal store."""
+
+    def _cal_payload(self):
+        return {
+            "system_current": [1.0, 0.2],
+            "metadata": {"i_ref": 5.0, "n_samples": 10},
+        }
+
+    def test_empty_store_returns_none(self):
+        assert CurrentCalStore(DummyTransport()).get() is None
+
+    def test_upload_get_round_trip_preserves_fields(self):
+        store = CurrentCalStore(DummyTransport())
+        payload = self._cal_payload()
+        store.upload(payload)
+        loaded = store.get()
+        assert loaded["system_current"] == payload["system_current"]
+        assert loaded["metadata"] == payload["metadata"]
+        # Transport.upload_dict injects an upload_time field on every write.
+        assert "upload_time" in loaded
+
+    def test_corrupt_json_returns_none(self):
+        transport = DummyTransport()
+        transport.r.set(CURRENT_CAL_KEY, b"not-json-{")
+        assert CurrentCalStore(transport).get() is None
+
+    def test_clear_removes_key(self):
+        store = CurrentCalStore(DummyTransport())
+        store.upload(self._cal_payload())
+        assert store.get() is not None
+        store.clear()
+        assert store.get() is None
+
+
+class TestPicoLidarCurrentCal:
+    """PicoLidar loads, applies, and live-updates the current cal."""
+
+    def test_uncalibrated_uses_nominal_conversion(self):
+        """No cal store → nominal ACS724 + divider transfer function."""
+        lidar = DummyPicoLidar("/dev/dummy")
+        try:
+            assert not lidar.is_current_calibrated
+            # V_adc at 0 A is Vq*k = 2.5 * 0.5875 = 1.46875
+            assert lidar._v_to_current(1.46875) == pytest.approx(0.0, abs=1e-6)
+        finally:
+            lidar.disconnect()
+
+    def test_cal_from_redis_applied_at_init(self):
+        transport = DummyTransport()
+        store = CurrentCalStore(transport)
+        store.upload({"system_current": [1.0, 0.2]})
+        lidar = DummyPicoLidar("/dev/dummy", current_cal_store=store)
+        try:
+            assert lidar.is_current_calibrated
+            assert lidar._current_cal == (1.0, 0.2)
+            # I = (V_adc - V0) / slope = (1.2 - 1.0)/0.2 = 1.0 A
+            assert lidar._v_to_current(1.2) == pytest.approx(1.0, abs=1e-9)
+            assert lidar._v_to_current(1.0) == pytest.approx(0.0, abs=1e-9)
+        finally:
+            lidar.disconnect()
+
+    def test_set_calibration_updates_live(self):
+        lidar = DummyPicoLidar("/dev/dummy")
+        try:
+            lidar.set_calibration(system_current_params=[1.0, 0.2])
+            assert lidar.is_current_calibrated
+            assert lidar._v_to_current(1.4) == pytest.approx(2.0, abs=1e-9)
+        finally:
+            lidar.disconnect()
+
+    def test_handler_uses_calibrated_conversion(self):
+        """The system_current publish reflects the loaded cal, not nominal."""
+        transport = DummyTransport()
+        store = CurrentCalStore(transport)
+        store.upload({"system_current": [1.0, 0.2]})
+        lidar = DummyPicoLidar("/dev/dummy", current_cal_store=store)
+        try:
+            published = []
+            lidar._base_redis_handler = lambda d: published.append(dict(d))
+            lidar._lidar_redis_handler(
+                {
+                    "sensor_name": "lidar",
+                    "status": "update",
+                    "distance_m": 1.0,
+                    "current_voltage": 1.2,
+                }
+            )
+            current = published[1]
+            assert current["sensor_name"] == "system_current"
+            assert current["current_a"] == pytest.approx(1.0, abs=1e-9)
+        finally:
+            lidar.disconnect()

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -124,8 +124,10 @@ class TestPicoLidarCurrentCal:
         lidar = DummyPicoLidar("/dev/dummy")
         try:
             assert not lidar.is_current_calibrated
-            # V_adc at 0 A is Vq*k = 2.5 * 0.5875 = 1.46875
-            assert lidar._v_to_current(1.46875) == pytest.approx(0.0, abs=1e-6)
+            # V_adc at 0 A is Vq*k = 2.5 * (4.64/7.96) = 1.45729
+            assert lidar._v_to_current(2.5 * (4.64 / 7.96)) == pytest.approx(
+                0.0, abs=1e-6
+            )
         finally:
             lidar.disconnect()
 

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -360,3 +360,30 @@ class TestMainDispatch:
         cc.main()
         assert len(uploaded) == 1
         assert uploaded[0]["metadata"]["mode"] == "two-point"
+
+    def test_multi_happy_path_uploads_calibration(self, monkeypatch):
+        """A clean multi fit reaches upload with the right payload shape.
+
+        Uses the real ``compute_multi_point`` so the residual/threshold
+        path is genuinely exercised; the points sit on a clean line, so the
+        residual stays below threshold and no bad-fit prompt fires.
+        """
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc,
+            "collect_multi_point",
+            lambda t, n, c: (
+                [0.0, 1.0, 2.0, 5.0],
+                [1.469, 1.587, 1.704, 2.056],
+            ),
+        )
+        monkeypatch.setattr(cc, "CurrentCalStore", _spy_store_factory(uploaded))
+        monkeypatch.setattr("sys.argv", ["calibrate-current", "--mode", "multi"])
+        cc.main()
+        assert len(uploaded) == 1
+        assert len(uploaded[0]["system_current"]) == 2
+        meta = uploaded[0]["metadata"]
+        assert meta["mode"] == "multi"
+        assert meta["n_points"] == 4

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -319,9 +319,13 @@ class TestMainDispatch:
                 },
             ),
         )
-        monkeypatch.setattr(cc, "CurrentCalStore", _spy_store_factory(uploaded))
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
         monkeypatch.setattr("builtins.input", lambda *a, **k: "n")
-        monkeypatch.setattr("sys.argv", ["calibrate-current", "--mode", "multi"])
+        monkeypatch.setattr(
+            "sys.argv", ["calibrate-current", "--mode", "multi"]
+        )
         with pytest.raises(SystemExit):
             cc.main()
         assert uploaded == []
@@ -356,7 +360,9 @@ class TestMainDispatch:
         monkeypatch.setattr(
             cc, "collect_two_point", lambda t, n: (1.0, 2.0, 5.0)
         )
-        monkeypatch.setattr(cc, "CurrentCalStore", _spy_store_factory(uploaded))
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
         monkeypatch.setattr("builtins.input", lambda *a, **k: "")
         monkeypatch.setattr("sys.argv", ["calibrate-current"])
         cc.main()
@@ -381,8 +387,12 @@ class TestMainDispatch:
                 [1.469, 1.587, 1.704, 2.056],
             ),
         )
-        monkeypatch.setattr(cc, "CurrentCalStore", _spy_store_factory(uploaded))
-        monkeypatch.setattr("sys.argv", ["calibrate-current", "--mode", "multi"])
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
+        monkeypatch.setattr(
+            "sys.argv", ["calibrate-current", "--mode", "multi"]
+        )
         cc.main()
         assert len(uploaded) == 1
         assert len(uploaded[0]["system_current"]) == 2

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -12,8 +12,16 @@ Covers three layers, mirroring the potentiometer calibration suite:
 import pytest
 from eigsep_redis.testing import DummyTransport
 
+import picohost.calibrate_current as cc
 from picohost.buses import CurrentCalStore
-from picohost.calibrate_current import compute_two_point
+from picohost.calibrate_current import (
+    _build_multi_cal_data,
+    _parse_currents,
+    _residual_threshold_a,
+    collect_multi_point,
+    compute_multi_point,
+    compute_two_point,
+)
 from picohost.keys import CURRENT_CAL_KEY
 from picohost.testing import DummyPicoLidar
 
@@ -33,6 +41,44 @@ class TestComputeTwoPoint:
     def test_identical_voltages_rejected(self):
         """No voltage swing between the two points → can't fit gain → None."""
         assert compute_two_point(1.5, 1.5, 5.0) is None
+
+
+class TestComputeMultiPoint:
+    """Least-squares (V0, slope) fit over N known currents."""
+
+    def _clean_line(self):
+        # V = 0.1175 * I + 1.469  (nominal ACS724 + divider line)
+        currents = [0.0, 1.0, 2.0, 5.0, 8.0]
+        voltages = [1.469 + 0.1175 * i for i in currents]
+        return currents, voltages
+
+    def test_recovers_slope_and_intercept(self):
+        currents, voltages = self._clean_line()
+        (v0, slope), quality = compute_multi_point(currents, voltages)
+        assert v0 == pytest.approx(1.469, abs=1e-6)
+        assert slope == pytest.approx(0.1175, abs=1e-6)
+        assert quality["r_squared"] == pytest.approx(1.0, abs=1e-9)
+        assert quality["residual_rms_v"] == pytest.approx(0.0, abs=1e-9)
+        assert quality["residual_rms_a"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_residual_flags_a_bent_dataset(self):
+        # Bend the middle point well off the line.
+        currents = [0.0, 1.0, 2.0, 5.0, 8.0]
+        voltages = [1.469 + 0.1175 * i for i in currents]
+        voltages[2] += 0.05  # 50 mV kink
+        (_v0, slope), quality = compute_multi_point(currents, voltages)
+        assert quality["residual_rms_v"] > 0.0
+        # residual in amps is residual_v / slope, kept positive.
+        assert quality["residual_rms_a"] == pytest.approx(
+            quality["residual_rms_v"] / slope, rel=1e-9
+        )
+        assert quality["r_squared"] < 1.0
+
+    def test_single_distinct_current_rejected(self):
+        assert compute_multi_point([2.0, 2.0, 2.0], [1.7, 1.7, 1.7]) is None
+
+    def test_zero_voltage_spread_rejected(self):
+        assert compute_multi_point([0.0, 1.0, 2.0], [1.5, 1.5, 1.5]) is None
 
 
 class TestCurrentCalStore:
@@ -128,3 +174,189 @@ class TestPicoLidarCurrentCal:
             assert current["current_a"] == pytest.approx(1.0, abs=1e-9)
         finally:
             lidar.disconnect()
+
+
+class TestMultiPointHelpers:
+    """Pure CLI/threshold helpers for the multi-point flow."""
+
+    def test_parse_currents_basic(self):
+        assert _parse_currents("0,1,2,5,8") == [0.0, 1.0, 2.0, 5.0, 8.0]
+
+    def test_parse_currents_tolerates_spaces_and_trailing_comma(self):
+        assert _parse_currents(" 0 , 1.5 , 3 ,") == [0.0, 1.5, 3.0]
+
+    def test_threshold_uses_2_percent_above_floor(self):
+        # 2% of 8 A = 0.16 A > 20 mA floor.
+        assert _residual_threshold_a([0.0, 1.0, 8.0]) == pytest.approx(0.16)
+
+    def test_threshold_applies_20mA_floor_for_small_currents(self):
+        # 2% of 0.5 A = 10 mA < 20 mA floor.
+        assert _residual_threshold_a([0.0, 0.5]) == pytest.approx(0.020)
+
+
+class TestMultiPointCollection:
+    """Interactive collection and payload assembly (no hardware/Redis)."""
+
+    def test_preset_walks_the_list(self, monkeypatch):
+        # collect_samples returns a voltage per point; feed deterministic values.
+        volts = iter([1.47, 1.59, 1.70, 2.06])
+        monkeypatch.setattr(cc, "collect_samples", lambda t, n: next(volts))
+        # Preset currents; blank Enter accepts each target as the reading.
+        inputs = iter(["", "", "", ""])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+        currents, voltages = collect_multi_point(
+            transport=None, n_samples=5, currents=[0.0, 1.0, 2.0, 5.0]
+        )
+        assert currents == [0.0, 1.0, 2.0, 5.0]
+        assert voltages == [1.47, 1.59, 1.70, 2.06]
+
+    def test_preset_override_uses_typed_reading(self, monkeypatch):
+        monkeypatch.setattr(cc, "collect_samples", lambda t, n: 1.6)
+        # Operator overrides the second target with a measured 1.05 A.
+        inputs = iter(["", "1.05", ""])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+        currents, _v = collect_multi_point(
+            transport=None, n_samples=5, currents=[0.0, 1.0, 2.0]
+        )
+        assert currents == [0.0, 1.05, 2.0]
+
+    def test_loop_until_blank_requires_three_points(self, monkeypatch):
+        monkeypatch.setattr(cc, "collect_samples", lambda t, n: 1.5)
+        # Blank too early is rejected; then three points, then blank to finish.
+        inputs = iter(["", "0", "1", "2", ""])
+        monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+        currents, voltages = collect_multi_point(
+            transport=None, n_samples=5, currents=None
+        )
+        assert currents == [0.0, 1.0, 2.0]
+        assert len(voltages) == 3
+
+    def test_build_multi_cal_data_shape(self):
+        cal = (1.469, 0.1175)
+        quality = {
+            "residual_rms_v": 0.001,
+            "residual_rms_a": 0.0085,
+            "r_squared": 0.999,
+        }
+        payload = _build_multi_cal_data(
+            cal,
+            n_samples=10,
+            currents=[0.0, 1.0, 2.0],
+            voltages=[1.469, 1.587, 1.704],
+            quality=quality,
+        )
+        assert payload["system_current"] == [1.469, 0.1175]
+        meta = payload["metadata"]
+        assert meta["mode"] == "multi"
+        assert meta["n_points"] == 3
+        assert meta["currents"] == [0.0, 1.0, 2.0]
+        assert meta["voltages"] == [1.469, 1.587, 1.704]
+        assert meta["residual_rms_a"] == pytest.approx(0.0085)
+        assert meta["r_squared"] == pytest.approx(0.999)
+        assert "timestamp" in meta
+
+
+class _FakeProxy:
+    """Stand-in for PicoProxy: always available, send_command is a no-op."""
+
+    is_available = True
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def send_command(self, *args, **kwargs):
+        return None
+
+
+class _FakeTransport:
+    """Stand-in for Transport with a no-op ``.r.bgsave()``."""
+
+    def __init__(self, *args, **kwargs):
+        self.r = self
+
+    def bgsave(self):
+        return None
+
+
+def _spy_store_factory(recorder):
+    """Build a CurrentCalStore stand-in that records uploaded payloads."""
+
+    class _SpyStore:
+        def __init__(self, transport):
+            pass
+
+        def upload(self, payload):
+            recorder.append(payload)
+
+    return _SpyStore
+
+
+class TestMainDispatch:
+    """Drive ``main()`` to lock the storage-gating control flow."""
+
+    def test_bad_fit_prompt_blocks_storage_on_no(self, monkeypatch):
+        """Residual over threshold + operator 'n' aborts before upload."""
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc,
+            "collect_multi_point",
+            lambda t, n, c: ([0.0, 1.0, 2.0], [1.0, 1.1, 1.2]),
+        )
+        # Force a residual well above the threshold so the gate fires.
+        monkeypatch.setattr(
+            cc,
+            "compute_multi_point",
+            lambda c, v: (
+                (1.0, 0.1175),
+                {
+                    "residual_rms_v": 1.0,
+                    "residual_rms_a": 1.0,
+                    "r_squared": 0.5,
+                },
+            ),
+        )
+        monkeypatch.setattr(cc, "CurrentCalStore", _spy_store_factory(uploaded))
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "n")
+        monkeypatch.setattr("sys.argv", ["calibrate-current", "--mode", "multi"])
+        with pytest.raises(SystemExit):
+            cc.main()
+        assert uploaded == []
+
+    def test_currents_under_three_errors_before_collection(self, monkeypatch):
+        """``--currents 0,1`` (2 points) exits before any sample collection."""
+        called = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc,
+            "collect_multi_point",
+            lambda *a, **k: called.append("collect_multi_point"),
+        )
+        monkeypatch.setattr(
+            cc,
+            "collect_samples",
+            lambda *a, **k: called.append("collect_samples"),
+        )
+        monkeypatch.setattr(
+            "sys.argv", ["calibrate-current", "--currents", "0,1"]
+        )
+        with pytest.raises(SystemExit):
+            cc.main()
+        assert called == []
+
+    def test_two_point_metadata_tags_mode(self, monkeypatch):
+        """Default-mode payload carries ``metadata['mode'] == 'two-point'``."""
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc, "collect_two_point", lambda t, n: (1.0, 2.0, 5.0)
+        )
+        monkeypatch.setattr(cc, "CurrentCalStore", _spy_store_factory(uploaded))
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+        monkeypatch.setattr("sys.argv", ["calibrate-current"])
+        cc.main()
+        assert len(uploaded) == 1
+        assert uploaded[0]["metadata"]["mode"] == "two-point"

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -86,7 +86,7 @@ IMU_FIELDS = {
     "accel_z",
 }
 
-LIDAR_FIELDS = {"sensor_name", "status", "app_id", "distance_m"}
+LIDAR_FIELDS = {"sensor_name", "status", "app_id", "distance_m", "current_voltage"}
 
 RFSWITCH_FIELDS = {"sensor_name", "status", "app_id", "sw_state"}
 

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -86,7 +86,13 @@ IMU_FIELDS = {
     "accel_z",
 }
 
-LIDAR_FIELDS = {"sensor_name", "status", "app_id", "distance_m", "current_voltage"}
+LIDAR_FIELDS = {
+    "sensor_name",
+    "status",
+    "app_id",
+    "distance_m",
+    "current_voltage",
+}
 
 RFSWITCH_FIELDS = {"sensor_name", "status", "app_id", "sw_state"}
 

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -1030,7 +1030,13 @@ class TestLidarEmulator:
     def test_status_fields(self):
         emu = LidarEmulator()
         status = emu.get_status()
-        expected_keys = {"sensor_name", "status", "app_id", "distance_m", "current_voltage"}
+        expected_keys = {
+            "sensor_name",
+            "status",
+            "app_id",
+            "distance_m",
+            "current_voltage",
+        }
         assert set(status.keys()) == expected_keys
 
     def test_failure_then_recovery_returns_to_update(self):

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -1030,7 +1030,7 @@ class TestLidarEmulator:
     def test_status_fields(self):
         emu = LidarEmulator()
         status = emu.get_status()
-        expected_keys = {"sensor_name", "status", "app_id", "distance_m"}
+        expected_keys = {"sensor_name", "status", "app_id", "distance_m", "current_voltage"}
         assert set(status.keys()) == expected_keys
 
     def test_failure_then_recovery_returns_to_update(self):
@@ -1198,6 +1198,7 @@ class TestLidarStatusTypes:
         assert isinstance(status["status"], str)
         assert isinstance(status["app_id"], int)
         assert isinstance(status["distance_m"], float)
+        assert isinstance(status["current_voltage"], float)
 
 
 class TestRFSwitchStatusTypes:

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -427,12 +427,12 @@ class TestLidarProtocol:
         refreshes every cycle even when the lidar I2C read fails."""
         emu = LidarEmulator()
         emu.op()
-        first = emu.get_status()["current_voltage"]
+        emu.get_status()["current_voltage"]
         emu.simulate_sensor_failure()
         emu.op()
         bad = emu.get_status()
-        assert bad["status"] == "error"          # lidar half failed
-        assert "current_voltage" in bad           # current half still present
+        assert bad["status"] == "error"  # lidar half failed
+        assert "current_voltage" in bad  # current half still present
         assert isinstance(bad["current_voltage"], float)
 
     def test_status_is_per_cycle(self):

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -416,6 +416,25 @@ class TestLidarProtocol:
         emu.op()
         assert isinstance(emu.get_status()["distance_m"], float)
 
+    def test_current_voltage_is_float(self):
+        """currentmon.c reports the raw divided ADC voltage as a float."""
+        emu = LidarEmulator()
+        emu.op()
+        assert isinstance(emu.get_status()["current_voltage"], float)
+
+    def test_current_independent_of_lidar_failure(self):
+        """currentmon_op() is a separate dispatch call: the current voltage
+        refreshes every cycle even when the lidar I2C read fails."""
+        emu = LidarEmulator()
+        emu.op()
+        first = emu.get_status()["current_voltage"]
+        emu.simulate_sensor_failure()
+        emu.op()
+        bad = emu.get_status()
+        assert bad["status"] == "error"          # lidar half failed
+        assert "current_voltage" in bad           # current half still present
+        assert isinstance(bad["current_voltage"], float)
+
     def test_status_is_per_cycle(self):
         """lidar.c: status="update" iff op() refreshed distance this cycle."""
         emu = LidarEmulator()

--- a/src/currentmon.c
+++ b/src/currentmon.c
@@ -1,0 +1,32 @@
+#include "currentmon.h"
+#include "hardware/adc.h"
+#include "pico/stdlib.h"
+
+#define CURRENTMON_GPIO         28
+#define CURRENTMON_ADC_CH       2
+#define CURRENTMON_ADC_SAMPLES  16
+#define CURRENTMON_ADC_MAX      4095.0f
+#define CURRENTMON_VREF         3.3f
+
+static float current_voltage = 0.0f;
+
+void currentmon_init(void) {
+    adc_init();
+    adc_gpio_init(CURRENTMON_GPIO);
+}
+
+void currentmon_op(void) {
+    adc_select_input(CURRENTMON_ADC_CH);
+    (void)adc_read();  // discard first conversion after selecting the input
+
+    uint32_t total = 0;
+    for (uint i = 0; i < CURRENTMON_ADC_SAMPLES; i++) {
+        total += adc_read();
+    }
+    float counts = (float)total / (float)CURRENTMON_ADC_SAMPLES;
+    current_voltage = counts * CURRENTMON_VREF / CURRENTMON_ADC_MAX;
+}
+
+float currentmon_voltage(void) {
+    return current_voltage;
+}

--- a/src/currentmon.c
+++ b/src/currentmon.c
@@ -2,8 +2,8 @@
 #include "hardware/adc.h"
 #include "pico/stdlib.h"
 
-#define CURRENTMON_GPIO         28
-#define CURRENTMON_ADC_CH       2
+#define CURRENTMON_GPIO         26
+#define CURRENTMON_ADC_CH       0   // GP26 is ADC0 (GP27=ADC1, GP28=ADC2)
 #define CURRENTMON_ADC_SAMPLES  16
 #define CURRENTMON_ADC_MAX      4095.0f
 #define CURRENTMON_VREF         3.3f

--- a/src/currentmon.h
+++ b/src/currentmon.h
@@ -1,0 +1,16 @@
+#ifndef CURRENTMON_H
+#define CURRENTMON_H
+
+// Whole-system current monitor. Reads an ACS724 current sensor (through a
+// 3.3k/4.7k resistive divider) on GP28 / ADC2 and exposes the raw ADC-pin
+// voltage. Composed into the lidar app dispatch in main.c because the lidar
+// Pico uses no other ADC channel, so this sensor is the sole occupant of the
+// ADC mux (no adc_select_input swapping → no cross-channel correlation).
+//
+// Firmware stays "dumb": it reports volts only. The voltage->current
+// conversion lives host-side (picohost PicoLidar redis handler).
+void currentmon_init(void);
+void currentmon_op(void);
+float currentmon_voltage(void);
+
+#endif // CURRENTMON_H

--- a/src/currentmon.h
+++ b/src/currentmon.h
@@ -2,7 +2,7 @@
 #define CURRENTMON_H
 
 // Whole-system current monitor. Reads an ACS724 current sensor (through a
-// 3.3k/4.7k resistive divider) on GP26 / ADC0 and exposes the raw ADC-pin
+// 3.32k/4.64k resistive divider, DMM-measured) on GP26 / ADC0 and exposes the raw ADC-pin
 // voltage. Composed into the lidar app dispatch in main.c because the lidar
 // Pico uses no other ADC channel, so this sensor is the sole occupant of the
 // ADC mux (no adc_select_input swapping → no cross-channel correlation).

--- a/src/currentmon.h
+++ b/src/currentmon.h
@@ -2,7 +2,7 @@
 #define CURRENTMON_H
 
 // Whole-system current monitor. Reads an ACS724 current sensor (through a
-// 3.3k/4.7k resistive divider) on GP28 / ADC2 and exposes the raw ADC-pin
+// 3.3k/4.7k resistive divider) on GP26 / ADC0 and exposes the raw ADC-pin
 // voltage. Composed into the lidar app dispatch in main.c because the lidar
 // Pico uses no other ADC channel, so this sensor is the sole occupant of the
 // ADC mux (no adc_select_input swapping → no cross-channel correlation).

--- a/src/lidar.c
+++ b/src/lidar.c
@@ -3,6 +3,7 @@
 #include "hardware/i2c.h"
 #include "eigsep_command.h"
 #include "cJSON.h"
+#include "currentmon.h"
 #include <stdio.h>
 
 #define I2C_PORT i2c0
@@ -62,11 +63,12 @@ void lidar_server(uint8_t app_id, const char *json_str) {
 
 void lidar_status(uint8_t app_id) {
     const char *status = lidar_data.last_op_ok ? "update" : "error";
-    send_json(4,
+    send_json(5,
         KV_STR, "sensor_name", "lidar",
         KV_STR, "status", status,
         KV_INT, "app_id", app_id,
-        KV_FLOAT, "distance_m", lidar_data.distance
+        KV_FLOAT, "distance_m", lidar_data.distance,
+        KV_FLOAT, "current_voltage", currentmon_voltage()
     );
     lidar_data.last_op_ok = false;
 }

--- a/src/lidar.c
+++ b/src/lidar.c
@@ -75,6 +75,9 @@ void lidar_status(uint8_t app_id) {
 
 
 void lidar_reset(uint8_t app_id) {
+    // Reset only the I2C peripheral. The co-located current monitor owns the
+    // ADC (GP26/ADC0); deliberately leave it untouched so a lidar recovery
+    // does not disturb the independent current reading.
     i2c_deinit(I2C_PORT);
     sleep_ms(50);
     lidar_init(app_id);

--- a/src/main.c
+++ b/src/main.c
@@ -150,6 +150,11 @@ int main(void) {
             case APP_IMU_AZ: imu_op(app_id); break;
             case APP_LIDAR:
                 lidar_op(app_id);
+                // Keep currentmon_op() a SEPARATE dispatch call, not nested in
+                // lidar_op(): lidar_op() early-returns on an I2C failure, so
+                // folding the ADC read inside it would freeze the current
+                // reading during every lidar outage. The current monitor must
+                // keep sampling independent of lidar's I2C health.
                 currentmon_op();
                 break;
             default:

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "potmon.h"
 #include "imu.h"
 #include "lidar.h"
+#include "currentmon.h"
 
 
 // Read 3-bit DIP switch code
@@ -85,7 +86,10 @@ int main(void) {
         case APP_POTMON: potmon_init(app_id); break;
         case APP_IMU_EL:
         case APP_IMU_AZ: imu_init(app_id); break;
-        case APP_LIDAR: lidar_init(app_id); break;
+        case APP_LIDAR:
+            lidar_init(app_id);
+            currentmon_init();
+            break;
         default: break;
     }
    
@@ -144,7 +148,10 @@ int main(void) {
             case APP_POTMON: potmon_op(app_id); break;
             case APP_IMU_EL:
             case APP_IMU_AZ: imu_op(app_id); break;
-            case APP_LIDAR: lidar_op(app_id); break;
+            case APP_LIDAR:
+                lidar_op(app_id);
+                currentmon_op();
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
## Summary

Adds a **whole-system current monitor** (ACS724-10AB, 5 V, 200 mV/A, bidirectional) on the **shared power-supply feed**. The sensor's analog OUT is read on the **lidar Pico's `GP26` / `ADC0`**, and the derived current is published to Redis under a clean **`system_current`** key.

> **Pin update:** originally on `GP28`/`ADC2`; moved to **`GP26`/`ADC0`** (commit "use the pico gpio26 for currentmon"). GP26 is ADC channel **0** on the RP2350 — the `CURRENTMON_ADC_CH` constant has been corrected from `2` to `0` to match (an earlier commit moved the GPIO but left the channel at 2, so the firmware was still reading GP28). Reflash + bench-verify on GP26 before deploy.

### Why the lidar Pico / GP26
The lidar app uses **no ADC** (it's I2C-only), so the current sensor is the **sole occupant of that Pico's ADC mux** — no `adc_select_input()` channel-swapping, which avoids the cross-channel correlation we saw on the potmon Pico. The current read is dispatched as a **separate `currentmon_op()` call** (not appended inside `lidar_op()`), so a lidar I2C-failure early-`return` can't skip the current sample.

### Design
- **Firmware stays dumb:** `currentmon.c` (a reusable module like `temp_simple.c`) samples GP26 and reports the **raw ADC-pin voltage** only. The lidar status line merges one field, `current_voltage` (`send_json` 4→5).
- **Host does the conversion + naming:** `PicoLidar`'s redis handler fans the merged line into **two** metadata publishes — distance under `metadata['lidar']`, current under `metadata['system_current']` (raw `current_voltage` **plus** derived `current_a`). Nothing user-facing names "lidar"; "lidar" stays only in infra-internal places (which Pico the manager polls / its heartbeat). No manager change — `system_current` is a metadata key, not a device.

### Conversion
Nominal until calibrated: `I = (V_adc / k − 2.5) / 0.2`, with divider ratio `k = 4.7 / (3.3 + 4.7) = 0.5875` (top 3.3 kΩ / bottom 4.7 kΩ) and `Vq = 2.5 V` (bidirectional Vcc/2). On a DC load only one half of the bidirectional range is used — **no per-amp resolution loss**. Once a two-point cal is uploaded (see below), conversion switches to the measured `I = (V_adc − V0) / slope`.

## Hardware (reviewer action before deploy)
- Wire the ACS724 OUT through a **3.3 kΩ (top) / 4.7 kΩ (bottom)** divider into `GP26`. Ratio keeps the sensor's worst case (~5 V) under the 3.3 V ADC ceiling (0 A → 1.47 V, 10 A → 2.64 V). *(No decoupling cap fitted; an optional 100 nF from the pin to GND would anti-alias sensor noise if needed.)*
- Wire `IP+ → IP−` so output rises **above** 2.5 V (forward half). If reversed, just flip the sign in the conversion.

## Calibration (now included in this PR)
The nominal constants (`k`, `Vq`, `S`) are traceable to the hardware but un-trimmed (ACS724 offset + resistor tolerance). This PR adds a **two-point calibration** that absorbs both offset and gain empirically — `I = (V_adc − V0) / slope`, with `V0` = mean ADC volts at **0 A** and `slope = (V1 − V0)/I_ref` from a known reference current. `slope` is at the ADC pin, so it folds in both `k` and `S` — no need to trust nominal resistor values.

Implemented mirroring `calibrate-pot`/`PotCalStore`:
- **`CurrentCalStore`** (`buses.py`, key `current_calibration`) — single Redis key holding `{"system_current": [V0, slope], metadata, upload_time}`.
- **`calibrate-current`** entry point reads `stream:system_current` via `PicoProxy`/Redis (never serial), prompts for the 0 A and known-current samples, fits, persists (`BGSAVE`), and pushes live via `set_calibration`. Guards reject a 0 A reference / zero voltage swing and warn on a negative or far-from-nominal slope (reversed wiring / wrong load).
- **`PicoLidar`** loads the cal at `__init__` (wired through `PicoManager` like `pot_cal_store`); `_v_to_current` uses `(V_adc − V0)/slope` when calibrated, nominal otherwise. `set_calibration` applies a live cal without a manager restart.
- Tests: `compute_two_point` fit + guards, `CurrentCalStore` round-trip/error paths, and `PicoLidar` calibrated-conversion / init-load / live-update / handler paths (11 new tests; full suite **524 passed**).

> Running an actual cal needs the hardware + an inline reference ammeter — the tool is ready; the stored values come from a field run.

## Tests / build
- `picohost` suite: **524 passed** (uv venv), output pristine; ruff clean.
- Firmware `./build.sh`: **build successful**, `pico_multi.uf2` produced.
- TDD throughout: emulator parity (`LidarEmulator` mirrors `current_voltage`, refreshed even on simulated lidar failure) + new `PicoLidar` handler tests (two-publish split, conversion exact at 0/2/5 A, status decoupling, no-current-field path).

## Notes
- **Backward compatible:** a status line lacking `current_voltage` publishes only the lidar entry.
- The `system_current` entry's `status` is hard-set to `"update"`, **decoupled** from lidar's I2C status (the ADC read is independent).
- Downstream consumers of `metadata['system_current']` should allow a **small-negative `current_a` near idle** (bidirectional sensor + noise) — don't validate `current_a >= 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
