### PR TITLE
PicoManager owns device discovery; flash-picos flash-only + DTR-independent firmware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@ flash-picos --uf2 build/pico_multi.uf2 --no-gpio
 # Target a single Pico (automatically uses the USB path)
 flash-picos --uf2 build/pico_multi.uf2 --usb-serial <ID>
 
-# Flash with custom parameters
-flash-picos --uf2 build/pico_multi.uf2 --baud 115200 --timeout 10
+# Flash and write the confirmed device list to a JSON file
+flash-picos --uf2 build/pico_multi.uf2 --output-file devices.json
 
 # Drive the shared GPIO lines directly (all bussed Picos at once)
 pico-gpio bootsel   # everyone into BOOTSEL (2e8a:000f)
@@ -192,12 +192,12 @@ with MotorDevice() as motor:
 
 ### flash-picos
 
-CLI tool (installed as `flash-picos` entry point from picohost package) for flashing all attached Picos. It is **FLASH-ONLY**: it loads the UF2 firmware and confirms the result by polling the always-running `picomanager`'s Redis `pico_config` (which the manager owns by self-discovering boards from their CDC status). Two flash paths:
+CLI tool (installed as `flash-picos` entry point from picohost package) for flashing all attached Picos. It is **FLASH-ONLY**: it loads the UF2 firmware and confirms each board by polling its per-name heartbeat in Redis for `alive=True` — mere presence in `pico_config` is not enough (it has no TTL, so a stale pre-flash entry would false-green). The always-running `picomanager` owns `pico_config` by self-discovering boards from their CDC status. Two flash paths:
 - **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. The lines are driven through the `pinctrl` CLI (`pinctrl set 17/18 op dh|dl`), so there is no GPIO library or pin-factory backend to install. One GPIO sequence (`17 dh → 18 dh → 17 dl → 18 dl`, i.e. reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then each board is booted individually and staggered via `picotool reboot -a`. Fails fast with a pointer to `--no-gpio` if `pinctrl` is not on PATH
 - **USB per-device (`--no-gpio`, or automatic with `--port`/`--usb-serial`)**: reboots each CDC Pico into BOOTSEL via `picotool reboot --bus/--address`, then loads — for hosts without the GPIO wiring
 - `picotool` targets devices by USB bus/address resolved from sysfs (never `--ser`, whose descriptor read corrupts under hub contention)
-- **No longer** stops/restarts `picomanager.service` — the manager runs continuously and owns the CDC ports; flash-picos confirms against its `pico_config` instead of reading directly
-- When `picomanager` is not active, prints "loaded N; start picomanager to confirm" and exits successfully (0) — the manager owns device discovery and publication to Redis
+- **No longer** stops/restarts `picomanager.service` — the manager runs continuously and owns the CDC ports; flash-picos confirms each board via the manager's per-name heartbeat (`alive=True`), reading `pico_config` only to resolve serial → name
+- When `picomanager` is not active, prints `"Loaded N board(s). picomanager is not active; start it to confirm device info (or this is a manager-less host)."` and exits successfully (0) — the manager owns device discovery and publication to Redis
 - Optionally writes confirmed device info to a JSON file via `--output-file`
 
 ### pico-gpio

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,13 +192,13 @@ with MotorDevice() as motor:
 
 ### flash-picos
 
-CLI tool (installed as `flash-picos` entry point from picohost package) for flashing and configuring multiple Picos. Two flash paths:
-- **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. The lines are driven through the `pinctrl` CLI (`pinctrl set 17/18 op dh|dl`), so there is no GPIO library or pin-factory backend to install. One GPIO sequence (`17 dh → 18 dh → 17 dl → 18 dl`, i.e. reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then one mass reset boots everything. Fails fast with a pointer to `--no-gpio` if `pinctrl` is not on PATH
+CLI tool (installed as `flash-picos` entry point from picohost package) for flashing all attached Picos. It is **FLASH-ONLY**: it loads the UF2 firmware and confirms the result by polling the always-running `picomanager`'s Redis `pico_config` (which the manager owns by self-discovering boards from their CDC status). Two flash paths:
+- **GPIO mass-BOOTSEL (default)**: all Picos' BOOTSEL pads are bussed to Pi GPIO 18 and RUN/RESET pads to GPIO 17 (BCM) via inverting drivers — Pi pin HIGH grounds the line, LOW releases it; BOOTSEL (the shared QSPI flash CS) is only asserted while the Picos are held in reset. The lines are driven through the `pinctrl` CLI (`pinctrl set 17/18 op dh|dl`), so there is no GPIO library or pin-factory backend to install. One GPIO sequence (`17 dh → 18 dh → 17 dl → 18 dl`, i.e. reset on → bootsel on → reset off → bootsel off) puts the whole fleet into BOOTSEL (works even for wedged firmware), each device is loaded by `picotool load --bus/--address` (no `-x`/`-f`) over a quiet bus, then each board is booted individually and staggered via `picotool reboot -a`. Fails fast with a pointer to `--no-gpio` if `pinctrl` is not on PATH
 - **USB per-device (`--no-gpio`, or automatic with `--port`/`--usb-serial`)**: reboots each CDC Pico into BOOTSEL via `picotool reboot --bus/--address`, then loads — for hosts without the GPIO wiring
 - `picotool` targets devices by USB bus/address resolved from sysfs (never `--ser`, whose descriptor read corrupts under hub contention)
-- Stops an active `picomanager.service` before flashing and restarts it afterwards — the manager owns every Pico's CDC port (no exclusive open on either side), so a live manager races the post-flash readback. Restart happens **only if flash-picos itself stopped the unit**, so `eigsep-field patch pico-firmware` (which stops/starts the unit around its own flash-picos call and inserts an ExecStart drop-in in between) is unaffected. `--keep-manager` opts out; unprivileged runs fall back to `sudo -n systemctl`, and an active manager that cannot be stopped aborts the flash with a pointer to `--keep-manager`
-- Reads JSON device info from each Pico after flashing and publishes the device list to Redis (optionally `--output-file`)
-- Automatically discovers connected Picos (CDC via pyserial, BOOTSEL via sysfs)
+- **No longer** stops/restarts `picomanager.service` — the manager runs continuously and owns the CDC ports; flash-picos confirms against its `pico_config` instead of reading directly
+- When `picomanager` is not active, prints "loaded N; start picomanager to confirm" and exits successfully (0) — the manager owns device discovery and publication to Redis
+- Optionally writes confirmed device info to a JSON file via `--output-file`
 
 ### pico-gpio
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ target_link_libraries(pico_multi
 # enable USB CDC for stdio
 pico_enable_stdio_usb(pico_multi 1)
 pico_enable_stdio_uart(pico_multi 0)
+# Emit USB-CDC stdout whenever the device is USB-ready, not only while the host
+# asserts DTR. flash-picos / the manager's discovery probe churn open/close (each
+# close drops DTR); on a marginal hub a re-asserted DTR control transfer can be
+# lost, which otherwise silently suppresses all status (the readback-flicker bug).
+target_compile_definitions(pico_multi PRIVATE PICO_STDIO_USB_CONNECTION_WITHOUT_DTR=1)
 
 # generate UF2, map file, etc.
 pico_add_extra_outputs(pico_multi)
@@ -80,6 +85,8 @@ target_link_libraries(pico_test_blink
 )
 pico_enable_stdio_usb(pico_test_blink 1)
 pico_enable_stdio_uart(pico_test_blink 0)
+# Match pico_multi: report status without requiring host DTR (see above).
+target_compile_definitions(pico_test_blink PRIVATE PICO_STDIO_USB_CONNECTION_WITHOUT_DTR=1)
 pico_add_extra_outputs(pico_test_blink)
 set_target_properties(pico_test_blink PROPERTIES OUTPUT_NAME "pico_test_blink")
 

--- a/picohost/picomanager.service
+++ b/picohost/picomanager.service
@@ -5,7 +5,7 @@ Requires=redis-server.service
 
 [Service]
 Environment=PYTHONUNBUFFERED=1
-ExecStart=%h/venv/bin/pico-manager --uf2 %h/eigsep/pico-firmware/build/pico_multi.uf2
+ExecStart=%h/venv/bin/pico-manager
 Restart=always
 RestartSec=5
 TimeoutStartSec=120

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -67,11 +67,12 @@ class PicoConfigStore:
     :meth:`Transport.upload_dict` stays at the top level next to
     it.
 
-    ``flash-picos`` uploads the list after every flash pass. The
-    manager reads it once at boot and treats it as the source of
-    truth; if it's missing, the manager falls back to running
-    ``flash-and-discover`` itself and writes the result back with
-    :meth:`upload`.
+    The manager is the sole writer: it publishes the list via
+    :meth:`upload` after each live-discovery pass (``_discover_new``
+    adopts new boards and immediately updates the store).
+    ``flash-picos`` only reads from this store — via
+    :func:`~picohost.flash_picos._await_manager_confirmation` — to
+    confirm that reflashed boards came back alive.
     """
 
     def __init__(self, transport):

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -203,6 +203,28 @@ def _wait_for_stable_bootsel_set(
     return last
 
 
+_CONFIRM_TIMEOUT_S = 45.0   # > boot stagger (~7x1.5s) + udev + a couple 5s manager cadences
+_CONFIRM_POLL_S = 0.5
+
+
+def _await_manager_confirmation(expected, transport,
+                                timeout=_CONFIRM_TIMEOUT_S, poll=_CONFIRM_POLL_S):
+    """Poll the manager-owned pico_config until *expected* serials all appear.
+
+    Returns (confirmed, stragglers). Presence in pico_config is the
+    confirmation: the manager only writes an entry after reading a status line.
+    """
+    store = PicoConfigStore(transport)
+    expected = set(expected)
+    deadline = time.monotonic() + timeout
+    while True:
+        published = {d.get("usb_serial") for d in store.get()}
+        confirmed = expected & published
+        if confirmed == expected or time.monotonic() >= deadline:
+            return confirmed, expected - confirmed
+        time.sleep(poll)
+
+
 _FLASH_MAX_ATTEMPTS = 3
 _FLASH_RETRY_BACKOFF_S = 2.0
 

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -960,6 +960,13 @@ def main(argv=None):
             "Flash all attached Picos and confirm via the manager-owned "
             "pico_config that each board is reporting."
         ),
+        epilog=(
+            "flash-picos is FLASH-ONLY: it loads the UF2 firmware and confirms "
+            "the result by polling picomanager's Redis pico_config (which the "
+            "manager owns by self-discovering boards from their CDC status). "
+            "If picomanager is not running, reports loaded count and exits "
+            "successfully — the manager owns device discovery and publication."
+        ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument(

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -10,12 +10,12 @@ import sys
 import time
 from pathlib import Path
 
-from eigsep_redis import Transport
+from eigsep_redis import HeartbeatReader, Transport
 from serial.tools import list_ports
 
 from . import manager_service
 from .buses import PicoConfigStore
-from .keys import PICO_CONFIG_KEY
+from .keys import PICO_CONFIG_KEY, pico_heartbeat_name
 
 logger = logging.getLogger(__name__)
 
@@ -209,17 +209,44 @@ _CONFIRM_POLL_S = 0.5
 
 def _await_manager_confirmation(expected, transport,
                                 timeout=_CONFIRM_TIMEOUT_S, poll=_CONFIRM_POLL_S):
-    """Poll the manager-owned pico_config until *expected* serials all appear.
+    """Poll the manager-owned pico_config until *expected* serials are alive.
 
-    Returns (confirmed, stragglers). Presence in pico_config is the
-    confirmation: the manager only writes an entry after reading a status line.
+    Returns (confirmed, stragglers). A serial is confirmed only when its board's
+    per-name heartbeat is alive=True — mere presence in pico_config is NOT
+    sufficient. pico_config has no TTL and the manager (never stopped during a
+    flash) leaves stale entries, so a board that was already known before the
+    flash would appear "present" before it even re-enumerates. The manager sets a
+    board's heartbeat alive=False while it is in BOOTSEL during the flash (its
+    reconnect fails) and only back to alive=True once it re-establishes the
+    board afterward, so alive=True is a genuine "came back from this flash"
+    signal.
+
+    Circular-import note: manager.py imports from flash_picos at module load,
+    so APP_NAMES is imported lazily inside this function, not at module top level.
     """
+    # Lazy import to avoid a circular dependency: manager imports from
+    # flash_picos at module load, so flash_picos must not import APP_NAMES
+    # from manager at module top level.
+    from .manager import APP_NAMES
+
     store = PicoConfigStore(transport)
     expected = set(expected)
     deadline = time.monotonic() + timeout
     while True:
-        published = {d.get("usb_serial") for d in store.get()}
-        confirmed = expected & published
+        entries = store.get() or []
+        serial_to_appid = {
+            d.get("usb_serial"): d.get("app_id") for d in entries
+        }
+        confirmed = set()
+        for serial in expected:
+            app_id = serial_to_appid.get(serial)
+            if app_id is None:
+                continue
+            name = APP_NAMES.get(app_id)
+            if name is None:
+                continue
+            if HeartbeatReader(transport, name=pico_heartbeat_name(name)).check():
+                confirmed.add(serial)
         if confirmed == expected or time.monotonic() >= deadline:
             return confirmed, expected - confirmed
         time.sleep(poll)

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -15,7 +15,7 @@ from serial.tools import list_ports
 
 from . import manager_service
 from .buses import PicoConfigStore
-from .keys import PICO_CONFIG_KEY, pico_heartbeat_name
+from .keys import pico_heartbeat_name
 
 logger = logging.getLogger(__name__)
 
@@ -203,12 +203,15 @@ def _wait_for_stable_bootsel_set(
     return last
 
 
-_CONFIRM_TIMEOUT_S = 45.0   # > boot stagger (~7x1.5s) + udev + a couple 5s manager cadences
+_CONFIRM_TIMEOUT_S = (
+    45.0  # > boot stagger (~7x1.5s) + udev + a couple 5s manager cadences
+)
 _CONFIRM_POLL_S = 0.5
 
 
-def _await_manager_confirmation(expected, transport,
-                                timeout=_CONFIRM_TIMEOUT_S, poll=_CONFIRM_POLL_S):
+def _await_manager_confirmation(
+    expected, transport, timeout=_CONFIRM_TIMEOUT_S, poll=_CONFIRM_POLL_S
+):
     """Poll the manager-owned pico_config until *expected* serials are alive.
 
     Returns (confirmed, stragglers). A serial is confirmed only when its board's
@@ -245,7 +248,9 @@ def _await_manager_confirmation(expected, transport,
             name = APP_NAMES.get(app_id)
             if name is None:
                 continue
-            if HeartbeatReader(transport, name=pico_heartbeat_name(name)).check():
+            if HeartbeatReader(
+                transport, name=pico_heartbeat_name(name)
+            ).check():
                 confirmed.add(serial)
         if confirmed == expected or time.monotonic() >= deadline:
             return confirmed, expected - confirmed
@@ -661,8 +666,6 @@ def _read_cdc_port(port, usb_serial, baud, timeout):
     return data
 
 
-
-
 def flash_and_discover(
     uf2_path="build/pico_multi.uf2",
     port=None,
@@ -859,7 +862,6 @@ def _boot_fleet_staggered(
     return booted
 
 
-
 def flash_and_discover_gpio(
     uf2_path="build/pico_multi.uf2",
 ):
@@ -937,7 +939,7 @@ def flash_and_discover_gpio(
     # transiently mute, and a mute board cannot be reached over USB to
     # recover).
     expected_serials = {d["usb_serial"] for d in flashed if d["usb_serial"]}
-    booted = _boot_fleet_staggered(flashed)
+    _boot_fleet_staggered(flashed)
 
     # Surface any board still in BOOTSEL, distinguishing the two causes:
     # a board we flashed that will not leave BOOTSEL even after its
@@ -978,7 +980,6 @@ def flash_and_discover_gpio(
             )
 
     return sorted(s for s in expected_serials if s)
-
 
 
 def main(argv=None):

--- a/picohost/src/picohost/flash_picos.py
+++ b/picohost/src/picohost/flash_picos.py
@@ -473,35 +473,6 @@ _REENUMERATE_TIMEOUT_S = 10.0
 _REENUMERATE_POLL_S = 0.2
 _UDEV_SETTLE_TIMEOUT_S = 3.0
 _INTER_DEVICE_SETTLE_S = 1.0
-# After the staggered fleet boot, the booted boards re-enumerate as CDC.
-# On the contended hub that enumeration *flickers*: a board can be absent
-# from find_pico_ports() at one instant and back a second later (the LED
-# keeps blinking throughout — the firmware is up, only USB is intermittent).
-# The readback therefore keeps polling for this long, reading each board as
-# it appears, rather than reading a single snapshot. Bounded so a board that
-# never (re)enumerates cannot stall the run.
-_CDC_DISCOVER_TIMEOUT_S = 15.0
-_CDC_DISCOVER_POLL_S = 0.3
-# Per-board read timeout for the reconcile sweep, on a quiet bus. A board
-# that re-enumerated as CDC emits a status line every 200 ms, so this is
-# plenty; one that stays mute this long is genuinely not reporting.
-_CDC_READ_TIMEOUT_S = 5
-# Discovery-pass read timeout: deliberately short. The first pass runs while
-# the bus is still busy from the staggered boot and must keep cycling to
-# catch boards as they (re)enumerate — it must NOT spend the whole readback
-# budget blocking on a board that is momentarily mute. A board mute under
-# that contention is deferred to the quiet-bus sweep below, not waited on
-# here.
-_FIRST_PASS_READ_TIMEOUT_S = 2
-# Quiet-bus reconcile sweep: settle briefly so nothing is mid-re-enumeration,
-# then give each board that enumerated but stayed silent a couple of patient
-# reads on the now-idle bus (the first pass gave up on it fast). A board that
-# is alive answers on the first sweep read (status every 200 ms vs a 5 s
-# read); the second is a hedge for one still coming alive. Kept at 2 so the
-# sweep cannot stall long on genuinely-silent boards (each costs its full
-# read timeout per attempt).
-_PRE_SWEEP_SETTLE_S = 2.0
-_SWEEP_REREAD_ATTEMPTS = 2
 
 
 def _udev_settle(timeout=_UDEV_SETTLE_TIMEOUT_S):
@@ -617,12 +588,9 @@ def _classify_read_failure(exc):
 def _read_cdc_outcome(port, usb_serial, baud, timeout):
     """Attempt one device-info read; return ``(data_or_None, reason)``.
 
-    ``reason`` is ``None`` on success, otherwise a short verdict (from
-    :func:`_classify_read_failure`, or a no-port message) that
-    :func:`_read_fleet_cdc` reconciles into a per-serial report. Keeping
-    the classification here — rather than only logging the raw exception
-    in :func:`_read_cdc_port` — lets the fleet path attribute *why* each
-    board dropped without re-parsing a log line.
+    ``reason`` is ``None`` on success, otherwise a short verdict from
+    :func:`_classify_read_failure` (or a no-port message). Used by the
+    manager's discovery probe via :func:`_read_cdc_port`.
     """
     if port is None:
         return None, (
@@ -666,143 +634,15 @@ def _read_cdc_port(port, usb_serial, baud, timeout):
     return data
 
 
-def _read_device_info(usb_serial, baud, timeout=_CDC_READ_TIMEOUT_S):
-    """Resolve the post-flash CDC port for *usb_serial* and read its JSON.
-
-    Used by the USB per-device path, which already knows each Pico by
-    its (stable) CDC serial.
-    """
-    port = _resolve_post_flash_port(usb_serial)
-    return _read_cdc_port(port, usb_serial, baud, timeout)
-
-
-def _read_fleet_cdc(expected, baud, read_timeout=_CDC_READ_TIMEOUT_S):
-    """Read device-info JSON from every Pico that boots into CDC, riding
-    out enumeration flicker.
-
-    On the contended observatory hub a freshly-booted board's CDC
-    enumeration flickers: it may be absent from :func:`find_pico_ports` at
-    one instant and back a second later, and the set rarely shows all
-    *expected* boards simultaneously even though each appears at *some*
-    instant. A single snapshot read therefore silently drops whichever
-    boards happened to be absent at the read instant — even though they
-    flashed fine and their LED is blinking. This instead keeps polling
-    until *expected* boards have reported or ``_CDC_DISCOVER_TIMEOUT_S``
-    elapses: each pass it reads every currently-enumerated board not yet
-    read, remembering successes (so a board that flickers out after it is
-    read is kept), retrying boards that opened but stayed mute, and picking
-    up boards still mid-(re)enumeration as they appear.
-
-    Boards are keyed by their **CDC** serial, not the BOOTSEL-mode serial
-    used to load: a wiped or odd board can present a different (or absent)
-    serial in BOOTSEL, which would leave it flashed but unreported. Keying
-    off the CDC serial — the same identity ``find_pico_ports`` and
-    PicoManager use — reports every Pico that actually booted into
-    firmware. A board that never (re)enumerates only costs the bounded
-    deadline.
-
-    Returns ``(devices, outcomes)`` where *outcomes* maps each
-    read-attempted serial to ``None`` (read succeeded) or its last failure
-    reason. The caller reconciles that against the flashed set and emits
-    the per-serial report.
-    """
-    deadline = time.monotonic() + _CDC_DISCOVER_TIMEOUT_S
-    devices = {}  # cdc_serial -> device-info (first successful read wins)
-    outcomes = {}
-    while True:
-        for port, serial in sorted(find_pico_ports().items()):
-            if serial in devices:
-                continue  # already read this board; don't re-disturb it
-            data, reason = _read_cdc_outcome(port, serial, baud, read_timeout)
-            outcomes[serial] = reason
-            if data is not None:
-                devices[serial] = data
-                logger.info(
-                    "Read device info from %s (serial=%s)", port, serial
-                )
-        if len(devices) >= expected or time.monotonic() >= deadline:
-            break
-        time.sleep(_CDC_DISCOVER_POLL_S)
-    if len(devices) < expected:
-        logger.warning(
-            "only %d of %d booted Pico(s) reported device info within "
-            "%.0fs (the rest never (re)enumerated as CDC, or stayed mute)",
-            len(devices),
-            expected,
-            _CDC_DISCOVER_TIMEOUT_S,
-        )
-    return list(devices.values()), outcomes
-
-
-def _log_readback_reconciliation(expected_serials, present_serials, outcomes):
-    """Log a per-serial verdict reconciling flashed vs. reported boards.
-
-    *expected_serials* is the set of board serials that were flashed and
-    should report device info; *present_serials* is the set that
-    re-enumerated as CDC; *outcomes* maps each read-attempted serial to
-    ``None`` (read succeeded) or a failure reason from
-    :func:`_classify_read_failure`.
-
-    For every expected board that did not report, emits one line saying
-    whether it never re-enumerated or opened-but-failed (and why) — the
-    "which board, and at which stage" detail that turns an inconsistent
-    device count into an actionable diagnosis. Boards that reported but
-    were not in the flashed set (e.g. a board whose BOOTSEL serial
-    differed from its CDC serial) are named too. With no baseline
-    (*expected_serials* is ``None``), falls back to logging any
-    present-but-failed read.
-    """
-    if expected_serials is None:
-        for serial, reason in sorted(outcomes.items()):
-            if reason is not None:
-                logger.error(
-                    "could not read device info for serial=%s: %s",
-                    serial,
-                    reason,
-                )
-        return
-
-    expected = set(expected_serials)
-    reported = {s for s, reason in outcomes.items() if reason is None}
-    ok = expected & reported
-    unexpected = reported - expected
-    if ok == expected and not unexpected:
-        logger.info(
-            "device-info readback: all %d flashed Pico(s) reported",
-            len(expected),
-        )
-        return
-
-    logger.warning(
-        "device-info readback: %d of %d flashed Pico(s) reported device info",
-        len(ok),
-        len(expected),
-    )
-    for serial in sorted(expected - reported):
-        if serial in present_serials:
-            reason = outcomes.get(serial) or "read failed"
-        else:
-            reason = (
-                f"did not re-enumerate as CDC within "
-                f"{_CDC_DISCOVER_TIMEOUT_S:.0f}s"
-            )
-        logger.error("  serial=%s NOT reported: %s", serial, reason)
-    for serial in sorted(unexpected):
-        logger.warning(
-            "  serial=%s reported but was not in the flashed set "
-            "(BOOTSEL/CDC serial mismatch, or an unexpected board)",
-            serial,
-        )
 
 
 def flash_and_discover(
     uf2_path="build/pico_multi.uf2",
     port=None,
     usb_serial=None,
-    baud=115200,
 ):
-    """
-    Flash all attached Picos and read device config from each.
+    """Flash all attached Picos and return the USB serials of those
+    successfully flashed.
 
     Parameters
     ----------
@@ -816,14 +656,12 @@ def flash_and_discover(
         ID). Stable across reboots and port renumbering — preferred
         over ``port`` for targeted flashing. If both are given, the
         device must match both.
-    baud : int
-        Serial baud rate for reading JSON after flash.
 
     Returns
     -------
-    list[dict]
-        List of device info dicts, each with keys like ``app_id``,
-        ``port``, ``usb_serial``.
+    list[str]
+        Sorted list of USB serials that were successfully flashed.
+        Caller confirms via the manager-owned ``pico_config``.
 
     Raises
     ------
@@ -845,7 +683,7 @@ def flash_and_discover(
         return []
 
     logger.info(f"Found Picos on: {ports}")
-    all_devices = []
+    flashed_serials = []
 
     for idx, (port_dev, port_serial) in enumerate(ports.items()):
         if idx > 0:
@@ -861,16 +699,9 @@ def flash_and_discover(
             logger.error(f"Flash failed on {port_dev}: {e}")
             continue
 
-        # picotool load reboots the Pico, which re-enumerates as a
-        # CDC device. _read_device_info resolves the current path from
-        # the stable usb_serial (the kernel may assign a different
-        # /dev/ttyACMn than it had pre-flash) and reads its JSON.
-        data = _read_device_info(port_serial, baud)
-        if data is not None:
-            all_devices.append(data)
-            logger.info(f"Read device info from {data['port']}")
+        flashed_serials.append(port_serial)
 
-    return all_devices
+    return sorted(flashed_serials)
 
 
 def _load_bootsel_device(
@@ -1001,69 +832,9 @@ def _boot_fleet_staggered(
     return booted
 
 
-def _reconcile_silent_boards(
-    missing,
-    baud,
-    attempts=_SWEEP_REREAD_ATTEMPTS,
-    settle=_PRE_SWEEP_SETTLE_S,
-    read_timeout=_CDC_READ_TIMEOUT_S,
-):
-    """Re-read boards that enumerated as CDC but stayed silent, on a quiet bus.
-
-    The discovery pass (:func:`_read_fleet_cdc`) runs while the bus is still
-    busy from the staggered boot and gives up *fast* on any board that does
-    not answer immediately, so it does not burn the whole readback budget
-    blocking on one mute board. That leaves a gap: a board that is alive and
-    emitting status every 200 ms, but whose reads lost out to contention in
-    that busy window, would be reported missing even though it is fine. This
-    sweep closes it — after a *settle* it gives each still-missing board that
-    is *present* as CDC a few patient reads on the now-idle bus.
-
-    Only boards in *missing* that currently appear in
-    :func:`find_pico_ports` are touched: a board that never (re)enumerated
-    cannot be read over USB, and there is no re-flash fallback (re-flashing a
-    healthy board only re-introduces a BOOTSEL round-trip). Each board's CDC
-    port is resolved once up front, then its fixed path is re-read up to
-    *attempts* times — without re-scanning USB descriptors between tries,
-    which would re-disturb the marginal deep-hub node we are coaxing a line
-    out of.
-
-    Returns ``(devices, outcomes)`` — *outcomes* maps each swept serial to
-    ``None`` once read, else its last failure reason, for the caller's
-    reconciliation report.
-    """
-    if not missing:
-        return [], {}
-    time.sleep(settle)
-    by_serial = {sn: dev for dev, sn in find_pico_ports().items()}
-    pending = {s for s in missing if s in by_serial}
-    recovered = []
-    outcomes = {}
-    for attempt in range(1, attempts + 1):
-        if not pending:
-            break
-        if attempt > 1:
-            time.sleep(settle)
-        for serial in sorted(pending):
-            data, reason = _read_cdc_outcome(
-                by_serial[serial], serial, baud, read_timeout
-            )
-            outcomes[serial] = reason
-            if data is not None:
-                recovered.append(data)
-                pending.discard(serial)
-                logger.info(
-                    "reconcile sweep recovered serial=%s on %s (was silent "
-                    "during the busy discovery pass)",
-                    serial,
-                    data["port"],
-                )
-    return recovered, outcomes
-
 
 def flash_and_discover_gpio(
     uf2_path="build/pico_multi.uf2",
-    baud=115200,
 ):
     """Mass-flash all Picos via the bussed GPIO BOOTSEL/RUN lines.
 
@@ -1078,11 +849,12 @@ def flash_and_discover_gpio(
     2. ``picotool load`` each device by bus/address — without ``-x``,
        so nothing re-enumerates and the bus stays quiet while every
        device is idle mass-storage.
-    3. One mass GPIO reset boots all Picos into the new firmware
-       simultaneously; then read each device's JSON over serial.
+    3. Boot each loaded board individually and staggered via
+       ``picotool reboot -a``.
 
-    Returns the device info dicts (``app_id``, ``port``,
-    ``usb_serial``) for every Pico that flashed and re-enumerated.
+    Returns the sorted list of USB serials that were successfully
+    loaded and booted.  Caller confirms via the manager-owned
+    ``pico_config``.
 
     Raises ``FileNotFoundError`` for a missing UF2 and ``RuntimeError``
     when no Pico enters BOOTSEL (bad wiring, or no GPIO access).
@@ -1116,7 +888,7 @@ def flash_and_discover_gpio(
     )
 
     # Phase 2: load each device over a quiet bus (no -x: everything
-    # stays in BOOTSEL until the mass reset below).
+    # stays in BOOTSEL until the staggered per-board boot below).
     flashed = []
     for dev in bootsel_devices:
         if _load_bootsel_device(dev, uf2_path):
@@ -1131,52 +903,14 @@ def flash_and_discover_gpio(
                 dev["address"],
             )
 
-    # Phase 3: boot each loaded board individually and staggered, then
-    # read the fleet on a settled bus.
+    # Phase 3: boot each loaded board individually and staggered.
     #
-    # This replaces the single shared gpio.reset() pulse, which is
-    # unreliable across the full fleet (boards miss it and stay in
-    # BOOTSEL) and re-enumerates everything at once — a simultaneous storm
-    # that leaves some boards transiently mute (and a mute board cannot be
-    # reached over USB to read or recover). Per-board picotool reboot -a,
-    # staggered, boots reliably without storming the bus.
+    # Per-board picotool reboot -a, staggered, boots reliably without
+    # storming the bus (simultaneous re-enumeration leaves some boards
+    # transiently mute, and a mute board cannot be reached over USB to
+    # recover).
     expected_serials = {d["usb_serial"] for d in flashed if d["usb_serial"]}
     booted = _boot_fleet_staggered(flashed)
-
-    # Readback in two phases, keyed off the CDC serial (not the BOOTSEL
-    # serial used for loading, so a board whose BOOTSEL serial differed or
-    # was absent is still reported). There is no re-flash fallback — a
-    # genuinely mute board cannot be reached over USB to re-flash, and
-    # re-flashing a healthy board only re-introduces a BOOTSEL round-trip —
-    # so a still-missing board is reported, not re-flashed.
-    #
-    # Phase 3a — patient discovery with a FAST give-up: while the bus is
-    # still busy from the staggered boot, keep polling and reading boards as
-    # they (re)appear (so a board whose CDC enumeration flickers is not
-    # dropped for being absent at one instant), but give up quickly on any
-    # board that does not answer at once rather than draining the budget
-    # blocking on it.
-    all_devices, outcomes = _read_fleet_cdc(
-        len(booted), baud, _FIRST_PASS_READ_TIMEOUT_S
-    )
-    reported = {d["usb_serial"] for d in all_devices}
-
-    # Phase 3b — quiet-bus reconcile sweep: give any board that enumerated
-    # but stayed silent in that busy window a few patient reads on the now-
-    # idle bus. A board that is alive and emitting (its heartbeat LED and
-    # status share one code path in the firmware) but lost its reads to
-    # contention is recovered here; one that is genuinely silent (stuck in
-    # init, wrong DIP/app) is reported missing for the operator.
-    sweep_devices, sweep_outcomes = _reconcile_silent_boards(
-        expected_serials - reported,
-        baud,
-    )
-    all_devices.extend(sweep_devices)
-    outcomes.update(sweep_outcomes)
-
-    _log_readback_reconciliation(
-        expected_serials, set(find_pico_ports().values()), outcomes
-    )
 
     # Surface any board still in BOOTSEL, distinguishing the two causes:
     # a board we flashed that will not leave BOOTSEL even after its
@@ -1216,75 +950,15 @@ def flash_and_discover_gpio(
                 ),
             )
 
-    return all_devices
+    return sorted(s for s in expected_serials if s)
 
-
-def _merge_device_lists(existing, fresh):
-    """Merge *fresh* device dicts over *existing* by ``usb_serial``.
-
-    Returns ``(merged_list, preserved_serials)``. A board read this run
-    overrides its prior entry; a board present in *existing* but absent
-    from *fresh* — flashed and running, but lost to a flaky readback this
-    run — keeps its last-known entry rather than vanishing. This matters
-    because :meth:`PicoConfigStore.upload` overwrites the device list
-    wholesale and PicoManager treats it as the source of truth, so a
-    partial readback would otherwise silently de-register working boards.
-    *preserved_serials* names the carried-over boards so the caller can
-    warn that they rode on stale data.
-
-    *existing* may be ``None`` (nothing published yet) — then the result
-    is *fresh* unchanged with no preserved boards. Devices without a
-    ``usb_serial`` cannot be keyed; fresh ones are kept as-is and existing
-    ones are dropped (they cannot be matched or trusted).
-    """
-    merged = {}  # usb_serial -> device-info
-    for dev in existing or []:
-        serial = dev.get("usb_serial")
-        if serial is not None:
-            merged[serial] = dev
-    preserved = set(merged)
-    extras = []  # fresh devices with no serial: keep, but cannot dedup
-    for dev in fresh:
-        serial = dev.get("usb_serial")
-        if serial is None:
-            extras.append(dev)
-            continue
-        merged[serial] = dev
-        preserved.discard(serial)
-    return list(merged.values()) + extras, preserved
-
-
-def _publish_to_redis(devices, host, port):
-    """Publish *devices* to Redis via :class:`PicoConfigStore`.
-
-    Merges *devices* over the list already in Redis by ``usb_serial``
-    (see :func:`_merge_device_lists`) rather than overwriting it, so a
-    board that flashed and is running but was missed by this run's
-    readback is not dropped from PicoManager's source of truth. Returns
-    the merged device list that was published. Raises on connection
-    failure so ``main`` can fall back to file output if the user asked
-    for that.
-    """
-    transport = Transport(host=host, port=port)
-    store = PicoConfigStore(transport)
-    merged, preserved = _merge_device_lists(store.get(), devices)
-    if preserved:
-        logger.warning(
-            "%d board(s) not read this run kept their previous Redis "
-            "entry (flashed but lost to a flaky readback?): %s. Re-run "
-            "flash-picos to refresh them.",
-            len(preserved),
-            ", ".join(sorted(map(str, preserved))),
-        )
-    store.upload(merged)
-    return merged
 
 
 def main(argv=None):
     p = argparse.ArgumentParser(
         description=(
-            "Flash all attached Picos, read JSON from each, and publish "
-            "the device list to Redis (source of truth for PicoManager)."
+            "Flash all attached Picos and confirm via the manager-owned "
+            "pico_config that each board is reporting."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -1297,8 +971,7 @@ def main(argv=None):
         help=(
             "USB serial number (Pico board unique ID). Stable across "
             "reboots and port renumbering — preferred over --port for "
-            "targeted flashing. Look up in `devices_info.json` or with "
-            "`picotool info -a`."
+            "targeted flashing. Look up with `picotool info -a`."
         ),
     )
     p.add_argument(
@@ -1307,36 +980,22 @@ def main(argv=None):
         help="Path to your pico_multi.uf2",
     )
     p.add_argument(
-        "--baud",
-        type=int,
-        default=115200,
-        help="Serial baud rate.",
-    )
-    p.add_argument(
         "--redis-host",
         default="localhost",
-        help="Redis host for PicoConfigStore publication",
+        help="Redis host for manager confirmation polling",
     )
     p.add_argument(
         "--redis-port",
         type=int,
         default=6379,
-        help="Redis port for PicoConfigStore publication",
-    )
-    p.add_argument(
-        "--no-redis",
-        action="store_true",
-        help=(
-            "Skip Redis publication. Use with --output-file for offline "
-            "provisioning on a host without Redis."
-        ),
+        help="Redis port for manager confirmation polling",
     )
     p.add_argument(
         "--output-file",
         default=None,
         help=(
-            "Optional: also write the device list to this JSON file. "
-            "Not required — PicoManager reads from Redis directly."
+            "Optional: write the confirmed device list (from "
+            "pico_config) to this JSON file after confirmation."
         ),
     )
     p.add_argument(
@@ -1346,19 +1005,6 @@ def main(argv=None):
             "Skip the GPIO mass-BOOTSEL flash flow and reboot each "
             "Pico into BOOTSEL over USB instead. Required on hosts "
             "without the bussed BOOTSEL/RUN wiring."
-        ),
-    )
-    p.add_argument(
-        "--keep-manager",
-        action="store_true",
-        help=(
-            "Do not stop an active picomanager.service before "
-            "flashing. By default flash-picos stops the manager (it "
-            "owns every Pico's serial port and its reconnect loop "
-            "corrupts the post-flash readback) and restarts it after "
-            "the flash. Only the active unit is touched, so under "
-            "`eigsep-field patch` — which stops the unit itself — "
-            "the default is already a no-op."
         ),
     )
     args = p.parse_args(argv)
@@ -1389,73 +1035,50 @@ def main(argv=None):
             )
             sys.exit(1)
 
-    stopped_manager = False
-    if not args.keep_manager and manager_service.manager_is_active():
-        logger.info(
-            "%s is active and owns the Pico serial ports; stopping "
-            "it for the flash (it will be restarted afterwards)",
-            manager_service.MANAGER_UNIT,
-        )
-        try:
-            manager_service.stop_manager()
-        except RuntimeError as e:
-            print(str(e), file=sys.stderr)
-            sys.exit(1)
-        stopped_manager = True
-
     try:
-        try:
-            if use_gpio:
-                all_devices = flash_and_discover_gpio(
-                    uf2_path=args.uf2,
-                    baud=args.baud,
-                )
-            else:
-                all_devices = flash_and_discover(
-                    uf2_path=args.uf2,
-                    port=args.port,
-                    usb_serial=args.usb_serial,
-                    baud=args.baud,
-                )
-        except (FileNotFoundError, RuntimeError) as e:
-            print(str(e), file=sys.stderr)
-            sys.exit(1)
+        if use_gpio:
+            all_serials = flash_and_discover_gpio(uf2_path=args.uf2)
+        else:
+            all_serials = flash_and_discover(
+                uf2_path=args.uf2,
+                port=args.port,
+                usb_serial=args.usb_serial,
+            )
+    except (FileNotFoundError, RuntimeError) as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
 
-        if not all_devices:
-            print("No devices discovered.", file=sys.stderr)
-            sys.exit(1)
+    if not all_serials:
+        print("No devices loaded.", file=sys.stderr)
+        sys.exit(1)
 
-        if not args.no_redis:
-            try:
-                published = _publish_to_redis(
-                    all_devices, args.redis_host, args.redis_port
-                )
-                print(
-                    f"Published {len(published)} device(s) to Redis at "
-                    f"{args.redis_host}:{args.redis_port} "
-                    f"(key: {PICO_CONFIG_KEY})."
-                )
-            except Exception as e:
-                print(
-                    f"Redis publication failed: {e}\n"
-                    "Re-run with --no-redis (and optionally "
-                    "--output-file) if Redis is not available.",
-                    file=sys.stderr,
-                )
+    if not manager_service.manager_is_active():
+        print(
+            f"Loaded {len(all_serials)} board(s). picomanager is not active; "
+            "start it to confirm device info (or this is a manager-less host)."
+        )
+        return
 
-        if args.output_file:
-            with open(args.output_file, "w") as f:
-                json.dump(all_devices, f, indent=2)
-            print(f"Wrote {len(all_devices)} device(s) to {args.output_file}.")
-    finally:
-        # Restart ONLY if we stopped it: under `eigsep-field patch`
-        # the unit is already stopped by the coordinator, which must
-        # write its ExecStart drop-in and daemon-reload BEFORE the
-        # unit starts again. The finally also runs on sys.exit() so
-        # the manager comes back even when the flash fails — same
-        # best-effort restore eigsep-field's patch flow does.
-        if stopped_manager:
-            manager_service.start_manager()
+    transport = Transport(host=args.redis_host, port=args.redis_port)
+    confirmed, stragglers = _await_manager_confirmation(all_serials, transport)
+    print(
+        f"Confirmed {len(confirmed)}/{len(all_serials)} board(s) via "
+        "picomanager."
+    )
+
+    if args.output_file:
+        store = PicoConfigStore(transport)
+        with open(args.output_file, "w") as f:
+            json.dump(store.get(), f, indent=2)
+        print(f"Wrote confirmed device info to {args.output_file}.")
+
+    if stragglers:
+        print(
+            f"  NOT confirmed (booted but not reporting): "
+            f"{', '.join(sorted(stragglers))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -127,10 +127,11 @@ class PicoManager:
     """
     Standalone service that owns all pico serial connections.
 
-    Discovers devices from the Redis :class:`PicoConfigStore`,
-    monitors their health via per-device heartbeats, and relays
-    commands from :class:`PicoCmdReader` to the right
-    :class:`PicoDevice`.
+    Discovers devices by live-scanning CDC ports (via
+    :func:`find_pico_ports` and :func:`read_json_from_serial`) and
+    adopting any unbound Pico it finds, monitors their health via
+    per-device heartbeats, and relays commands from
+    :class:`PicoCmdReader` to the right :class:`PicoDevice`.
     """
 
     def __init__(self, transport):

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -303,7 +303,8 @@ class PicoManager:
                     continue
                 self._register_devices(
                     [{"app_id": app_id, "port": port, "usb_serial": sn}])
-            self._config_store.upload(self._current_device_list())
+                device_list = self._current_device_list()   # snapshot under lock
+            self._config_store.upload(device_list)           # upload outside lock
 
     # --- Health Monitoring ---
 

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -1,12 +1,12 @@
 """
 PicoManager - standalone service that owns all pico serial connections.
 
-Redis is the source of truth. ``flash-picos`` writes the discovered
-device list into ``PicoConfigStore`` on the host side; the manager
-boots, reads that list, instantiates the matching :class:`PicoDevice`
-subclass per entry, and then exposes each device to the rest of the
-system through four bus surfaces (all from ``eigsep_redis`` /
-``picohost.buses``):
+Redis is the source of truth. On startup the manager performs a live
+scan of attached CDC Picos (via :func:`find_pico_ports` /
+:func:`read_json_from_serial`), instantiates the matching
+:class:`PicoDevice` subclass per entry, and then exposes each device
+to the rest of the system through four bus surfaces (all from
+``eigsep_redis`` / ``picohost.buses``):
 
 - :class:`eigsep_redis.MetadataWriter` — per-sensor firmware status
   (the 200 ms JSON packets) is republished onto ``stream:{sensor}``
@@ -26,7 +26,7 @@ system through four bus surfaces (all from ``eigsep_redis`` /
   and has no eigsep_observing analogue.
 
 Usage:
-    python -m picohost.manager [--uf2 build/pico_multi.uf2] [--log-level INFO]
+    python -m picohost.manager [--log-level INFO]
 """
 
 import argparse
@@ -35,7 +35,6 @@ import logging
 import signal
 import threading
 import time
-from pathlib import Path
 
 from eigsep_redis import (
     HeartbeatWriter,
@@ -134,11 +133,7 @@ class PicoManager:
     :class:`PicoDevice`.
     """
 
-    def __init__(
-        self,
-        transport,
-        uf2_path="build/pico_multi.uf2",
-    ):
+    def __init__(self, transport):
         """
         Parameters
         ----------
@@ -151,12 +146,8 @@ class PicoManager:
             :class:`PotCalStore` (passed to ``PicoPotentiometer``),
             :class:`PicoCmdReader`, :class:`PicoRespWriter`, and
             :class:`PicoClaimStore`.
-        uf2_path : str or Path
-            Path to the UF2 firmware file for auto-flashing when
-            Redis is empty at boot.
         """
         self.transport = transport
-        self.uf2_path = Path(uf2_path)
         self.picos = {}
         self._heartbeats = {}
         self._metadata_writer = MetadataWriter(transport)
@@ -200,23 +191,14 @@ class PicoManager:
     # --- Discovery & Config ---
 
     def discover(self):
-        """
-        Resolve the device list and instantiate devices.
+        """Discover all currently-attached Picos from live status and publish.
 
-        1. Read :class:`PicoConfigStore` from Redis. If non-empty,
-           register those devices.
-        2. If empty, run :func:`flash_picos.flash_and_discover` and
-           publish the result back into the config store.
+        No cached-config input and no flashing: a live scan adopts whatever
+        CDC Picos are present (flashing is flash-picos's job).
         """
-        devices = self._config_store.get()
-        if devices:
-            self._status(f"Loaded {len(devices)} device(s) from Redis")
-            self._register_devices(devices)
-            return
-
-        self._try_flash_discover()
+        self._discover_new()
         if self.picos:
-            self._config_store.upload(self._current_device_list())
+            self._status(f"Discovered {len(self.picos)} device(s)")
 
     def _current_device_list(self):
         """Build a list of device dicts from currently registered picos."""
@@ -277,27 +259,6 @@ class PicoManager:
                     f"Failed to init {name} on {port}: {e}",
                     level=logging.ERROR,
                 )
-
-    def _try_flash_discover(self):
-        """Attempt to flash attached Picos and discover devices."""
-        from .flash_picos import flash_and_discover
-
-        try:
-            devices = flash_and_discover(uf2_path=self.uf2_path)
-        except FileNotFoundError:
-            self.logger.warning(
-                f"UF2 file {self.uf2_path} not found, skipping flash"
-            )
-            return
-        except Exception as e:
-            self.logger.error(f"Flash-and-discover failed: {e}")
-            return
-
-        if not devices:
-            self.logger.warning("Flash produced no devices")
-            return
-
-        self._register_devices(devices)
 
     def _probe_status(self, port):
         """Read one self-identifying status line from *port*, or None.
@@ -550,7 +511,9 @@ class PicoManager:
                         if hb is not None:
                             hb.set(ex=HEARTBEAT_TTL, alive=False)
                     self.picos.clear()
-                    self.discover()
+                # discover() acquires self._lock internally; must run unlocked
+                self.discover()
+                with self._lock:
                     device_names = list(self.picos.keys())
                 self._resp_writer.send(
                     target="manager",
@@ -650,12 +613,6 @@ def main():
     """Console-script and ``python -m picohost.manager`` entry point."""
     parser = argparse.ArgumentParser(description="EIGSEP Pico Manager")
     parser.add_argument(
-        "--uf2",
-        default="build/pico_multi.uf2",
-        help="Path to pico_multi.uf2 for auto-flashing when Redis is empty "
-        "(default: build/pico_multi.uf2)",
-    )
-    parser.add_argument(
         "--redis-host",
         default="localhost",
         help="Redis host (default: localhost)",
@@ -685,7 +642,7 @@ def main():
     )
 
     transport = Transport(host=args.redis_host, port=args.redis_port)
-    mgr = PicoManager(transport, uf2_path=args.uf2)
+    mgr = PicoManager(transport)
     if args.clear_config:
         mgr._config_store.clear()
     mgr.run()

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -268,7 +268,9 @@ class PicoManager:
         cannot hang the manager's discovery pass.
         """
         try:
-            return read_json_from_serial(port, DISCOVERY_BAUD, DISCOVERY_READ_TIMEOUT_S)
+            return read_json_from_serial(
+                port, DISCOVERY_BAUD, DISCOVERY_READ_TIMEOUT_S
+            )
         except (RuntimeError, OSError) as e:
             self.logger.debug("discovery probe of %s failed: %s", port, e)
             return None
@@ -283,8 +285,9 @@ class PicoManager:
         ports = find_pico_ports()
         with self._lock:
             bound = {p.usb_serial for p in self.picos.values() if p.usb_serial}
-        candidates = {port: sn for port, sn in ports.items()
-                      if sn and sn not in bound}
+        candidates = {
+            port: sn for port, sn in ports.items() if sn and sn not in bound
+        }
         for port, sn in candidates.items():
             info = self._probe_status(port)
             if info is None:
@@ -293,18 +296,28 @@ class PicoManager:
             name = APP_NAMES.get(app_id)
             if name is None:
                 self.logger.warning(
-                    "discovery: unknown app_id %r on %s (serial=%s)", app_id, port, sn)
+                    "discovery: unknown app_id %r on %s (serial=%s)",
+                    app_id,
+                    port,
+                    sn,
+                )
                 continue
             with self._lock:
                 if name in self.picos:
                     self.logger.warning(
                         "discovery: %s already bound; %s (serial=%s) ignored",
-                        name, port, sn)
+                        name,
+                        port,
+                        sn,
+                    )
                     continue
                 self._register_devices(
-                    [{"app_id": app_id, "port": port, "usb_serial": sn}])
-                device_list = self._current_device_list()   # snapshot under lock
-            self._config_store.upload(device_list)           # upload outside lock
+                    [{"app_id": app_id, "port": port, "usb_serial": sn}]
+                )
+                device_list = (
+                    self._current_device_list()
+                )  # snapshot under lock
+            self._config_store.upload(device_list)  # upload outside lock
 
     # --- Health Monitoring ---
 
@@ -358,7 +371,7 @@ class PicoManager:
                 hb = self._heartbeats.get(name)
                 if hb is not None:
                     hb.set(ex=HEARTBEAT_TTL, alive=connected)
-        self._discover_new()   # NEW: adopt any newly-appeared board
+        self._discover_new()  # NEW: adopt any newly-appeared board
 
     # --- Command Relay ---
 

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -60,6 +60,7 @@ from .buses import (
     PicoRespWriter,
     PotCalStore,
 )
+from .flash_picos import find_pico_ports, read_json_from_serial
 from .keys import PICO_CMD_STREAM, pico_heartbeat_name
 from .motor import PicoMotor
 
@@ -95,6 +96,8 @@ PICO_CLASSES = {
 # Timing
 HEALTH_CHECK_INTERVAL = 5.0  # seconds between health checks
 HEALTH_TIMEOUT = 10.0  # seconds without status before unhealthy
+DISCOVERY_READ_TIMEOUT_S = 3.0  # bounded one-shot probe of an unbound CDC port
+DISCOVERY_BAUD = 115200
 # Heartbeat TTL is 4× the check interval so a single missed tick
 # (or a reconnection storm that blocks one pass) doesn't expire the
 # key before the next tick has a chance to re-assert liveness.
@@ -296,6 +299,50 @@ class PicoManager:
 
         self._register_devices(devices)
 
+    def _probe_status(self, port):
+        """Read one self-identifying status line from *port*, or None.
+
+        Bounded + abandonable (runs in a child process): a wedged/mute port
+        cannot hang the manager's discovery pass.
+        """
+        try:
+            return read_json_from_serial(port, DISCOVERY_BAUD, DISCOVERY_READ_TIMEOUT_S)
+        except (RuntimeError, OSError) as e:
+            self.logger.debug("discovery probe of %s failed: %s", port, e)
+            return None
+
+    def _discover_new(self):
+        """Adopt any CDC port not already bound to a registered device.
+
+        Keys off usb_serial (a renumbered known board is already bound; the
+        health loop's reconnect re-resolves its port). Probes happen lock-free;
+        registration re-checks the name under the lock.
+        """
+        ports = find_pico_ports()
+        with self._lock:
+            bound = {p.usb_serial for p in self.picos.values() if p.usb_serial}
+        candidates = {port: sn for port, sn in ports.items()
+                      if sn and sn not in bound}
+        for port, sn in candidates.items():
+            info = self._probe_status(port)
+            if info is None:
+                continue
+            app_id = info.get("app_id")
+            name = APP_NAMES.get(app_id)
+            if name is None:
+                self.logger.warning(
+                    "discovery: unknown app_id %r on %s (serial=%s)", app_id, port, sn)
+                continue
+            with self._lock:
+                if name in self.picos:
+                    self.logger.warning(
+                        "discovery: %s already bound; %s (serial=%s) ignored",
+                        name, port, sn)
+                    continue
+                self._register_devices(
+                    [{"app_id": app_id, "port": port, "usb_serial": sn}])
+            self._config_store.upload(self._current_device_list())
+
     # --- Health Monitoring ---
 
     def health_loop(self):
@@ -348,6 +395,7 @@ class PicoManager:
                 hb = self._heartbeats.get(name)
                 if hb is not None:
                     hb.set(ex=HEARTBEAT_TTL, alive=connected)
+        self._discover_new()   # NEW: adopt any newly-appeared board
 
     # --- Command Relay ---
 

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -8,6 +8,7 @@ import types
 import pytest
 
 import picohost.flash_picos as fp
+from eigsep_redis import HeartbeatWriter
 from eigsep_redis.testing import DummyTransport
 from picohost.buses import PicoConfigStore
 from picohost.flash_picos import (
@@ -16,6 +17,8 @@ from picohost.flash_picos import (
     _resolve_post_flash_port,
     flash_and_discover,
 )
+from picohost.keys import pico_heartbeat_name
+from picohost.manager import APP_NAMES
 
 
 def _publish(transport, serials):
@@ -26,6 +29,8 @@ def _publish(transport, serials):
 def test_confirmation_all_present():
     t = DummyTransport()
     _publish(t, ["A", "B"])
+    # _publish uses app_id=0 for all serials → name "motor"; set its heartbeat alive.
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
     confirmed, stragglers = _await_manager_confirmation(
         {"A", "B"}, t, timeout=1.0, poll=0.01)
     assert confirmed == {"A", "B"} and stragglers == set()
@@ -34,9 +39,25 @@ def test_confirmation_all_present():
 def test_confirmation_timeout_reports_stragglers():
     t = DummyTransport()
     _publish(t, ["A"])
+    # "A" → app_id=0 → "motor"; set motor heartbeat alive so A is confirmed.
+    # "B" is not in pico_config at all → straggler regardless.
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
     confirmed, stragglers = _await_manager_confirmation(
         {"A", "B"}, t, timeout=0.2, poll=0.01)
     assert confirmed == {"A"} and stragglers == {"B"}
+
+
+def test_confirmation_present_but_not_alive_is_straggler():
+    """A serial present in pico_config but whose heartbeat is NOT alive must
+    NOT be confirmed — regression guard for the false-green bug where mere
+    presence in the (TTL-less, stale) config was accepted as confirmation."""
+    t = DummyTransport()
+    _publish(t, ["A"])
+    # Deliberately do NOT set the heartbeat alive: the board is in pico_config
+    # but never came back after flash (or its heartbeat expired).
+    confirmed, stragglers = _await_manager_confirmation(
+        {"A"}, t, timeout=0.2, poll=0.01)
+    assert confirmed == set() and stragglers == {"A"}
 
 
 @pytest.fixture
@@ -1014,22 +1035,20 @@ class TestWaitForStableBootselSet:
 
 @pytest.fixture
 def _mock_gpio_flash(monkeypatch, tmp_path):
-    """Patch GPIO entry, sysfs scans, picotool loads, the staggered fleet
-    boot, and serial reads so flash_and_discover_gpio runs without
-    hardware.
+    """Patch GPIO entry, sysfs scans, picotool loads, and the staggered fleet
+    boot so flash_and_discover_gpio runs without hardware.
 
-    ``find_pico_ports`` and ``_find_bootsel_devices`` are time-dependent:
-    they return the pre-boot view until ``_boot_fleet_staggered`` runs,
-    then the post-boot view (the flashed fleet back in CDC under their
-    real CDC serials, and whatever is still stuck in BOOTSEL). picotool
-    load goes through a fake subprocess.run so tests can assert the argv
-    (no reboot, no -x, no -f); the per-board boot itself is mocked as the
-    phase boundary (it is unit-tested separately in TestBootFleetStaggered).
+    ``_find_bootsel_devices`` returns the BOOTSEL set until
+    ``_boot_fleet_staggered`` runs, then the stuck set (default empty).
+    ``find_pico_ports`` always returns the pre-boot CDC snapshot.
+    picotool load goes through a fake subprocess.run so tests can assert
+    the argv (no reboot, no -x, no -f); the per-board boot itself is
+    mocked as the phase boundary (it is unit-tested separately in
+    TestBootFleetStaggered).
 
     Tests tweak behaviour by mutating the exposed dicts/lists in place:
-    ``bootsel`` (BOOTSEL set), ``pre_cdc`` (CDC before entry), ``post_cdc``
-    (CDC after boot), ``reads`` (port → JSON), ``stuck`` (still in BOOTSEL
-    after boot).
+    ``bootsel`` (BOOTSEL set), ``pre_cdc`` (CDC snapshot), ``stuck``
+    (still in BOOTSEL after boot).
     """
     import picohost.flash_picos as fp
     import picohost.gpio as gpio_mod
@@ -1047,13 +1066,10 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
         {"usb_serial": "SER_A", "bus": 1, "address": 50},
         {"usb_serial": "SER_B", "bus": 1, "address": 51},
     ]
-    # CDC view before the mass entry (only used for the missing-from-
-    # BOOTSEL warning).
+    # CDC snapshot before the mass BOOTSEL entry (used for the missing-
+    # from-BOOTSEL warning; flash_and_discover_gpio only calls
+    # find_pico_ports once, before the GPIO entry).
     pre_cdc = {"/dev/ttyACM0": "SER_A", "/dev/ttyACM1": "SER_B"}
-    # CDC view after the fleet boot: the flashed fleet, at new /dev nodes
-    # and under their real CDC serials.
-    post_cdc = {"/dev/ttyACM5": "SER_A", "/dev/ttyACM6": "SER_B"}
-    reads = {"/dev/ttyACM5": {"app_id": 0}, "/dev/ttyACM6": {"app_id": 5}}
     # Boards still in BOOTSEL after the boot (default: none).
     stuck = []
 
@@ -1066,13 +1082,10 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
 
     monkeypatch.setattr(fp, "_find_bootsel_devices", fake_find_bootsel)
 
-    def fake_find_pico_ports():
-        return dict(post_cdc) if state["booted"] else dict(pre_cdc)
+    monkeypatch.setattr(fp, "find_pico_ports", lambda: dict(pre_cdc))
 
-    monkeypatch.setattr(fp, "find_pico_ports", fake_find_pico_ports)
-
-    # _boot_fleet_staggered is the phase boundary: it flips the view to
-    # post-boot and returns the serials that left BOOTSEL (every flashed
+    # _boot_fleet_staggered is the phase boundary: it marks the state as
+    # booted and returns the serials that left BOOTSEL (every flashed
     # board except the hardware-stuck ones). The real per-board reboot
     # logic is unit-tested separately.
     def fake_boot_fleet(flashed, **kw):
@@ -1096,12 +1109,6 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
 
     monkeypatch.setattr(fp.subprocess, "run", fake_run)
 
-    monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-    monkeypatch.setattr(
-        fp,
-        "read_json_from_serial",
-        lambda port, baud, timeout: reads[port],
-    )
     monkeypatch.setattr(fp.time, "sleep", lambda _: None)
 
     return types.SimpleNamespace(
@@ -1110,8 +1117,6 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
         cmds=cmds,
         bootsel=bootsel,
         pre_cdc=pre_cdc,
-        post_cdc=post_cdc,
-        reads=reads,
         stuck=stuck,
         fp=fp,
         monkeypatch=monkeypatch,
@@ -1511,9 +1516,48 @@ def test_main_confirmed_via_manager(monkeypatch, tmp_path, capsys):
         {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
         {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
     ])
+    # Confirmation now requires liveness: set both boards' heartbeats alive.
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[5])).set(ex=60, alive=True)
     monkeypatch.setattr(fp, "Transport", lambda host, port: t)
 
     fp.main(["--uf2", str(uf2)])
 
     out = capsys.readouterr().out
     assert "Confirmed 2/2" in out
+
+
+def test_main_straggler_exits_nonzero(monkeypatch, tmp_path, capsys):
+    """main() exits 1 and names the straggler when a flashed board is present
+    in pico_config but its heartbeat is NOT alive (booted but not reporting)."""
+    import picohost.flash_picos as fp
+    import picohost.gpio as gpio_mod
+
+    uf2 = tmp_path / "fw.uf2"
+    uf2.write_bytes(b"\x00")
+
+    monkeypatch.setattr(
+        fp, "flash_and_discover_gpio", lambda **kw: ["SER_A", "SER_B"]
+    )
+    monkeypatch.setattr(gpio_mod, "available", lambda: True)
+    monkeypatch.setattr(
+        fp.manager_service, "manager_is_active", lambda: True
+    )
+
+    t = DummyTransport()
+    # Both serials appear in pico_config…
+    PicoConfigStore(t).upload([
+        {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
+        {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
+    ])
+    # …but only SER_A's heartbeat is alive (motor, app_id=0).
+    # SER_B (rfswitch, app_id=5) has no heartbeat set → not alive.
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
+    monkeypatch.setattr(fp, "Transport", lambda host, port: t)
+
+    with pytest.raises(SystemExit) as excinfo:
+        fp.main(["--uf2", str(uf2)])
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "SER_B" in err
+    assert "NOT confirmed" in err

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -13,7 +13,6 @@ from picohost.buses import PicoConfigStore
 from picohost.flash_picos import (
     _await_manager_confirmation,
     _classify_read_failure,
-    _log_readback_reconciliation,
     _resolve_post_flash_port,
     flash_and_discover,
 )
@@ -85,27 +84,21 @@ def _mock_flash(monkeypatch, tmp_path):
 
 
 class TestFlashAndDiscover:
-    def test_returns_device_list(self, _mock_flash):
+    def test_returns_serial_list(self, _mock_flash):
         uf2, flashed = _mock_flash
-        devices = flash_and_discover(uf2_path=uf2)
-        assert len(devices) == 2
-        assert {d["app_id"] for d in devices} == {0, 5}
-        assert all("port" in d for d in devices)
-        assert all("usb_serial" in d for d in devices)
+        serials = flash_and_discover(uf2_path=uf2)
+        assert set(serials) == {"SER_A", "SER_B"}
         assert set(flashed) == {"SER_A", "SER_B"}
 
     def test_single_port_filter(self, _mock_flash):
         uf2, _ = _mock_flash
-        devices = flash_and_discover(uf2_path=uf2, port="/dev/ttyACM0")
-        assert len(devices) == 1
-        assert devices[0]["port"] == "/dev/ttyACM0"
+        serials = flash_and_discover(uf2_path=uf2, port="/dev/ttyACM0")
+        assert serials == ["SER_A"]
 
     def test_usb_serial_filter(self, _mock_flash):
         uf2, flashed = _mock_flash
-        devices = flash_and_discover(uf2_path=uf2, usb_serial="SER_B")
-        assert len(devices) == 1
-        assert devices[0]["usb_serial"] == "SER_B"
-        assert devices[0]["port"] == "/dev/ttyACM1"
+        serials = flash_and_discover(uf2_path=uf2, usb_serial="SER_B")
+        assert serials == ["SER_B"]
         assert flashed == ["SER_B"]
 
     def test_usb_serial_no_match_returns_empty(self, _mock_flash):
@@ -115,10 +108,10 @@ class TestFlashAndDiscover:
     def test_port_and_usb_serial_must_both_match(self, _mock_flash):
         uf2, _ = _mock_flash
         # SER_A is on /dev/ttyACM0, so this combination is empty
-        devices = flash_and_discover(
+        serials = flash_and_discover(
             uf2_path=uf2, port="/dev/ttyACM0", usb_serial="SER_B"
         )
-        assert devices == []
+        assert serials == []
 
     def test_missing_uf2_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="UF2 file not found"):
@@ -152,161 +145,7 @@ class TestFlashAndDiscover:
             ),
         )
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
         assert flash_and_discover(uf2_path=uf2) == []
-
-    def test_serial_read_failure_skips_device(self, monkeypatch, tmp_path):
-        import picohost.flash_picos as fp
-
-        uf2 = tmp_path / "test.uf2"
-        uf2.write_bytes(b"\x00")
-        monkeypatch.setattr(
-            fp,
-            "find_pico_ports",
-            lambda: {
-                "/dev/ttyACM0": "SER_A",
-            },
-        )
-        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: (_ for _ in ()).throw(
-                RuntimeError("timeout")
-            ),
-        )
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-        assert flash_and_discover(uf2_path=uf2) == []
-
-    def test_settles_udev_before_opening_post_flash_port(
-        self, monkeypatch, tmp_path
-    ):
-        """``udevadm settle`` must run between re-enumeration and the
-        serial open. The new ttyACM node exists with driver-default
-        permissions before udev applies the rule that chgrps it to
-        ``dialout``; opening immediately races against that and fails
-        intermittently with ``EACCES``. Settling closes the window.
-        """
-        import picohost.flash_picos as fp
-
-        uf2 = tmp_path / "test.uf2"
-        uf2.write_bytes(b"\x00")
-
-        monkeypatch.setattr(
-            fp, "find_pico_ports", lambda: {"/dev/ttyACM0": "SER_A"}
-        )
-        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-
-        events = []
-        monkeypatch.setattr(
-            fp, "_udev_settle", lambda: events.append("settle")
-        )
-
-        def fake_read(port, baud, timeout):
-            events.append(("read", port))
-            return {"app_id": 0}
-
-        monkeypatch.setattr(fp, "read_json_from_serial", fake_read)
-
-        devices = flash_and_discover(uf2_path=uf2)
-        assert len(devices) == 1
-        assert events == ["settle", ("read", "/dev/ttyACM0")]
-
-    def test_resolves_current_port_after_reenumeration(
-        self, monkeypatch, tmp_path
-    ):
-        """Picos may land on a different /dev/ttyACMn after the
-        post-flash reboot. The recorded ``port`` must reflect the
-        current path (looked up via the stable ``usb_serial``), not
-        the pre-flash path — otherwise two flashed Picos can collide
-        on the same recorded port and a Pico that drifted to an
-        unsnapshotted slot is silently dropped.
-        """
-        import picohost.flash_picos as fp
-
-        uf2 = tmp_path / "test.uf2"
-        uf2.write_bytes(b"\x00")
-
-        monkeypatch.setattr(
-            fp,
-            "find_pico_ports",
-            lambda: {
-                "/dev/ttyACM0": "SER_A",
-                "/dev/ttyACM1": "SER_B",
-            },
-        )
-
-        # Post-flash, both Picos have re-enumerated to different slots.
-        post_flash = {"SER_A": "/dev/ttyACM5", "SER_B": "/dev/ttyACM6"}
-        monkeypatch.setattr(
-            fp,
-            "_resolve_post_flash_port",
-            lambda serial: post_flash[serial],
-        )
-
-        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
-        serial_data = {
-            "/dev/ttyACM5": {"app_id": 0},
-            "/dev/ttyACM6": {"app_id": 5},
-        }
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: serial_data[port],
-        )
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-
-        devices = flash_and_discover(uf2_path=uf2)
-        by_serial = {d["usb_serial"]: d for d in devices}
-        assert by_serial["SER_A"]["port"] == "/dev/ttyACM5"
-        assert by_serial["SER_A"]["app_id"] == 0
-        assert by_serial["SER_B"]["port"] == "/dev/ttyACM6"
-        assert by_serial["SER_B"]["app_id"] == 5
-
-    def test_skips_device_that_does_not_reenumerate(
-        self, monkeypatch, tmp_path
-    ):
-        """A Pico that never re-appears after its post-flash reboot
-        must be dropped from the result rather than capturing some
-        other Pico's JSON via a stale port.
-        """
-        import picohost.flash_picos as fp
-
-        uf2 = tmp_path / "test.uf2"
-        uf2.write_bytes(b"\x00")
-
-        monkeypatch.setattr(
-            fp,
-            "find_pico_ports",
-            lambda: {
-                "/dev/ttyACM0": "SER_A",
-                "/dev/ttyACM1": "SER_B",
-            },
-        )
-
-        # SER_A never re-appears; SER_B comes back fine.
-        monkeypatch.setattr(
-            fp,
-            "_resolve_post_flash_port",
-            lambda serial: {"SER_B": "/dev/ttyACM1"}.get(serial),
-        )
-
-        monkeypatch.setattr(fp, "flash_uf2", lambda path, serial: None)
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: {"app_id": 5},
-        )
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-
-        devices = flash_and_discover(uf2_path=uf2)
-        assert len(devices) == 1
-        assert devices[0]["usb_serial"] == "SER_B"
-        assert devices[0]["port"] == "/dev/ttyACM1"
 
     def test_inter_device_settle_delay_before_second_and_later_flash(
         self, monkeypatch, tmp_path
@@ -333,23 +172,6 @@ class TestFlashAndDiscover:
             lambda path, serial: events.append(("flash", serial)),
         )
         monkeypatch.setattr(
-            fp,
-            "_resolve_post_flash_port",
-            lambda serial: {
-                "SER_A": "/dev/ttyACM0",
-                "SER_B": "/dev/ttyACM1",
-                "SER_C": "/dev/ttyACM2",
-            }[serial],
-        )
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: (
-                events.append(("read", port)) or {"app_id": 0}
-            ),
-        )
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-        monkeypatch.setattr(
             fp.time, "sleep", lambda s: events.append(("sleep", s))
         )
 
@@ -357,13 +179,10 @@ class TestFlashAndDiscover:
 
         assert events == [
             ("flash", "SER_A"),
-            ("read", "/dev/ttyACM0"),
             ("sleep", fp._INTER_DEVICE_SETTLE_S),
             ("flash", "SER_B"),
-            ("read", "/dev/ttyACM1"),
             ("sleep", fp._INTER_DEVICE_SETTLE_S),
             ("flash", "SER_C"),
-            ("read", "/dev/ttyACM2"),
         ]
 
 
@@ -701,89 +520,6 @@ class TestResolvePostFlashPort:
         assert calls["n"] >= 3
 
 
-class TestReadDeviceInfo:
-    """The post-flash device-info readback is a single attempt.
-
-    Failing boards fail persistently (wrong DIP, failed boot), so a
-    board whose read fails is dropped immediately rather than retried.
-    """
-
-    def _patch_common(self, monkeypatch, fp):
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-
-    def test_reads_device_info(self, monkeypatch):
-        import picohost.flash_picos as fp
-
-        self._patch_common(monkeypatch, fp)
-        monkeypatch.setattr(
-            fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
-        )
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: {"app_id": 3},
-        )
-
-        data = fp._read_device_info("SER_A", 115200, 1)
-        assert data == {
-            "app_id": 3,
-            "port": "/dev/ttyACM0",
-            "usb_serial": "SER_A",
-        }
-
-    def test_returns_none_on_read_failure(self, monkeypatch):
-        import picohost.flash_picos as fp
-
-        self._patch_common(monkeypatch, fp)
-        monkeypatch.setattr(
-            fp, "_resolve_post_flash_port", lambda s: "/dev/ttyACM0"
-        )
-
-        calls = {"n": 0}
-
-        def always_timeout(port, baud, timeout):
-            calls["n"] += 1
-            raise RuntimeError("Timed out waiting for JSON")
-
-        monkeypatch.setattr(fp, "read_json_from_serial", always_timeout)
-
-        data = fp._read_device_info("SER_A", 115200, 1)
-        assert data is None
-        assert calls["n"] == 1  # no retry
-
-    def test_returns_none_when_port_missing(self, monkeypatch):
-        """A Pico that never re-enumerated has no port to read from."""
-        import picohost.flash_picos as fp
-
-        self._patch_common(monkeypatch, fp)
-        monkeypatch.setattr(fp, "_resolve_post_flash_port", lambda s: None)
-
-        def fail_read(port, baud, timeout):
-            raise AssertionError("must not read without a port")
-
-        monkeypatch.setattr(fp, "read_json_from_serial", fail_read)
-
-        assert fp._read_device_info("SER_A", 115200, 1) is None
-
-    def test_gpio_flow_drops_unreadable_board(self, _mock_gpio_flash):
-        """End-to-end: a board whose read times out is dropped; the
-        rest of the fleet is still published."""
-        m = _mock_gpio_flash
-        # Cap the patient readback deadline so the unreadable board does
-        # not spin out the full window.
-        m.monkeypatch.setattr(m.fp, "_CDC_DISCOVER_TIMEOUT_S", 0.05)
-
-        def read(port, baud, timeout):
-            if port == "/dev/ttyACM6":  # SER_B never yields JSON
-                raise RuntimeError("Timed out waiting for JSON")
-            return {"/dev/ttyACM5": {"app_id": 0}}[port]
-
-        m.monkeypatch.setattr(m.fp, "read_json_from_serial", read)
-
-        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-
-        assert [d["usb_serial"] for d in devices] == ["SER_A"]
 
 
 class TestSerialReaderChild:
@@ -1383,14 +1119,10 @@ def _mock_gpio_flash(monkeypatch, tmp_path):
 
 
 class TestFlashAndDiscoverGpio:
-    def test_happy_path_returns_device_list(self, _mock_gpio_flash):
+    def test_happy_path_returns_serials(self, _mock_gpio_flash):
         m = _mock_gpio_flash
-        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        by_serial = {d["usb_serial"]: d for d in devices}
-        assert by_serial["SER_A"]["port"] == "/dev/ttyACM5"
-        assert by_serial["SER_A"]["app_id"] == 0
-        assert by_serial["SER_B"]["port"] == "/dev/ttyACM6"
-        assert by_serial["SER_B"]["app_id"] == 5
+        serials = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert set(serials) == {"SER_A", "SER_B"}
 
     def test_phase2_loads_use_only_picotool_load(self, _mock_gpio_flash):
         # Phase 2 (loading) never reboots: it loads each BOOTSEL device by
@@ -1438,12 +1170,10 @@ class TestFlashAndDiscoverGpio:
             m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
 
     def test_failed_load_excluded_but_boot_still_fires(self, _mock_gpio_flash):
-        # SER_A's load never succeeds, so it is not booted and never
-        # reaches CDC — absent from the results — but the fleet boot must
+        # SER_A's load never succeeds, so it is not in expected_serials
+        # and absent from the returned serials — but the fleet boot must
         # still run for the boards that did load.
         m = _mock_gpio_flash
-        del m.post_cdc["/dev/ttyACM5"]  # SER_A doesn't come back to CDC
-        m.reads.pop("/dev/ttyACM5", None)
         m.stuck.append({"usb_serial": "SER_A", "bus": 1, "address": 50})
 
         def fake_run(cmd, **kw):
@@ -1454,8 +1184,8 @@ class TestFlashAndDiscoverGpio:
             return types.SimpleNamespace(returncode=rc, stdout="boom")
 
         m.monkeypatch.setattr(m.fp.subprocess, "run", fake_run)
-        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert [d["usb_serial"] for d in devices] == ["SER_B"]
+        serials = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        assert serials == ["SER_B"]
         assert m.events.count("boot_fleet") == 1
 
     def test_stuck_in_bootsel_is_logged_as_hardware(
@@ -1465,8 +1195,6 @@ class TestFlashAndDiscoverGpio:
         # per-board reboot is the hardware case — surface it by
         # serial/bus/address for the operator.
         m = _mock_gpio_flash
-        del m.post_cdc["/dev/ttyACM6"]  # SER_B never reaches CDC
-        m.reads.pop("/dev/ttyACM6", None)
         m.stuck.append({"usb_serial": "SER_B", "bus": 1, "address": 51})
         m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         assert "still in BOOTSEL" in caplog.text
@@ -1502,128 +1230,19 @@ class TestFlashAndDiscoverGpio:
         ]
         assert load_addrs[:2] == ["50", "60"]
 
-    def test_serialless_bootsel_device_reported_via_cdc(
+    def test_serialless_bootsel_device_is_loaded(
         self, _mock_gpio_flash
     ):
         # A board with no serial in BOOTSEL still flashes (by bus/
-        # address) and, once it reboots into CDC under its real serial,
-        # is reported — the readback keys off the CDC serial, not the
-        # BOOTSEL one.
+        # address). It cannot be tracked in the returned serials
+        # (no usb_serial), but its load must be attempted.
         m = _mock_gpio_flash
         m.bootsel.append({"usb_serial": None, "bus": 1, "address": 52})
-        m.post_cdc["/dev/ttyACM7"] = "SER_C"
-        m.reads["/dev/ttyACM7"] = {"app_id": 6}
-        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
+        serials = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
         flashed_addrs = {c[c.index("--address") + 1] for c in m.cmds}
         assert "52" in flashed_addrs
-        assert {d["usb_serial"] for d in devices} == {
-            "SER_A",
-            "SER_B",
-            "SER_C",
-        }
-
-    def test_reports_board_with_mismatched_bootsel_serial(
-        self, _mock_gpio_flash
-    ):
-        # The serial a board presents in BOOTSEL can differ from its CDC
-        # serial; keying the readback off the CDC serial still reports it.
-        m = _mock_gpio_flash
-        m.pre_cdc.clear()  # boards were already in BOOTSEL, not prior CDC
-        m.bootsel[0]["usb_serial"] = "BOOTSEL_ONLY"  # SER_A in BOOTSEL
-        devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
-
-    def test_reconciliation_confirms_all_reported(
-        self, _mock_gpio_flash, caplog
-    ):
-        # Happy path: the readback report confirms every flashed board
-        # reported, so an operator can trust the count at a glance.
-        m = _mock_gpio_flash
-        with caplog.at_level(logging.INFO, logger="picohost.flash_picos"):
-            m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert "all 2 flashed Pico(s) reported" in caplog.text
-
-    def test_reconciliation_names_silent_board(self, _mock_gpio_flash, caplog):
-        # SER_B re-enumerates but never emits JSON, even on the re-read:
-        # the report must name it (with the read-failure reason), not
-        # silently drop the count. Cap the patient deadline so the test
-        # does not spin out the full readback window on the mute board.
-        m = _mock_gpio_flash
-        m.monkeypatch.setattr(m.fp, "_CDC_DISCOVER_TIMEOUT_S", 0.05)
-
-        def read(port, baud, timeout):
-            if port == "/dev/ttyACM6":  # SER_B
-                raise RuntimeError("Timed out waiting for JSON")
-            return m.reads[port]
-
-        m.monkeypatch.setattr(m.fp, "read_json_from_serial", read)
-        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert "1 of 2 flashed Pico(s) reported" in caplog.text
-        assert "serial=SER_B NOT reported" in caplog.text
-        assert "no JSON before timeout" in caplog.text
-
-    def test_mute_board_recovered_on_a_later_poll(
-        self, _mock_gpio_flash, caplog
-    ):
-        # SER_B is mute on the first read (a momentary enumeration race)
-        # but answers on a later poll once the bus quiets. The patient
-        # readback must recover it by re-READING it — there is no re-flash
-        # fallback.
-        m = _mock_gpio_flash
-        calls = {"/dev/ttyACM6": 0}
-
-        def read(port, baud, timeout):
-            if port == "/dev/ttyACM6":  # SER_B: mute on pass 1, OK on re-read
-                calls[port] += 1
-                if calls[port] == 1:
-                    raise RuntimeError("Timed out waiting for JSON")
-                return {"app_id": 5}
-            return m.reads[port]
-
-        m.monkeypatch.setattr(m.fp, "read_json_from_serial", read)
-        with caplog.at_level(logging.INFO, logger="picohost.flash_picos"):
-            devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
-        assert (
-            "Read device info from /dev/ttyACM6 (serial=SER_B)" in caplog.text
-        )
-
-    def test_board_silent_in_discovery_recovered_by_sweep(
-        self, _mock_gpio_flash, caplog
-    ):
-        # SER_B is alive and emitting but loses its reads during the busy
-        # fast-give-up discovery pass (short timeout); on the quiet-bus sweep
-        # (patient timeout) it answers. Distinguish the phases by the read
-        # timeout: the sweep reads with the full timeout, discovery with the
-        # short one.
-        m = _mock_gpio_flash
-        m.monkeypatch.setattr(m.fp, "_CDC_DISCOVER_TIMEOUT_S", 0.05)
-
-        def read(port, baud, timeout):
-            if port == "/dev/ttyACM6":  # SER_B
-                if timeout < m.fp._CDC_READ_TIMEOUT_S:  # discovery (fast)
-                    raise RuntimeError("Timed out waiting for JSON")
-                return {"app_id": 5}  # sweep (patient)
-            return m.reads[port]
-
-        m.monkeypatch.setattr(m.fp, "read_json_from_serial", read)
-        with caplog.at_level(logging.INFO, logger="picohost.flash_picos"):
-            devices = m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
-        assert "reconcile sweep recovered serial=SER_B" in caplog.text
-
-    def test_absent_board_reported_not_recovered(
-        self, _mock_gpio_flash, caplog
-    ):
-        # A board that never re-enumerated as CDC cannot be read or
-        # recovered over USB — it is reported as not re-enumerated, not
-        # silently dropped (and there is no re-flash to attempt).
-        m = _mock_gpio_flash
-        m.bootsel.append({"usb_serial": "SER_D", "bus": 1, "address": 52})
-        m.monkeypatch.setattr(m.fp, "_CDC_DISCOVER_TIMEOUT_S", 0.01)
-        m.fp.flash_and_discover_gpio(uf2_path=m.uf2)
-        assert "serial=SER_D NOT reported" in caplog.text
-        assert "did not re-enumerate as CDC" in caplog.text
+        # serialless board not in returned serials (no usb_serial to track)
+        assert set(serials) == {"SER_A", "SER_B"}
 
     def test_missing_uf2_raises_before_any_gpio_action(
         self, _mock_gpio_flash, tmp_path
@@ -1731,177 +1350,6 @@ class TestBootFleetStaggered:
         ]
 
 
-class TestReadFleetCdcPatient:
-    """_read_fleet_cdc keeps polling for boards to (re)enumerate as CDC and
-    reads each as it appears, so a board whose CDC enumeration flickers on
-    the contended hub is not dropped by a single-snapshot read."""
-
-    def _patch(self, monkeypatch):
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-
-    def test_flickering_boards_never_simultaneous_all_read(self, monkeypatch):
-        # SER_A and SER_B never appear in the SAME scan — A on odd scans,
-        # B on even. A single-snapshot read sees only one; the patient
-        # readback must catch both as they each appear.
-        self._patch(monkeypatch)
-        scans = {"n": 0}
-
-        def fake_find():
-            scans["n"] += 1
-            if scans["n"] % 2 == 1:
-                return {"/dev/ttyACM0": "SER_A"}
-            return {"/dev/ttyACM1": "SER_B"}
-
-        monkeypatch.setattr(fp, "find_pico_ports", fake_find)
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: {"app_id": 0},
-        )
-        devices, outcomes = fp._read_fleet_cdc(2, 115200)
-        assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
-        assert outcomes["SER_A"] is None
-        assert outcomes["SER_B"] is None
-
-    def test_already_read_board_is_not_re_read(self, monkeypatch):
-        # Once a board has been read, later polls must not open it again —
-        # re-reading a marginal node can re-disturb it. SER_A reads on the
-        # first pass; SER_B only appears on the third scan, so the loop
-        # keeps polling, but SER_A must be read exactly once.
-        self._patch(monkeypatch)
-        scans = {"n": 0}
-
-        def fake_find():
-            scans["n"] += 1
-            ports = {"/dev/ttyACM0": "SER_A"}
-            if scans["n"] >= 3:
-                ports["/dev/ttyACM1"] = "SER_B"
-            return ports
-
-        monkeypatch.setattr(fp, "find_pico_ports", fake_find)
-        reads = []
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: reads.append(port) or {"app_id": 0},
-        )
-        devices, _ = fp._read_fleet_cdc(2, 115200)
-        assert {d["usb_serial"] for d in devices} == {"SER_A", "SER_B"}
-        assert reads.count("/dev/ttyACM0") == 1  # SER_A read exactly once
-
-    def test_mute_board_recovers_on_later_poll(self, monkeypatch):
-        # A board present but mute on the first read is retried on the next
-        # poll and recovered; its outcome ends up None (success).
-        self._patch(monkeypatch)
-        monkeypatch.setattr(
-            fp, "find_pico_ports", lambda: {"/dev/ttyACM1": "SER_B"}
-        )
-        calls = {"n": 0}
-
-        def read(port, baud, timeout):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                raise RuntimeError("Timed out waiting for JSON")
-            return {"app_id": 5}
-
-        monkeypatch.setattr(fp, "read_json_from_serial", read)
-        devices, outcomes = fp._read_fleet_cdc(1, 115200)
-        assert [d["usb_serial"] for d in devices] == ["SER_B"]
-        assert outcomes["SER_B"] is None
-
-    def test_absent_board_is_bounded_by_deadline(self, monkeypatch):
-        # A board that never (re)enumerates must not hang the readback: the
-        # loop returns after the bounded deadline with only what appeared.
-        self._patch(monkeypatch)
-        monkeypatch.setattr(fp, "_CDC_DISCOVER_TIMEOUT_S", 0.05)
-        monkeypatch.setattr(
-            fp, "find_pico_ports", lambda: {"/dev/ttyACM0": "SER_A"}
-        )
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda port, baud, timeout: {"app_id": 0},
-        )
-        # Expect 2 boards but only 1 ever appears — must still return.
-        devices, outcomes = fp._read_fleet_cdc(2, 115200)
-        assert [d["usb_serial"] for d in devices] == ["SER_A"]
-        assert "SER_B" not in outcomes
-
-
-class TestReconcileSilentBoards:
-    """_reconcile_silent_boards gives boards that enumerated but stayed
-    silent during the busy discovery pass a patient re-read on a now-quiet
-    bus — the recovery the fast-give-up first pass deliberately defers."""
-
-    def _patch(self, monkeypatch):
-        monkeypatch.setattr(fp, "_udev_settle", lambda: None)
-        monkeypatch.setattr(fp.time, "sleep", lambda _: None)
-
-    def test_recovers_board_that_answers_on_a_later_attempt(self, monkeypatch):
-        self._patch(monkeypatch)
-        monkeypatch.setattr(
-            fp, "find_pico_ports", lambda: {"/dev/ttyACM1": "SER_B"}
-        )
-        calls = {"n": 0}
-
-        def read(port, baud, timeout):
-            calls["n"] += 1
-            if calls["n"] < 2:
-                raise RuntimeError("Timed out waiting for JSON")
-            return {"app_id": 5}
-
-        monkeypatch.setattr(fp, "read_json_from_serial", read)
-        devices, outcomes = fp._reconcile_silent_boards({"SER_B"}, 115200)
-        assert [d["usb_serial"] for d in devices] == ["SER_B"]
-        assert outcomes["SER_B"] is None
-
-    def test_skips_board_not_present_as_cdc(self, monkeypatch):
-        # A board that never enumerated cannot be re-read over USB; the
-        # sweep only touches boards that are present.
-        self._patch(monkeypatch)
-        monkeypatch.setattr(
-            fp, "find_pico_ports", lambda: {"/dev/ttyACM1": "SER_B"}
-        )
-
-        def read(port, baud, timeout):
-            raise AssertionError("must not read an absent board")
-
-        monkeypatch.setattr(fp, "read_json_from_serial", read)
-        devices, outcomes = fp._reconcile_silent_boards({"SER_GONE"}, 115200)
-        assert devices == []
-        assert "SER_GONE" not in outcomes
-
-    def test_persistently_silent_board_returns_reason(self, monkeypatch):
-        self._patch(monkeypatch)
-        monkeypatch.setattr(
-            fp, "find_pico_ports", lambda: {"/dev/ttyACM1": "SER_B"}
-        )
-        monkeypatch.setattr(
-            fp,
-            "read_json_from_serial",
-            lambda *a, **k: (_ for _ in ()).throw(
-                RuntimeError("Timed out waiting for JSON")
-            ),
-        )
-        devices, outcomes = fp._reconcile_silent_boards(
-            {"SER_B"}, 115200, attempts=2
-        )
-        assert devices == []
-        assert outcomes["SER_B"] is not None
-
-    def test_no_missing_boards_is_a_noop(self, monkeypatch):
-        self._patch(monkeypatch)
-
-        def boom():
-            raise AssertionError("must not scan when nothing is missing")
-
-        monkeypatch.setattr(fp, "find_pico_ports", boom)
-        devices, outcomes = fp._reconcile_silent_boards(set(), 115200)
-        assert devices == []
-        assert outcomes == {}
-
-
 class TestClassifyReadFailure:
     def test_runtime_timeout_is_silent_firmware(self):
         reason = _classify_read_failure(
@@ -1946,125 +1394,6 @@ class TestClassifyReadFailure:
         assert "some other failure" in reason
 
 
-class TestLogReadbackReconciliation:
-    def _reasons(self, caplog):
-        return caplog.text
-
-    def test_all_reported_logs_confirmation(self, caplog):
-        with caplog.at_level(logging.INFO, logger="picohost.flash_picos"):
-            _log_readback_reconciliation(
-                {"A", "B"}, {"A", "B"}, {"A": None, "B": None}
-            )
-        assert "all 2 flashed Pico(s) reported" in caplog.text
-
-    def test_board_absent_from_cdc_attributed_to_reenumeration(self, caplog):
-        _log_readback_reconciliation({"A", "B"}, {"A"}, {"A": None})
-        assert "serial=B NOT reported" in caplog.text
-        assert "did not re-enumerate as CDC" in caplog.text
-
-    def test_present_but_failed_carries_its_reason(self, caplog):
-        _log_readback_reconciliation(
-            {"A", "B"}, {"A", "B"}, {"A": None, "B": "port busy (EBUSY ...)"}
-        )
-        assert "serial=B NOT reported: port busy (EBUSY" in caplog.text
-
-    def test_unexpected_serial_is_named(self, caplog):
-        _log_readback_reconciliation({"A"}, {"A", "X"}, {"A": None, "X": None})
-        assert (
-            "serial=X reported but was not in the flashed set" in caplog.text
-        )
-
-    def test_none_baseline_falls_back_to_failure_logs(self, caplog):
-        # Without a flashed-serial baseline, still surface read failures.
-        _log_readback_reconciliation(
-            None, {"A"}, {"A": "permission denied opening port (EACCES ...)"}
-        )
-        assert "could not read device info for serial=A" in caplog.text
-        assert "EACCES" in caplog.text
-
-
-class TestMergeDeviceLists:
-    """_merge_device_lists merges freshly-read devices over the existing
-    Redis list by usb_serial, so a board lost to a flaky readback keeps its
-    last-known entry instead of being clobbered by a partial publish."""
-
-    def test_fresh_overrides_existing_same_serial(self):
-        existing = [{"usb_serial": "A", "app_id": 0, "port": "/dev/ttyACM0"}]
-        fresh = [{"usb_serial": "A", "app_id": 0, "port": "/dev/ttyACM5"}]
-        merged, preserved = fp._merge_device_lists(existing, fresh)
-        assert merged == [
-            {"usb_serial": "A", "app_id": 0, "port": "/dev/ttyACM5"}
-        ]
-        assert preserved == set()
-
-    def test_existing_board_absent_from_fresh_is_preserved(self):
-        # B flashed-and-ran but was lost to a flaky readback this run; it
-        # must survive in the published list rather than vanish.
-        existing = [
-            {"usb_serial": "A", "app_id": 0},
-            {"usb_serial": "B", "app_id": 5},
-        ]
-        fresh = [{"usb_serial": "A", "app_id": 0}]
-        merged, preserved = fp._merge_device_lists(existing, fresh)
-        by_serial = {d["usb_serial"]: d for d in merged}
-        assert by_serial.keys() == {"A", "B"}
-        assert by_serial["B"] == {"usb_serial": "B", "app_id": 5}
-        assert preserved == {"B"}
-
-    def test_no_existing_returns_fresh_only(self):
-        # First flash: nothing in Redis yet.
-        fresh = [{"usb_serial": "A", "app_id": 0}]
-        merged, preserved = fp._merge_device_lists(None, fresh)
-        assert merged == fresh
-        assert preserved == set()
-
-
-class TestPublishToRedisMerge:
-    """_publish_to_redis merges fresh devices over the existing Redis list
-    rather than overwriting it, so a partial readback never drops a board."""
-
-    def _patch_store(self, monkeypatch, existing):
-        published = {}
-
-        class FakeStore:
-            def __init__(self, transport):
-                pass
-
-            def get(self):
-                return existing
-
-            def upload(self, devices):
-                published["devices"] = devices
-
-        monkeypatch.setattr(fp, "Transport", lambda host, port: object())
-        monkeypatch.setattr(fp, "PicoConfigStore", FakeStore)
-        return published
-
-    def test_partial_readback_does_not_drop_existing_board(self, monkeypatch):
-        existing = [
-            {"usb_serial": "A", "app_id": 0},
-            {"usb_serial": "B", "app_id": 5},
-        ]
-        published = self._patch_store(monkeypatch, existing)
-        # This run only read A back; B was lost to a flaky readback.
-        result = fp._publish_to_redis(
-            [{"usb_serial": "A", "app_id": 0}], "h", 1
-        )
-        serials = {d["usb_serial"] for d in published["devices"]}
-        assert serials == {"A", "B"}  # B preserved, not clobbered
-        assert {d["usb_serial"] for d in result} == {"A", "B"}
-
-    def test_warns_when_a_board_rides_on_stale_data(self, monkeypatch, caplog):
-        existing = [
-            {"usb_serial": "A", "app_id": 0},
-            {"usb_serial": "B", "app_id": 5},
-        ]
-        self._patch_store(monkeypatch, existing)
-        fp._publish_to_redis([{"usb_serial": "A", "app_id": 0}], "h", 1)
-        assert "kept their previous Redis entry" in caplog.text
-        assert "B" in caplog.text
-
-
 class TestMainRouting:
     def _run_main(self, monkeypatch, argv, gpio_available=True):
         import picohost.flash_picos as fp
@@ -2077,15 +1406,15 @@ class TestMainRouting:
         monkeypatch.setattr(
             fp,
             "flash_and_discover",
-            lambda **kw: calls.append(("usb", kw)) or [{"app_id": 0}],
+            lambda **kw: calls.append(("usb", kw)) or ["SER_A"],
         )
         monkeypatch.setattr(
             fp,
             "flash_and_discover_gpio",
-            lambda **kw: calls.append(("gpio", kw)) or [{"app_id": 0}],
+            lambda **kw: calls.append(("gpio", kw)) or ["SER_A"],
         )
         monkeypatch.setattr(gpio_mod, "available", lambda: gpio_available)
-        fp.main(argv + ["--no-redis"])
+        fp.main(argv)
         return calls
 
     def test_default_routes_to_gpio(self, monkeypatch):
@@ -2137,115 +1466,54 @@ class TestMainRouting:
 
         monkeypatch.setattr(fp, "flash_and_discover_gpio", boom)
         with pytest.raises(SystemExit) as excinfo:
-            fp.main(["--uf2", "x.uf2", "--no-redis"])
+            fp.main(["--uf2", "x.uf2"])
         assert excinfo.value.code == 1
         assert "BOOTSEL" in capsys.readouterr().err
 
+    def test_manager_inactive_prints_not_active(self, monkeypatch, capsys):
+        import picohost.flash_picos as fp
+        import picohost.gpio as gpio_mod
 
-class TestManagerAutoStop:
-    """main() stops an active picomanager around the flash window."""
-
-    def _setup(
-        self, monkeypatch, tmp_path, active, devices=None, flash_exc=None
-    ):
-        uf2 = tmp_path / "fw.uf2"
-        uf2.write_bytes(b"\x00")
-        events = []
         monkeypatch.setattr(
-            fp.manager_service, "manager_is_active", lambda: active
+            fp.manager_service, "manager_is_active", lambda: False
         )
         monkeypatch.setattr(
-            fp.manager_service,
-            "stop_manager",
-            lambda: events.append("stop"),
+            fp, "flash_and_discover_gpio", lambda **kw: ["SER_A", "SER_B"]
         )
-        monkeypatch.setattr(
-            fp.manager_service,
-            "start_manager",
-            lambda: events.append("start"),
-        )
+        monkeypatch.setattr(gpio_mod, "available", lambda: True)
+        fp.main(["--uf2", "x.uf2"])
+        out = capsys.readouterr().out
+        assert "2 board(s)" in out
+        assert "picomanager is not active" in out
 
-        def fake_flash(**kwargs):
-            events.append("flash")
-            if flash_exc is not None:
-                raise flash_exc
-            return list(devices or [])
 
-        monkeypatch.setattr(fp, "flash_and_discover", fake_flash)
-        return uf2, events
+def test_main_confirmed_via_manager(monkeypatch, tmp_path, capsys):
+    """main() polls pico_config via the manager and prints 'Confirmed N/N'
+    when the manager is active and all flashed serials appear in time."""
+    import picohost.flash_picos as fp
+    import picohost.gpio as gpio_mod
+    from eigsep_redis.testing import DummyTransport
+    from picohost.buses import PicoConfigStore
 
-    def _argv(self, uf2):
-        return ["--uf2", str(uf2), "--no-gpio", "--no-redis"]
+    uf2 = tmp_path / "fw.uf2"
+    uf2.write_bytes(b"\x00")
 
-    def test_stops_then_flashes_then_restarts(self, monkeypatch, tmp_path):
-        uf2, events = self._setup(
-            monkeypatch,
-            tmp_path,
-            active=True,
-            devices=[{"app_id": 0, "port": "p", "usb_serial": "s"}],
-        )
-        fp.main(self._argv(uf2))
-        assert events == ["stop", "flash", "start"]
+    monkeypatch.setattr(
+        fp, "flash_and_discover_gpio", lambda **kw: ["SER_A", "SER_B"]
+    )
+    monkeypatch.setattr(gpio_mod, "available", lambda: True)
+    monkeypatch.setattr(
+        fp.manager_service, "manager_is_active", lambda: True
+    )
 
-    def test_restarts_after_flash_failure(self, monkeypatch, tmp_path):
-        uf2, events = self._setup(
-            monkeypatch,
-            tmp_path,
-            active=True,
-            flash_exc=RuntimeError("boom"),
-        )
-        with pytest.raises(SystemExit) as excinfo:
-            fp.main(self._argv(uf2))
-        assert excinfo.value.code == 1
-        assert events == ["stop", "flash", "start"]
+    t = DummyTransport()
+    PicoConfigStore(t).upload([
+        {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
+        {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
+    ])
+    monkeypatch.setattr(fp, "Transport", lambda host, port: t)
 
-    def test_restarts_when_no_devices_found(self, monkeypatch, tmp_path):
-        uf2, events = self._setup(
-            monkeypatch, tmp_path, active=True, devices=[]
-        )
-        with pytest.raises(SystemExit) as excinfo:
-            fp.main(self._argv(uf2))
-        assert excinfo.value.code == 1
-        assert events == ["stop", "flash", "start"]
+    fp.main(["--uf2", str(uf2)])
 
-    def test_inactive_manager_left_alone(self, monkeypatch, tmp_path):
-        # The eigsep-field patch flow: the coordinator already stopped
-        # the unit; flash-picos must not restart it behind its back.
-        uf2, events = self._setup(
-            monkeypatch,
-            tmp_path,
-            active=False,
-            devices=[{"app_id": 0, "port": "p", "usb_serial": "s"}],
-        )
-        fp.main(self._argv(uf2))
-        assert events == ["flash"]
-
-    def test_keep_manager_skips_stop(self, monkeypatch, tmp_path):
-        uf2, events = self._setup(
-            monkeypatch,
-            tmp_path,
-            active=True,
-            devices=[{"app_id": 0, "port": "p", "usb_serial": "s"}],
-        )
-        fp.main(self._argv(uf2) + ["--keep-manager"])
-        assert events == ["flash"]
-
-    def test_stop_failure_aborts_before_flash(
-        self, monkeypatch, tmp_path, capsys
-    ):
-        uf2, events = self._setup(
-            monkeypatch,
-            tmp_path,
-            active=True,
-            devices=[{"app_id": 0, "port": "p", "usb_serial": "s"}],
-        )
-
-        def failing_stop():
-            raise RuntimeError("cannot stop")
-
-        monkeypatch.setattr(fp.manager_service, "stop_manager", failing_stop)
-        with pytest.raises(SystemExit) as excinfo:
-            fp.main(self._argv(uf2))
-        assert excinfo.value.code == 1
-        assert "cannot stop" in capsys.readouterr().err
-        assert events == []
+    out = capsys.readouterr().out
+    assert "Confirmed 2/2" in out

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -2,7 +2,6 @@
 
 import errno
 import json
-import logging
 import types
 
 import pytest
@@ -23,16 +22,20 @@ from picohost.manager import APP_NAMES
 
 def _publish(transport, serials):
     PicoConfigStore(transport).upload(
-        [{"app_id": 0, "port": f"/dev/{s}", "usb_serial": s} for s in serials])
+        [{"app_id": 0, "port": f"/dev/{s}", "usb_serial": s} for s in serials]
+    )
 
 
 def test_confirmation_all_present():
     t = DummyTransport()
     _publish(t, ["A", "B"])
     # _publish uses app_id=0 for all serials → name "motor"; set its heartbeat alive.
-    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(
+        ex=60, alive=True
+    )
     confirmed, stragglers = _await_manager_confirmation(
-        {"A", "B"}, t, timeout=1.0, poll=0.01)
+        {"A", "B"}, t, timeout=1.0, poll=0.01
+    )
     assert confirmed == {"A", "B"} and stragglers == set()
 
 
@@ -41,9 +44,12 @@ def test_confirmation_timeout_reports_stragglers():
     _publish(t, ["A"])
     # "A" → app_id=0 → "motor"; set motor heartbeat alive so A is confirmed.
     # "B" is not in pico_config at all → straggler regardless.
-    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(
+        ex=60, alive=True
+    )
     confirmed, stragglers = _await_manager_confirmation(
-        {"A", "B"}, t, timeout=0.2, poll=0.01)
+        {"A", "B"}, t, timeout=0.2, poll=0.01
+    )
     assert confirmed == {"A"} and stragglers == {"B"}
 
 
@@ -56,7 +62,8 @@ def test_confirmation_present_but_not_alive_is_straggler():
     # Deliberately do NOT set the heartbeat alive: the board is in pico_config
     # but never came back after flash (or its heartbeat expired).
     confirmed, stragglers = _await_manager_confirmation(
-        {"A"}, t, timeout=0.2, poll=0.01)
+        {"A"}, t, timeout=0.2, poll=0.01
+    )
     assert confirmed == set() and stragglers == {"A"}
 
 
@@ -539,8 +546,6 @@ class TestResolvePostFlashPort:
         monkeypatch.setattr(fp.time, "sleep", lambda _: None)
         assert _resolve_post_flash_port("SER_Z", timeout=1.0) == "/dev/ttyACM7"
         assert calls["n"] >= 3
-
-
 
 
 class TestSerialReaderChild:
@@ -1235,9 +1240,7 @@ class TestFlashAndDiscoverGpio:
         ]
         assert load_addrs[:2] == ["50", "60"]
 
-    def test_serialless_bootsel_device_is_loaded(
-        self, _mock_gpio_flash
-    ):
+    def test_serialless_bootsel_device_is_loaded(self, _mock_gpio_flash):
         # A board with no serial in BOOTSEL still flashes (by bus/
         # address). It cannot be tracked in the returned serials
         # (no usb_serial), but its load must be attempted.
@@ -1507,18 +1510,22 @@ def test_main_confirmed_via_manager(monkeypatch, tmp_path, capsys):
         fp, "flash_and_discover_gpio", lambda **kw: ["SER_A", "SER_B"]
     )
     monkeypatch.setattr(gpio_mod, "available", lambda: True)
-    monkeypatch.setattr(
-        fp.manager_service, "manager_is_active", lambda: True
-    )
+    monkeypatch.setattr(fp.manager_service, "manager_is_active", lambda: True)
 
     t = DummyTransport()
-    PicoConfigStore(t).upload([
-        {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
-        {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
-    ])
+    PicoConfigStore(t).upload(
+        [
+            {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
+            {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
+        ]
+    )
     # Confirmation now requires liveness: set both boards' heartbeats alive.
-    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
-    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[5])).set(ex=60, alive=True)
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(
+        ex=60, alive=True
+    )
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[5])).set(
+        ex=60, alive=True
+    )
     monkeypatch.setattr(fp, "Transport", lambda host, port: t)
 
     fp.main(["--uf2", str(uf2)])
@@ -1540,19 +1547,21 @@ def test_main_straggler_exits_nonzero(monkeypatch, tmp_path, capsys):
         fp, "flash_and_discover_gpio", lambda **kw: ["SER_A", "SER_B"]
     )
     monkeypatch.setattr(gpio_mod, "available", lambda: True)
-    monkeypatch.setattr(
-        fp.manager_service, "manager_is_active", lambda: True
-    )
+    monkeypatch.setattr(fp.manager_service, "manager_is_active", lambda: True)
 
     t = DummyTransport()
     # Both serials appear in pico_config…
-    PicoConfigStore(t).upload([
-        {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
-        {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
-    ])
+    PicoConfigStore(t).upload(
+        [
+            {"usb_serial": "SER_A", "app_id": 0, "port": "/dev/ttyACM0"},
+            {"usb_serial": "SER_B", "app_id": 5, "port": "/dev/ttyACM1"},
+        ]
+    )
     # …but only SER_A's heartbeat is alive (motor, app_id=0).
     # SER_B (rfswitch, app_id=5) has no heartbeat set → not alive.
-    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(ex=60, alive=True)
+    HeartbeatWriter(t, name=pico_heartbeat_name(APP_NAMES[0])).set(
+        ex=60, alive=True
+    )
     monkeypatch.setattr(fp, "Transport", lambda host, port: t)
 
     with pytest.raises(SystemExit) as excinfo:

--- a/picohost/tests/test_flash_picos.py
+++ b/picohost/tests/test_flash_picos.py
@@ -8,12 +8,36 @@ import types
 import pytest
 
 import picohost.flash_picos as fp
+from eigsep_redis.testing import DummyTransport
+from picohost.buses import PicoConfigStore
 from picohost.flash_picos import (
+    _await_manager_confirmation,
     _classify_read_failure,
     _log_readback_reconciliation,
     _resolve_post_flash_port,
     flash_and_discover,
 )
+
+
+def _publish(transport, serials):
+    PicoConfigStore(transport).upload(
+        [{"app_id": 0, "port": f"/dev/{s}", "usb_serial": s} for s in serials])
+
+
+def test_confirmation_all_present():
+    t = DummyTransport()
+    _publish(t, ["A", "B"])
+    confirmed, stragglers = _await_manager_confirmation(
+        {"A", "B"}, t, timeout=1.0, poll=0.01)
+    assert confirmed == {"A", "B"} and stragglers == set()
+
+
+def test_confirmation_timeout_reports_stragglers():
+    t = DummyTransport()
+    _publish(t, ["A"])
+    confirmed, stragglers = _await_manager_confirmation(
+        {"A", "B"}, t, timeout=0.2, poll=0.01)
+    assert confirmed == {"A"} and stragglers == {"B"}
 
 
 @pytest.fixture

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -489,6 +489,69 @@ class TestReconnectHook:
         assert switch.port == original_port
 
 
+# --- continuous self-discovery --------------------------------------------
+
+
+class TestDiscoverNew:
+    def _patch_scan(self, monkeypatch, ports, status_by_port):
+        import picohost.manager as mgr_mod
+        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: ports)
+        monkeypatch.setattr(
+            mgr_mod, "read_json_from_serial",
+            lambda port, baud, timeout: status_by_port[port],
+        )
+        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch)
+        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "motor", DummyPicoMotor)
+
+    def test_adopts_unbound_port(self, mgr, monkeypatch):
+        self._patch_scan(monkeypatch, {"/dev/dummy": "ABC"},
+                         {"/dev/dummy": {"app_id": 5, "sensor_name": "rfswitch"}})
+        mgr._discover_new()
+        assert "rfswitch" in mgr.picos
+        assert PicoConfigStore(mgr.transport).get() == [
+            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"}]
+
+    def test_skips_already_bound_serial(self, mgr, monkeypatch):
+        _attach(mgr, "rfswitch", DummyPicoRFSwitch)
+        mgr.picos["rfswitch"].usb_serial = "ABC"
+        self._patch_scan(monkeypatch, {"/dev/dummy2": "ABC"},
+                         {"/dev/dummy2": {"app_id": 5}})
+        probed = []
+        import picohost.manager as mgr_mod
+        monkeypatch.setattr(mgr_mod, "read_json_from_serial",
+                            lambda *a: probed.append(a))
+        mgr._discover_new()
+        assert probed == []                       # bound serial never probed
+
+    def test_skips_duplicate_app_id(self, mgr, monkeypatch):
+        _attach(mgr, "rfswitch", DummyPicoRFSwitch)
+        mgr.picos["rfswitch"].usb_serial = "FIRST"
+        self._patch_scan(monkeypatch, {"/dev/dummy3": "SECOND"},
+                         {"/dev/dummy3": {"app_id": 5}})  # also rfswitch
+        mgr._discover_new()
+        assert mgr.picos["rfswitch"].usb_serial == "FIRST"   # not overwritten
+
+    def test_skips_unknown_app_id(self, mgr, monkeypatch):
+        self._patch_scan(monkeypatch, {"/dev/dummy": "ABC"},
+                         {"/dev/dummy": {"app_id": 99}})
+        mgr._discover_new()
+        assert mgr.picos == {}
+
+    def test_skips_serial_less_port(self, mgr, monkeypatch):
+        self._patch_scan(monkeypatch, {"/dev/dummy": None},
+                         {"/dev/dummy": {"app_id": 5}})
+        mgr._discover_new()
+        assert mgr.picos == {}
+
+    def test_mute_probe_does_not_adopt(self, mgr, monkeypatch):
+        import picohost.manager as mgr_mod
+        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {"/dev/d": "ABC"})
+        def boom(*a): raise RuntimeError("timed out")
+        monkeypatch.setattr(mgr_mod, "read_json_from_serial", boom)
+        mgr._discover_new()                       # must not raise
+        assert mgr.picos == {}
+
+
 # --- module-level constants -----------------------------------------------
 
 

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -313,72 +313,22 @@ class TestLifecycle:
 
 
 class TestDiscover:
-    def test_empty_redis_is_a_noop_without_uf2(self, mgr, tmp_path):
-        """discover() with empty Redis and no UF2 just produces zero picos."""
-        mgr.uf2_path = tmp_path / "nonexistent.uf2"
+    def test_empty_bus_is_a_noop(self, mgr, monkeypatch):
+        import picohost.manager as mgr_mod
+        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {})
         mgr.discover()
         assert mgr.picos == {}
 
-    def test_redis_config_instantiates_devices(self, mgr, monkeypatch):
-        """discover() reads the PicoConfigStore and builds devices."""
+    def test_discover_scans_live_ports(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        PicoConfigStore(mgr.transport).upload(
-            [
-                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"},
-            ]
-        )
+        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "ABC"})
+        monkeypatch.setattr(mgr_mod, "read_json_from_serial",
+                            lambda *a: {"app_id": 5})
+        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch)
         mgr.discover()
         assert "rfswitch" in mgr.picos
-
-    def test_discover_emits_initial_heartbeat(self, mgr, monkeypatch):
-        """Each registered device gets an alive heartbeat as soon as it lands."""
-        import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        PicoConfigStore(mgr.transport).upload(
-            [
-                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"},
-            ]
-        )
-        mgr.discover()
-        hb_reader = HeartbeatReader(
-            mgr.transport, name=pico_heartbeat_name("rfswitch")
-        )
-        assert hb_reader.check() is True
-
-    def test_flash_fallback_on_empty_redis(self, mgr, monkeypatch):
-        """discover() falls through to flash when Redis is empty."""
-        import picohost.flash_picos as fp_mod
-        import picohost.manager as mgr_mod
-
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
-        monkeypatch.setattr(
-            fp_mod,
-            "flash_and_discover",
-            lambda **kw: [
-                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
-            ],
-        )
-        mgr.discover()
-        assert "rfswitch" in mgr.picos
-        # Result is persisted back into Redis
-        stored = PicoConfigStore(mgr.transport).get()
-        assert stored == [
-            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
-        ]
-
-    def test_flash_fallback_uf2_missing_is_noop(self, mgr, tmp_path):
-        mgr.uf2_path = tmp_path / "nonexistent.uf2"
-        mgr._try_flash_discover()
-        assert mgr.picos == {}
+        assert PicoConfigStore(mgr.transport).get() == [
+            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"}]
 
 
 # --- manager commands -----------------------------------------------------
@@ -388,18 +338,13 @@ class TestManagerCommand:
     def test_rediscover_clears_and_reloads(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
 
-        monkeypatch.setitem(
-            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
-        )
+        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch)
+        monkeypatch.setattr(mgr_mod, "find_pico_ports",
+                            lambda: {"/dev/dummy": "X"})
+        monkeypatch.setattr(mgr_mod, "read_json_from_serial",
+                            lambda *a: {"app_id": 5})
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         assert "rfswitch" in mgr.picos
-
-        # Stage Redis config for the rediscover path to pick up
-        PicoConfigStore(mgr.transport).upload(
-            [
-                {"app_id": 5, "port": "/dev/dummy", "usb_serial": "X"},
-            ]
-        )
 
         mgr._process_command(
             "1-0",

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -315,20 +315,28 @@ class TestLifecycle:
 class TestDiscover:
     def test_empty_bus_is_a_noop(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
+
         monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {})
         mgr.discover()
         assert mgr.picos == {}
 
     def test_discover_scans_live_ports(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
-        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "ABC"})
-        monkeypatch.setattr(mgr_mod, "read_json_from_serial",
-                            lambda *a: {"app_id": 5})
-        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch)
+
+        monkeypatch.setattr(
+            mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "ABC"}
+        )
+        monkeypatch.setattr(
+            mgr_mod, "read_json_from_serial", lambda *a: {"app_id": 5}
+        )
+        monkeypatch.setitem(
+            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
+        )
         mgr.discover()
         assert "rfswitch" in mgr.picos
         assert PicoConfigStore(mgr.transport).get() == [
-            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"}]
+            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"}
+        ]
 
 
 # --- manager commands -----------------------------------------------------
@@ -338,11 +346,15 @@ class TestManagerCommand:
     def test_rediscover_clears_and_reloads(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
 
-        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch)
-        monkeypatch.setattr(mgr_mod, "find_pico_ports",
-                            lambda: {"/dev/dummy": "X"})
-        monkeypatch.setattr(mgr_mod, "read_json_from_serial",
-                            lambda *a: {"app_id": 5})
+        monkeypatch.setitem(
+            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
+        )
+        monkeypatch.setattr(
+            mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "X"}
+        )
+        monkeypatch.setattr(
+            mgr_mod, "read_json_from_serial", lambda *a: {"app_id": 5}
+        )
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         assert "rfswitch" in mgr.picos
 
@@ -440,60 +452,82 @@ class TestReconnectHook:
 class TestDiscoverNew:
     def _patch_scan(self, monkeypatch, ports, status_by_port):
         import picohost.manager as mgr_mod
+
         monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: ports)
         monkeypatch.setattr(
-            mgr_mod, "read_json_from_serial",
+            mgr_mod,
+            "read_json_from_serial",
             lambda port, baud, timeout: status_by_port[port],
         )
-        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch)
+        monkeypatch.setitem(
+            mgr_mod.PICO_CLASSES, "rfswitch", DummyPicoRFSwitch
+        )
         monkeypatch.setitem(mgr_mod.PICO_CLASSES, "motor", DummyPicoMotor)
 
     def test_adopts_unbound_port(self, mgr, monkeypatch):
-        self._patch_scan(monkeypatch, {"/dev/dummy": "ABC"},
-                         {"/dev/dummy": {"app_id": 5, "sensor_name": "rfswitch"}})
+        self._patch_scan(
+            monkeypatch,
+            {"/dev/dummy": "ABC"},
+            {"/dev/dummy": {"app_id": 5, "sensor_name": "rfswitch"}},
+        )
         mgr._discover_new()
         assert "rfswitch" in mgr.picos
         assert PicoConfigStore(mgr.transport).get() == [
-            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"}]
+            {"app_id": 5, "port": "/dev/dummy", "usb_serial": "ABC"}
+        ]
 
     def test_skips_already_bound_serial(self, mgr, monkeypatch):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         mgr.picos["rfswitch"].usb_serial = "ABC"
-        self._patch_scan(monkeypatch, {"/dev/dummy2": "ABC"},
-                         {"/dev/dummy2": {"app_id": 5}})
+        self._patch_scan(
+            monkeypatch, {"/dev/dummy2": "ABC"}, {"/dev/dummy2": {"app_id": 5}}
+        )
         probed = []
         import picohost.manager as mgr_mod
-        monkeypatch.setattr(mgr_mod, "read_json_from_serial",
-                            lambda *a: probed.append(a))
+
+        monkeypatch.setattr(
+            mgr_mod, "read_json_from_serial", lambda *a: probed.append(a)
+        )
         mgr._discover_new()
-        assert probed == []                       # bound serial never probed
+        assert probed == []  # bound serial never probed
 
     def test_skips_duplicate_app_id(self, mgr, monkeypatch):
         _attach(mgr, "rfswitch", DummyPicoRFSwitch)
         mgr.picos["rfswitch"].usb_serial = "FIRST"
-        self._patch_scan(monkeypatch, {"/dev/dummy3": "SECOND"},
-                         {"/dev/dummy3": {"app_id": 5}})  # also rfswitch
+        self._patch_scan(
+            monkeypatch,
+            {"/dev/dummy3": "SECOND"},
+            {"/dev/dummy3": {"app_id": 5}},
+        )  # also rfswitch
         mgr._discover_new()
-        assert mgr.picos["rfswitch"].usb_serial == "FIRST"   # not overwritten
+        assert mgr.picos["rfswitch"].usb_serial == "FIRST"  # not overwritten
 
     def test_skips_unknown_app_id(self, mgr, monkeypatch):
-        self._patch_scan(monkeypatch, {"/dev/dummy": "ABC"},
-                         {"/dev/dummy": {"app_id": 99}})
+        self._patch_scan(
+            monkeypatch, {"/dev/dummy": "ABC"}, {"/dev/dummy": {"app_id": 99}}
+        )
         mgr._discover_new()
         assert mgr.picos == {}
 
     def test_skips_serial_less_port(self, mgr, monkeypatch):
-        self._patch_scan(monkeypatch, {"/dev/dummy": None},
-                         {"/dev/dummy": {"app_id": 5}})
+        self._patch_scan(
+            monkeypatch, {"/dev/dummy": None}, {"/dev/dummy": {"app_id": 5}}
+        )
         mgr._discover_new()
         assert mgr.picos == {}
 
     def test_mute_probe_does_not_adopt(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
-        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {"/dev/d": "ABC"})
-        def boom(*a): raise RuntimeError("timed out")
+
+        monkeypatch.setattr(
+            mgr_mod, "find_pico_ports", lambda: {"/dev/d": "ABC"}
+        )
+
+        def boom(*a):
+            raise RuntimeError("timed out")
+
         monkeypatch.setattr(mgr_mod, "read_json_from_serial", boom)
-        mgr._discover_new()                       # must not raise
+        mgr._discover_new()  # must not raise
         assert mgr.picos == {}
 
 

--- a/picohost/tests/test_manager_integration.py
+++ b/picohost/tests/test_manager_integration.py
@@ -22,7 +22,6 @@ from conftest import wait_for_condition, wait_for_settle
 from eigsep_redis import HeartbeatReader, MetadataSnapshotReader
 from eigsep_redis.testing import DummyTransport
 
-from picohost.buses import PicoConfigStore
 from picohost.keys import (
     PICO_CMD_STREAM,
     PICO_RESP_STREAM,
@@ -397,8 +396,12 @@ class TestDiscoverIntegration:
     def test_discover_creates_live_device(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
 
-        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "INT123"})
-        monkeypatch.setattr(mgr_mod, "read_json_from_serial", lambda *a: {"app_id": 5})
+        monkeypatch.setattr(
+            mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "INT123"}
+        )
+        monkeypatch.setattr(
+            mgr_mod, "read_json_from_serial", lambda *a: {"app_id": 5}
+        )
         monkeypatch.setitem(
             mgr_mod.PICO_CLASSES,
             "rfswitch",

--- a/picohost/tests/test_manager_integration.py
+++ b/picohost/tests/test_manager_integration.py
@@ -397,15 +397,8 @@ class TestDiscoverIntegration:
     def test_discover_creates_live_device(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod
 
-        PicoConfigStore(mgr.transport).upload(
-            [
-                {
-                    "app_id": 5,
-                    "port": "/dev/dummy",
-                    "usb_serial": "INT123",
-                },
-            ]
-        )
+        monkeypatch.setattr(mgr_mod, "find_pico_ports", lambda: {"/dev/dummy": "INT123"})
+        monkeypatch.setattr(mgr_mod, "read_json_from_serial", lambda *a: {"app_id": 5})
         monkeypatch.setitem(
             mgr_mod.PICO_CLASSES,
             "rfswitch",

--- a/picohost/uv.lock
+++ b/picohost/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.6.0"
+version = "3.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## Problem

Flashing the Pico fleet is reliable, but the intermittent **device-info readback** failure (`flash-picos` reporting "N-1 of N reported") got worse after splitting the fleet across a second USB hub. Root cause (confirmed on hardware): the firmware's USB-CDC stdout is gated on `tud_cdc_connected()` (host **DTR**). `flash-picos`'s readback churns open/close, and on a marginal hub a re-asserted DTR control transfer is occasionally lost, so a fully-working board (heartbeat LED still blinking) emits **zero** status for that readback window.

## What this does

Flips device-identity ownership from `flash-picos` to the always-running `PicoManager`, and removes the DTR dependency at the source:

1. **Firmware** (`CMakeLists.txt`): set `PICO_STDIO_USB_CONNECTION_WITHOUT_DTR=1` so `stdio_usb_connected()` returns `tud_ready()` instead of `tud_cdc_connected()` — status flows whenever USB is up, independent of DTR.
2. **PicoManager** (`manager.py`): a continuous self-discovery loop adopts any unbound CDC port by reading its self-identifying status line (`app_id`), folded into the health loop; `discover()` now live-scans instead of trusting cached Redis config, and the empty-Redis auto-flash path is gone. The manager holds ports open, so steady-state reads never churn DTR.
3. **flash-picos** (`flash_picos.py`): now **flash-only**. It deletes the serial readback machinery, no longer stops/restarts `picomanager` or publishes Redis (the `--keep-manager` flag is gone), and confirms flashed boards by polling the manager-owned `pico_config`.
4. **Redis `pico_config`** is now manager-written (sole writer); flash-picos only reads it.

### Confirmation requires liveness, not presence

`pico_config` is persistent and the manager is add-only, so on a reflash of the known fleet the serials are already present — presence alone would be a false green. Confirmation therefore requires each board's **per-name heartbeat to be `alive=True`** (the manager drives a board to `alive=False` while it's in BOOTSEL during the flash and back to `alive=True` only once it re-establishes the board afterward). A board that leaves BOOTSEL but never re-enumerates is reported as a straggler with a non-zero exit.

## Design docs

- Spec: `docs/specs/2026-06-25-pico-manager-discovery-design.md`
- Plan: `docs/plans/2026-06-25-pico-manager-owns-discovery.md`

## Testing

- `picohost` suite: **507 passed, 0 failed**.
- Firmware: `pico_test_blink` compiles cleanly with the new flag; CMake configure shows the define applied to both targets.

## Caveats / follow-ups

- **Firmware hardware verify pending:** the `pico_multi` full build needs the `BNO08x_Pico_Library` submodule (not initialized in the build env here), and the DTR behavior change must be confirmed on a board. The change itself is a one-line SDK compile flag verified against the vendored SDK source.
- **Behavior change for consumers:** during a flash, affected boards briefly publish `alive=False` (they're in BOOTSEL) before the manager re-adopts them.
- **Companion PR required:** `eigsep-field`'s `patch` flow must stop stopping `picomanager` (it now relies on the live manager to confirm). That change ships as a **draft** PR and must not merge ahead of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
