### PR TITLE
feat: IMU az/el calibration + live conversion

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -30,6 +30,7 @@ flash-test = "picohost.flash_test:main"
 pico-manager = "picohost.manager:main"
 calibrate-pot = "picohost.calibrate_pot:main"
 calibrate-current = "picohost.calibrate_current:main"
+calibrate-imu = "picohost.calibrate_imu:main"
 picohost-resolve = "picohost.resolve:main"
 pico-gpio = "picohost.gpio:main"
 

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -844,6 +844,12 @@ class PicoIMU(PicoDevice):
     with derived angles. ``imu_az`` reports az + el; ``imu_el`` reports el
     only (it cannot observe azimuth). All derived fields are ``None`` when
     that IMU is uncalibrated, so the published shape is stable.
+
+    Note on ``el_deg`` sign convention: ``imu_el.el_deg`` is SIGNED
+    (``el_from_imu``, negative below horizontal), while ``imu_az.el_deg``
+    is the unsigned magnitude |θ| (``el_abs_from_imu_az``, assumes θ≥0 for
+    a single-tick az estimate). Downstream consumers must account for this
+    difference.
     """
 
     def __init__(self, *args, imu_cal_store=None, **kwargs):

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -12,6 +12,7 @@ from serial import Serial
 from serial.tools import list_ports
 
 from .flash_picos import find_pico_ports
+from . import imu_geometry as ig
 
 logger = logging.getLogger(__name__)
 
@@ -836,9 +837,94 @@ class PicoPeltier(PicoDevice):
 
 
 class PicoIMU(PicoDevice):
-    """Specialized class for IMU devices (BNO08x UART RVC mode)."""
+    """IMU device (BNO08x UART RVC mode) with live az/el conversion.
 
-    pass
+    Loads its mount calibration from an :class:`ImuCalStore` section keyed
+    by sensor name (``imu_el`` / ``imu_az``) and augments each status tick
+    with derived angles. ``imu_az`` reports az + el; ``imu_el`` reports el
+    only (it cannot observe azimuth). All derived fields are ``None`` when
+    that IMU is uncalibrated, so the published shape is stable.
+    """
+
+    def __init__(self, *args, imu_cal_store=None, **kwargs):
+        # {"imu_el": {...}, "imu_az": {...}} — only loaded sections present.
+        self._imu_cal = {}
+        super().__init__(*args, **kwargs)
+        if imu_cal_store is not None:
+            cal = imu_cal_store.get()
+            if cal:
+                for key in ("imu_el", "imu_az"):
+                    if key in cal:
+                        self._imu_cal[key] = cal[key]
+        if self.redis_handler is not None:
+            self._base_redis_handler = self.redis_handler
+            self.redis_handler = self._imu_redis_handler
+
+    def set_calibration(self, imu_el=None, imu_az=None):
+        """Merge per-IMU calibration sections (live push from calibrate_imu)."""
+        if imu_el is not None:
+            self._imu_cal["imu_el"] = imu_el
+        if imu_az is not None:
+            self._imu_cal["imu_az"] = imu_az
+
+    @staticmethod
+    def _accel_unit(data, cal):
+        a = [data.get("accel_x"), data.get("accel_y"), data.get("accel_z")]
+        if any(v is None for v in a):
+            return None
+        return ig.precondition(a, cal["accel_bias"])
+
+    def _imu_redis_handler(self, data):
+        data = data.copy()
+        name = data.get("sensor_name")
+        cal = self._imu_cal.get(name)
+        if name == "imu_el":
+            data["el_deg"] = self._el_only(data, cal)
+        elif name == "imu_az":
+            data.update(self._az_and_el(data, cal))
+        self._base_redis_handler(data)
+
+    def _el_only(self, data, cal):
+        if cal is None:
+            return None
+        a = self._accel_unit(data, cal)
+        if a is None:
+            return None
+        return ig.el_from_imu(a, cal["M"])
+
+    def _az_and_el(self, data, cal):
+        out = {
+            "el_deg": None,
+            "az_deg": None,
+            "az_from_accel_deg": None,
+            "az_from_yaw_deg": None,
+            "az_blend_weight": None,
+        }
+        if cal is None:
+            return out
+        a = self._accel_unit(data, cal)
+        if a is None:
+            return out
+        M = cal["M"]
+        el = ig.el_abs_from_imu_az(a, M)
+        az_a = ig.az_from_accel(
+            a, M, cal["az_sign"], cal["az_accel_offset_deg"]
+        )
+        out["el_deg"] = el
+        out["az_from_accel_deg"] = az_a
+        yaw = data.get("yaw")
+        if yaw is not None:
+            az_y = ig.az_from_yaw(
+                yaw, cal["az_yaw_sign"], cal["az_yaw_offset_deg"]
+            )
+            az, w = ig.blend_az(az_a, az_y, el, cal["theta_cross_deg"])
+            out["az_from_yaw_deg"] = az_y
+            out["az_deg"] = az
+            out["az_blend_weight"] = w
+        else:
+            out["az_deg"] = az_a
+            out["az_blend_weight"] = 1.0
+        return out
 
 
 class PicoLidar(PicoDevice):

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -855,6 +855,7 @@ class PicoIMU(PicoDevice):
     def __init__(self, *args, imu_cal_store=None, **kwargs):
         # {"imu_el": {...}, "imu_az": {...}} — only loaded sections present.
         self._imu_cal = {}
+        self._imu_derive_warned = set()
         super().__init__(*args, **kwargs)
         if imu_cal_store is not None:
             cal = imu_cal_store.get()
@@ -884,11 +885,38 @@ class PicoIMU(PicoDevice):
         data = data.copy()
         name = data.get("sensor_name")
         cal = self._imu_cal.get(name)
-        if name == "imu_el":
-            data["el_deg"] = self._el_only(data, cal)
-        elif name == "imu_az":
-            data.update(self._az_and_el(data, cal))
+        try:
+            if name == "imu_el":
+                data["el_deg"] = self._el_only(data, cal)
+            elif name == "imu_az":
+                data.update(self._az_and_el(data, cal))
+        except Exception:
+            # A malformed/partial cal section (or a bad sample) must never
+            # suppress the raw firmware tick: publish raw with null derived
+            # fields, keeping the published shape stable. Warn once per IMU.
+            if name == "imu_el":
+                data["el_deg"] = None
+            elif name == "imu_az":
+                data.update(self._az_null())
+            if name not in self._imu_derive_warned:
+                self._imu_derive_warned.add(name)
+                self.logger.warning(
+                    "IMU derivation failed for %s; publishing raw with null "
+                    "derived fields — check the stored calibration section.",
+                    name,
+                )
         self._base_redis_handler(data)
+
+    @staticmethod
+    def _az_null():
+        """Null-valued imu_az derived shape (stable keys, no calibration)."""
+        return {
+            "el_deg": None,
+            "az_deg": None,
+            "az_from_accel_deg": None,
+            "az_from_yaw_deg": None,
+            "az_blend_weight": None,
+        }
 
     def _el_only(self, data, cal):
         if cal is None:
@@ -899,13 +927,7 @@ class PicoIMU(PicoDevice):
         return ig.el_from_imu(a, cal["M"])
 
     def _az_and_el(self, data, cal):
-        out = {
-            "el_deg": None,
-            "az_deg": None,
-            "az_from_accel_deg": None,
-            "az_from_yaw_deg": None,
-            "az_blend_weight": None,
-        }
+        out = self._az_null()
         if cal is None:
             return out
         a = self._accel_unit(data, cal)

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -46,6 +46,7 @@ from eigsep_redis import SingleStreamReader, SingleStreamWriter
 
 from .keys import (
     CURRENT_CAL_KEY,
+    IMU_CAL_KEY,
     MOTOR_POS_KEY,
     PICO_CMD_STREAM,
     PICO_CONFIG_KEY,
@@ -238,6 +239,60 @@ class CurrentCalStore:
     def clear(self):
         """Delete the stored calibration."""
         self.transport.r.delete(CURRENT_CAL_KEY)
+
+
+class ImuCalStore:
+    """Persistent single-key store for IMU mount calibration.
+
+    Value under :data:`IMU_CAL_KEY` is a JSON object with optional
+    ``imu_el`` / ``imu_az`` sections (each a mount calibration dict) plus
+    a ``metadata`` block; ``upload_time`` is injected by
+    :meth:`Transport.upload_dict` at the top level. Each section is
+    independent so a partially-calibrated fleet (e.g. ``imu_el`` dead)
+    round-trips cleanly.
+    A fresh :class:`picohost.PicoIMU` reads its own section at
+    ``__init__`` and applies the conversion from the first status tick.
+    """
+
+    def __init__(self, transport):
+        self.transport = transport
+
+    def upload(self, cal):
+        """Upload calibration parameters.
+
+        Parameters
+        ----------
+        cal : dict
+            May carry ``imu_az`` and/or ``imu_el`` section dicts and an
+            optional ``metadata`` block. Extra fields are preserved verbatim.
+        """
+        self.transport.upload_dict(cal, IMU_CAL_KEY)
+
+    def get(self):
+        """Return the stored calibration dict.
+
+        Returns
+        -------
+        dict or None
+            ``None`` if no calibration has been uploaded, or if the
+            stored JSON fails to decode. The caller falls back to
+            uncalibrated operation.
+        """
+        raw = self.transport.get_raw(IMU_CAL_KEY)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Corrupted {IMU_CAL_KEY} in Redis ({e}); "
+                "falling back to uncalibrated."
+            )
+            return None
+
+    def clear(self):
+        """Delete the stored calibration."""
+        self.transport.r.delete(IMU_CAL_KEY)
 
 
 class MotorPositionStore:

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -258,7 +258,13 @@ class ImuCalStore:
         self.transport = transport
 
     def upload(self, cal):
-        """Upload calibration parameters.
+        """Upload calibration parameters, merging into any existing store.
+
+        Read-modify-write: top-level keys in ``cal`` (sections and
+        ``metadata``) overwrite their counterparts, while sections absent
+        from ``cal`` are preserved. This keeps a partially-calibrated fleet
+        intact — e.g. a ``--mode elevation`` run that only produces
+        ``imu_el`` must not wipe a previously-stored ``imu_az`` section.
 
         Parameters
         ----------
@@ -266,7 +272,11 @@ class ImuCalStore:
             May carry ``imu_az`` and/or ``imu_el`` section dicts and an
             optional ``metadata`` block. Extra fields are preserved verbatim.
         """
-        self.transport.upload_dict(cal, IMU_CAL_KEY)
+        merged = self.get() or {}
+        # Drop the stale top-level upload_time; upload_dict re-injects it.
+        merged.pop("upload_time", None)
+        merged.update(cal)
+        self.transport.upload_dict(merged, IMU_CAL_KEY)
 
     def get(self):
         """Return the stored calibration dict.

--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -1,0 +1,239 @@
+"""Manual IMU mount calibration.
+
+Reads accel/yaw from stream:imu_az / stream:imu_el and az truth from
+stream:potmon (pot is the azimuth standard; the motor is a mover only and is
+never used as fit truth). Drives the operator through elevation + azimuth
+sweeps, fits each IMU's mount + zero via imu_geometry, then persists to
+ImuCalStore (BGSAVE) and live-pushes to each IMU via PicoProxy.
+
+Modes:
+  elevation : elevation sweep -> el calibration for alive IMUs
+  azimuth   : azimuth sweeps (near-level + tilted) -> imu_az az+el; needs pot
+  all       : guided full run (default)
+(A fast rezero-el re-level is a deferred follow-on; see the design doc.)
+"""
+
+from argparse import ArgumentParser
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+
+import numpy as np
+from eigsep_redis import Transport
+
+from .buses import ImuCalStore
+from .imu_geometry import fit_calibration_from_sweeps
+from .proxy import PicoProxy
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_TIMEOUT_S = 5.0
+IMU_AZ, IMU_EL, POTMON = "imu_az", "imu_el", "potmon"
+
+
+def collect_vector(transport, name, fields, n, start_id="$"):
+    """Average `n` fresh entries of `fields` from stream:<name>.
+
+    Reads only entries published after this call starts (``start_id``
+    defaults to ``"$"``), so repeated calls within one sweep don't
+    double-count the same firmware tick. Mirrors
+    :func:`calibrate_pot.collect_samples`' fail-fast semantics: if no new
+    entries arrive within ``SAMPLE_TIMEOUT_S``, raise rather than average a
+    stale value. Tests pass ``start_id="0-0"`` to read pre-loaded entries.
+    """
+    stream = f"stream:{name}"
+    rows, last_id = [], start_id
+    while len(rows) < n:
+        resp = transport.r.xread(
+            {stream: last_id},
+            block=int(SAMPLE_TIMEOUT_S * 1000),
+            count=n - len(rows),
+        )
+        if not resp:
+            raise RuntimeError(
+                f"No new entries on {stream} within {SAMPLE_TIMEOUT_S}s."
+            )
+        for _s, msgs in resp:
+            for msg_id, f in msgs:
+                value = json.loads(f[b"value"])
+                rows.append([float(value[k]) for k in fields])
+                last_id = msg_id
+    return np.mean(rows, axis=0)
+
+
+def stream_alive(transport, name, timeout_s=SAMPLE_TIMEOUT_S):
+    """True if stream:<name> publishes a NEW entry within timeout_s.
+
+    Uses a blocking ``$`` read so a dead-but-stale stream (old entries, no
+    current publisher) reads False — the graceful-degradation gate must not
+    treat a crashed IMU as alive and feed its junk into the fit.
+    """
+    resp = transport.r.xread(
+        {f"stream:{name}": "$"}, block=int(timeout_s * 1000), count=1
+    )
+    return bool(resp)
+
+
+class Calibrator:
+    """Operator-driven sweep collection (separated so tests can stub it)."""
+
+    def __init__(self, transport, n_samples, alive, mode):
+        self.transport = transport
+        self.n = n_samples
+        self.alive = alive  # set of alive stream names
+        self.mode = mode
+
+    def _accel(self, name):
+        return collect_vector(
+            self.transport, name, ("accel_x", "accel_y", "accel_z"), self.n
+        )
+
+    def _pot(self):
+        return float(
+            collect_vector(self.transport, POTMON, ("pot_az_angle",), self.n)[
+                0
+            ]
+        )
+
+    def _yaw(self):
+        return float(
+            collect_vector(self.transport, IMU_AZ, ("yaw",), self.n)[0]
+        )
+
+    def run_sweeps(self):
+        """Return (el_sweep, az_level, az_tilt) dicts, gated by self.mode.
+
+        Prompts the operator stop-by-stop; records pot/accel/yaw at rest.
+        """
+        el_sweep = {
+            "imu_el": None,
+            "imu_az": None,
+            "level_index": 0,
+            "direction": 1,
+        }
+        az_level = {"imu_az": None, "yaw_deg": None, "pot_deg": None}
+        az_tilt = {"imu_az": None, "pot_deg": None, "imu_el": None}
+        if self.mode in ("elevation", "all"):
+            el_sweep = self._elevation_sweep()
+        if self.mode in ("azimuth", "all"):
+            if IMU_AZ in self.alive and POTMON in self.alive:
+                az_level = self._az_sweep("near-LEVEL", want_yaw=True)
+                az_tilt = self._az_sweep("TILTED (~20-45 deg)", want_yaw=False)
+        return el_sweep, az_level, az_tilt
+
+    def _elevation_sweep(self):
+        el_el, el_az = [], []
+        print("\n== ELEVATION sweep ==")
+        input("Drive to the LEVEL pose (el 0), stop, press Enter.")
+        if IMU_EL in self.alive:
+            el_el.append(self._accel(IMU_EL))
+        if IMU_AZ in self.alive:
+            el_az.append(self._accel(IMU_AZ))
+        while True:
+            r = input("Next el stop + Enter (or 'q' to finish): ").strip()
+            if r.lower() == "q":
+                break
+            if IMU_EL in self.alive:
+                el_el.append(self._accel(IMU_EL))
+            if IMU_AZ in self.alive:
+                el_az.append(self._accel(IMU_AZ))
+        return {
+            "imu_el": np.array(el_el) if el_el else None,
+            "imu_az": np.array(el_az) if el_az else None,
+            "level_index": 0,
+            "direction": 1,
+        }
+
+    def _az_sweep(self, label, want_yaw):
+        print(f"\n== AZIMUTH sweep ({label}) ==")
+        acc, yaw, pot, el = [], [], [], []
+        input("Drive to the first az stop, stop, press Enter.")
+        while True:
+            acc.append(self._accel(IMU_AZ))
+            pot.append(self._pot())
+            if want_yaw:
+                yaw.append(self._yaw())
+            if IMU_EL in self.alive:
+                el.append(self._accel(IMU_EL))
+            r = input("Next az stop + Enter (or 'q' to finish): ").strip()
+            if r.lower() == "q":
+                break
+        out = {"imu_az": np.array(acc), "pot_deg": np.array(pot)}
+        out["yaw_deg"] = np.array(yaw) if want_yaw else None
+        out["imu_el"] = np.array(el) if el else None
+        return out
+
+
+def build_parser():
+    p = ArgumentParser(description="Calibrate IMU mount -> az/el conversion.")
+    p.add_argument(
+        "-m", "--mode", default="all", choices=["elevation", "azimuth", "all"]
+    )
+    p.add_argument("-n", "--n-samples", type=int, default=10)
+    p.add_argument("--theta-cross-deg", type=float, default=1.6)
+    p.add_argument("--redis-host", default="localhost")
+    p.add_argument("--redis-port", type=int, default=6379)
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO)
+    transport = Transport(host=args.redis_host, port=args.redis_port)
+
+    alive = {n for n in (IMU_AZ, IMU_EL, POTMON) if stream_alive(transport, n)}
+    if IMU_AZ not in alive and IMU_EL not in alive:
+        print("No IMU streams alive; nothing to calibrate.", file=sys.stderr)
+        return 1
+    if args.mode in ("azimuth", "all") and POTMON not in alive:
+        print(
+            "pot not alive; azimuth needs the pot standard.", file=sys.stderr
+        )
+        if args.mode == "azimuth":
+            return 1
+
+    cal = Calibrator(transport, args.n_samples, alive, args.mode)
+    el_sweep, az_level, az_tilt = cal.run_sweeps()
+    sections = fit_calibration_from_sweeps(
+        el_sweep, az_level, az_tilt, theta_cross_deg=args.theta_cross_deg
+    )
+    if not sections:
+        print("Fit produced no sections.", file=sys.stderr)
+        return 1
+
+    for name, sec in sections.items():
+        print(
+            f"\n{name}: mount_perm={sec.get('mount_perm')} "
+            f"misalign={sec.get('mount_misalign_deg'):.2f} deg "
+            f"accel_scale={sec['accel_scale']:.3f}"
+        )
+    if input("\nSave this calibration? [y/N]: ").strip().lower() not in (
+        "y",
+        "yes",
+    ):
+        print("Discarded.")
+        return 0
+
+    payload = dict(sections)
+    payload["metadata"] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "mode": args.mode,
+        "n_samples": args.n_samples,
+    }
+    ImuCalStore(transport).upload(payload)
+    transport.r.bgsave()
+    print("Published to Redis (key: imu_calibration); BGSAVE triggered.")
+
+    for name, sec in sections.items():
+        proxy = PicoProxy(name, transport, source="calibrate-imu")
+        try:
+            proxy.send_command("set_calibration", **{name: sec})
+            print(f"Live {name} updated.")
+        except (TimeoutError, RuntimeError) as e:
+            print(f"Live push to {name} failed: {e}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -22,8 +22,8 @@ from datetime import datetime, timezone
 import numpy as np
 from eigsep_redis import Transport
 
-from .buses import ImuCalStore
-from .imu_geometry import fit_calibration_from_sweeps
+from .buses import ImuCalStore, PotCalStore
+from .imu_geometry import circular_mean_deg, fit_calibration_from_sweeps
 from .proxy import PicoProxy
 
 logger = logging.getLogger(__name__)
@@ -32,8 +32,8 @@ SAMPLE_TIMEOUT_S = 5.0
 IMU_AZ, IMU_EL, POTMON = "imu_az", "imu_el", "potmon"
 
 
-def collect_vector(transport, name, fields, n, start_id="$"):
-    """Average `n` fresh entries of `fields` from stream:<name>.
+def collect_vector(transport, name, fields, n, start_id="$", reducer=None):
+    """Reduce `n` fresh entries of `fields` from stream:<name>.
 
     Reads only entries published after this call starts (``start_id``
     defaults to ``"$"``), so repeated calls within one sweep don't
@@ -41,6 +41,10 @@ def collect_vector(transport, name, fields, n, start_id="$"):
     :func:`calibrate_pot.collect_samples`' fail-fast semantics: if no new
     entries arrive within ``SAMPLE_TIMEOUT_S``, raise rather than average a
     stale value. Tests pass ``start_id="0-0"`` to read pre-loaded entries.
+
+    ``reducer`` maps the ``(n, len(fields))`` sample array to the reduced
+    result; it defaults to a per-field arithmetic mean. Pass a circular
+    reducer for angle fields (e.g. yaw) that wrap at +/-180.
     """
     stream = f"stream:{name}"
     rows, last_id = [], start_id
@@ -59,7 +63,8 @@ def collect_vector(transport, name, fields, n, start_id="$"):
                 value = json.loads(f[b"value"])
                 rows.append([float(value[k]) for k in fields])
                 last_id = msg_id
-    return np.mean(rows, axis=0)
+    arr = np.asarray(rows, dtype=float)
+    return arr.mean(axis=0) if reducer is None else reducer(arr)
 
 
 def stream_alive(transport, name, timeout_s=SAMPLE_TIMEOUT_S):
@@ -97,8 +102,13 @@ class Calibrator:
         )
 
     def _yaw(self):
-        return float(
-            collect_vector(self.transport, IMU_AZ, ("yaw",), self.n)[0]
+        # Yaw wraps at +/-180, so average it circularly, not linearly.
+        return collect_vector(
+            self.transport,
+            IMU_AZ,
+            ("yaw",),
+            self.n,
+            reducer=lambda r: circular_mean_deg(r[:, 0]),
         )
 
     def run_sweeps(self):
@@ -186,6 +196,18 @@ def main(argv=None):
     if IMU_AZ not in alive and IMU_EL not in alive:
         print("No IMU streams alive; nothing to calibrate.", file=sys.stderr)
         return 1
+    # The pot must be CALIBRATED, not merely alive, to serve as the az
+    # standard: an uncalibrated pot streams pot_az_angle=None, which would
+    # otherwise crash the az sweep mid-run. Drop it from `alive` so the check
+    # below treats it like a missing pot (azimuth aborts; all skips az).
+    if args.mode in ("azimuth", "all") and POTMON in alive:
+        pot_cal = PotCalStore(transport).get()
+        if not (pot_cal and pot_cal.get("pot_az")):
+            print(
+                "pot is alive but uncalibrated; run calibrate_pot first.",
+                file=sys.stderr,
+            )
+            alive.discard(POTMON)
     if args.mode in ("azimuth", "all") and POTMON not in alive:
         print(
             "pot not alive; azimuth needs the pot standard.", file=sys.stderr

--- a/picohost/src/picohost/emulators/imu.py
+++ b/picohost/src/picohost/emulators/imu.py
@@ -2,6 +2,7 @@ import time
 
 import numpy as np
 
+from .. import imu_geometry as ig
 from .base import PicoEmulator
 
 NOISE_STDDEV = 0.001
@@ -14,10 +15,18 @@ class ImuEmulator(PicoEmulator):
     Models orientation as rotations around two axes (azimuth and
     elevation), with sensor readings derived from the orientation.
     The BNO08x in RVC mode outputs euler angles and acceleration;
-    this emulator produces matching values.
+    this emulator produces matching values via the same forward model
+    that imu_geometry inverts.
     """
 
     def __init__(self, app_id=3, **kwargs):
+        # Forward-model state (set before super().__init__() in case
+        # super triggers init paths that reference these).
+        self._mount = np.eye(3)
+        self._accel_bias = np.zeros(3)
+        self._accel_scale = 1.0
+        self._hold = False  # True once set_orientation is called
+
         # Orientation state (radians)
         self.az_angle = 0.0
         self.el_angle = 0.0
@@ -64,6 +73,38 @@ class ImuEmulator(PicoEmulator):
         """Simulate BNO08x coming back after a failure."""
         self._sensor_failed = False
 
+    def set_orientation(self, az_deg, el_deg):
+        """Hold a fixed (az, el) pose; disables the idle drift model."""
+        self.az_angle = np.radians(az_deg)
+        self.el_angle = np.radians(el_deg)
+        self._hold = True
+
+    def set_mount(self, M):
+        self._mount = np.asarray(M, dtype=float)
+
+    def set_accel_error(self, bias=(0.0, 0.0, 0.0), scale=1.0):
+        self._accel_bias = np.asarray(bias, dtype=float)
+        self._accel_scale = float(scale)
+
+    def _render(self):
+        """Compute yaw/pitch/roll/accel from current az/el/mount/error.
+
+        imu_el sees elevation only; imu_az sees elevation then azimuth.
+        R = R_x(theta) [@ R_z(phi)] @ M ; accel = R[2,:] * g (+ error).
+        """
+        theta, phi = self.el_angle, self.az_angle
+        if self.name == "imu_az":
+            R = ig.R_x(theta) @ ig.R_z(phi) @ self._mount
+        else:  # imu_el ignores azimuth
+            R = ig.R_x(theta) @ self._mount
+        g_body = R[2, :] * ig.GRAVITY  # R^T @ [0,0,g]
+        g_body = g_body * self._accel_scale + self._accel_bias
+        self.accel_x, self.accel_y, self.accel_z = (float(v) for v in g_body)
+        # ZYX euler of R for yaw/pitch/roll (diagnostic channels)
+        self.pitch = float(np.degrees(-np.arcsin(np.clip(R[2, 0], -1, 1))))
+        self.roll = float(np.degrees(np.arctan2(R[2, 1], R[2, 2])))
+        self.yaw = float(np.degrees(np.arctan2(R[1, 0], R[0, 0])))
+
     def op(self):
         # Mirrors imu_op -> imu_init, including the memset(&imu.data, 0)
         # at imu.c:109 that zeros sensor data on every (re-)init.
@@ -88,33 +129,11 @@ class ImuEmulator(PicoEmulator):
 
         # Normal operation: sensor produces events
         self._last_event_time = time.monotonic()
-
-        # Small random angular drift (mean-reverting toward 0)
-        self.az_angle = 0.99 * self.az_angle + np.random.normal(0, 0.001)
-        self.el_angle = 0.99 * self.el_angle + np.random.normal(0, 0.001)
-
-        # Convert internal radians to degrees for output.
-        # TODO: verify on hardware which BNO08x euler angle (yaw/pitch/roll)
-        # corresponds to each mechanical axis (az/el).  The mapping below
-        # assumes yaw=az and pitch=el, but that depends on how the sensor
-        # is physically mounted on the antenna box.
-        self.yaw = float(np.degrees(self.az_angle))
-        self.pitch = float(np.degrees(self.el_angle))
-        self.roll = float(np.random.normal(0, NOISE_STDDEV))
-
-        # Acceleration: gravity rotated by pitch/roll + noise
-        cp = np.cos(self.el_angle)
-        sp = np.sin(self.el_angle)
-        cr = np.cos(np.radians(self.roll))
-        sr = np.sin(np.radians(self.roll))
-        self.accel_x = float(9.81 * sp + np.random.normal(0, NOISE_STDDEV))
-        self.accel_y = float(
-            -9.81 * cp * sr + np.random.normal(0, NOISE_STDDEV)
-        )
-        self.accel_z = float(
-            9.81 * cp * cr + np.random.normal(0, NOISE_STDDEV)
-        )
-
+        if not self._hold:
+            # idle: gentle mean-reverting drift (matches prior behaviour)
+            self.az_angle = 0.99 * self.az_angle + np.random.normal(0, 0.001)
+            self.el_angle = 0.99 * self.el_angle + np.random.normal(0, 0.001)
+        self._render()
         self.got_packet_this_cycle = True
 
     def get_status(self):

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -92,3 +92,67 @@ def nearest_signed_permutation(M):
     cos = (np.trace(R) - 1.0) / 2.0
     misalign = float(np.degrees(np.arccos(np.clip(cos, -1.0, 1.0))))
     return labels, misalign
+
+
+# ---------------------------------------------------------------------------
+# Task 3: handler-facing estimators
+# ---------------------------------------------------------------------------
+
+
+def _wrap180(x):
+    return (x + 180.0) % 360.0 - 180.0
+
+
+def el_from_imu(a_unit, M):
+    """Signed elevation (deg) for imu_el: arctan2(g_y, g_z) in box frame."""
+    g = np.asarray(M, dtype=float) @ np.asarray(a_unit, dtype=float)
+    return float(np.degrees(np.arctan2(g[1], g[2])))
+
+
+def el_abs_from_imu_az(a_unit, M):
+    """|theta| (deg) for imu_az; assumes theta >= 0 for the single-tick case."""
+    g = np.asarray(M, dtype=float) @ np.asarray(a_unit, dtype=float)
+    return float(np.degrees(np.arccos(np.clip(g[2], -1.0, 1.0))))
+
+
+def az_from_accel(a_unit, M, az_sign=1.0, az_offset_deg=0.0):
+    """Azimuth (deg) from the imu_az preconditioned accel, with sign/offset.
+
+    theta >= 0 is assumed (single-tick imu_az), so sign(sin theta) = +1.
+    """
+    g = np.asarray(M, dtype=float) @ np.asarray(a_unit, dtype=float)
+    phi = np.degrees(np.arctan2(g[0], g[1]))
+    return float(az_sign * phi + az_offset_deg)
+
+
+def az_from_yaw(yaw_deg, az_yaw_sign=1.0, az_yaw_offset_deg=0.0):
+    """Azimuth (deg) from BNO08x yaw with sign/offset registration."""
+    return float(az_yaw_sign * yaw_deg + az_yaw_offset_deg)
+
+
+def blend_az(az_accel_deg, az_yaw_deg, el_deg, theta_cross_deg):
+    """Tilt-weighted circular blend: yaw near level, accel when tilted.
+
+    weight ramps 0 -> 1 as |el| goes 0 -> 2*theta_cross_deg.
+    Interpolation takes the shortest circular path from yaw toward accel.
+    When w reaches 1 the accel value is returned directly (avoids an
+    off-by-360 at the wrap boundary).
+    """
+    w = float(np.clip(abs(el_deg) / (2.0 * theta_cross_deg), 0.0, 1.0))
+    if w >= 1.0:
+        return float(az_accel_deg), w
+    delta = _wrap180(az_accel_deg - az_yaw_deg)
+    return float(az_yaw_deg + w * delta), w
+
+
+def estimate_theta_phi_from_accel(a_el, a_az, M_el, M_az):
+    """Closed-form (theta_deg, phi_deg) from two preconditioned accel vectors.
+
+    Port of the notebook inverse. phi is degenerate where sin(theta) -> 0.
+    """
+    g_box = np.asarray(M_el, dtype=float) @ np.asarray(a_el, dtype=float)
+    g_tt = np.asarray(M_az, dtype=float) @ np.asarray(a_az, dtype=float)
+    theta = np.arctan2(g_box[1], g_box[2])
+    s = 1.0 if np.sin(theta) >= 0.0 else -1.0
+    phi = np.arctan2(s * g_tt[0], s * g_tt[1])
+    return float(np.degrees(theta)), float(np.degrees(phi))

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -159,3 +159,157 @@ def estimate_theta_phi_from_accel(a_el, a_az, M_el, M_az):
     s = 1.0 if np.sin(theta) >= 0.0 else -1.0
     phi = np.arctan2(s * g_tt[0], s * g_tt[1])
     return float(np.degrees(theta)), float(np.degrees(phi))
+
+
+# ---------------------------------------------------------------------------
+# Task 8: sweep helpers + calibration fitter
+# ---------------------------------------------------------------------------
+
+
+def assign_sweep_theta(unit_vectors, level_index, direction):
+    """Signed elevation angle (rad) per sample along a 1-axis sweep.
+
+    Angle of each sample from the level sample, about the fitted plane
+    normal; 0 at level_index; sign forced so it increases in `direction`.
+    """
+    X = np.asarray(unit_vectors, dtype=float)
+    ref = X[level_index]
+    n = fit_plane_normal(X)
+    thetas = np.empty(len(X))
+    for i, v in enumerate(X):
+        ang = np.arccos(np.clip(v @ ref, -1.0, 1.0))
+        s = np.sign(np.cross(ref, v) @ n)
+        thetas[i] = ang * (s if s != 0 else 1.0)
+    # orient so samples after level_index increase, scaled by commanded dir
+    if level_index + 1 < len(thetas) and thetas[level_index + 1] < 0:
+        thetas = -thetas
+    return thetas * direction
+
+
+def cone_angle(unit_vectors):
+    """Polar angle (rad) of a fixed-tilt az sweep about its plane normal."""
+    X = np.asarray(unit_vectors, dtype=float)
+    n = fit_plane_normal(X)
+    # samples sit at colatitude theta from the rotation axis; |X.n| = cos(theta)
+    c = np.clip(np.abs(X @ n).mean(), -1.0, 1.0)
+    return float(np.arccos(c))
+
+
+def register_linear(pred_deg, truth_deg):
+    """Find sign in {+1,-1} and offset so truth ~= sign*pred + offset."""
+    pred = np.asarray(pred_deg, dtype=float)
+    truth = np.asarray(truth_deg, dtype=float)
+    best = None
+    for sign in (1.0, -1.0):
+        resid = truth - sign * pred
+        # circular mean of the residual offset
+        offset = np.degrees(
+            np.arctan2(
+                np.sin(np.radians(resid)).mean(),
+                np.cos(np.radians(resid)).mean(),
+            )
+        )
+        err = np.abs(_wrap180(truth - (sign * pred + offset)))
+        score = err.mean()
+        if best is None or score < best[0]:
+            best = (score, sign, float(offset))
+    return best[1], best[2]
+
+
+def _host_el(theta_rad):
+    return np.array([0.0, np.sin(theta_rad), np.cos(theta_rad)])
+
+
+def fit_calibration_from_sweeps(
+    el_sweep, az_level, az_tilt, *, theta_cross_deg=1.6
+):
+    """Fit per-IMU calibration sections from the three sweeps.
+
+    Each present IMU gets a sphere fit (bias/scale), a Kabsch mount fit,
+    and (imu_az) pot registration for accel-phi and yaw. Missing IMUs are
+    omitted. See the test for the exact input dict shape.
+    """
+    out = {}
+
+    # ---- imu_el: elevation sweep only ----
+    # NOTE: a single-axis sweep is coplanar, so the sphere fit is rank
+    # deficient along the el-axis. np.linalg.lstsq returns the min-norm
+    # solution (the unobservable bias component -> ~0). That component lies
+    # along the el rotation axis (host x), which does not enter
+    # el = atan2(g_y, g_z), so el is unaffected. The in-plane bias (which
+    # does affect el) is recovered.
+    if el_sweep.get("imu_el") is not None:
+        raw = np.asarray(el_sweep["imu_el"], float)
+        bias, scale = fit_accel_sphere(raw)
+        u = precondition(raw, bias)
+        theta = assign_sweep_theta(
+            u, el_sweep["level_index"], el_sweep["direction"]
+        )
+        host = np.array([_host_el(t) for t in theta])
+        M = kabsch(u, host)
+        perm, mis = nearest_signed_permutation(M)
+        out["imu_el"] = {
+            "accel_bias": bias.tolist(),
+            "accel_scale": scale,
+            "M": M.tolist(),
+            "mount_perm": perm,
+            "mount_misalign_deg": mis,
+        }
+
+    # ---- imu_az: elevation sweep + azimuth sweeps ----
+    if az_tilt.get("imu_az") is not None:
+        # Sphere fit over ALL imu_az accel we have (best sphere coverage).
+        chunks = [np.asarray(az_tilt["imu_az"], float)]
+        if az_level.get("imu_az") is not None:
+            chunks.append(np.asarray(az_level["imu_az"], float))
+        if el_sweep.get("imu_az") is not None:
+            chunks.append(np.asarray(el_sweep["imu_az"], float))
+        raw_all = np.vstack(chunks)
+        bias, scale = fit_accel_sphere(raw_all)
+
+        # theta for the tilt sweep: from imu_el if alive, else the cone angle.
+        u_tilt = precondition(np.asarray(az_tilt["imu_az"], float), bias)
+        if az_tilt.get("imu_el") is not None and "imu_el" in out:
+            M_el = np.array(out["imu_el"]["M"])
+            b_el = np.array(out["imu_el"]["accel_bias"])
+            u_el = precondition(np.asarray(az_tilt["imu_el"], float), b_el)
+            theta_tilt = np.array([el_from_imu(a, M_el) for a in u_el])
+            theta_tilt = np.radians(theta_tilt)
+        else:
+            theta_tilt = np.full(len(u_tilt), cone_angle(u_tilt))
+
+        phi_tilt = np.radians(np.asarray(az_tilt["pot_deg"], float))
+        host_tilt = np.array(
+            [R_z(p).T @ _host_el(t) for p, t in zip(phi_tilt, theta_tilt)]
+        )
+        M_az = kabsch(u_tilt, host_tilt)
+        perm, mis = nearest_signed_permutation(M_az)
+
+        # accel-phi -> pot registration (use tilt sweep, where phi is sharp)
+        phi_pred = np.array([az_from_accel(a, M_az) for a in u_tilt])
+        az_sign, az_off = register_linear(phi_pred, np.degrees(phi_tilt))
+
+        section = {
+            "accel_bias": bias.tolist(),
+            "accel_scale": scale,
+            "M": M_az.tolist(),
+            "az_sign": az_sign,
+            "az_accel_offset_deg": az_off,
+            "theta_cross_deg": float(theta_cross_deg),
+            "mount_perm": perm,
+            "mount_misalign_deg": mis,
+            "az_yaw_sign": 1.0,
+            "az_yaw_offset_deg": 0.0,
+        }
+        # yaw -> pot registration from the near-level az sweep
+        if (
+            az_level.get("imu_az") is not None
+            and az_level.get("yaw_deg") is not None
+        ):
+            yaw = np.asarray(az_level["yaw_deg"], float)
+            pot = np.asarray(az_level["pot_deg"], float)
+            ys, yo = register_linear(yaw, pot)
+            section["az_yaw_sign"], section["az_yaw_offset_deg"] = ys, yo
+        out["imu_az"] = section
+
+    return out

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -49,3 +49,46 @@ def precondition(a, bias):
     a = np.asarray(a, dtype=float) - np.asarray(bias, dtype=float)
     n = np.linalg.norm(a, axis=-1, keepdims=True)
     return a / n
+
+
+_AXES = {
+    "+x": np.array([1.0, 0.0, 0.0]),
+    "-x": np.array([-1.0, 0.0, 0.0]),
+    "+y": np.array([0.0, 1.0, 0.0]),
+    "-y": np.array([0.0, -1.0, 0.0]),
+    "+z": np.array([0.0, 0.0, 1.0]),
+    "-z": np.array([0.0, 0.0, -1.0]),
+}
+
+
+def kabsch(body, host):
+    """Proper rotation M minimizing sum |M @ body_i - host_i|^2."""
+    B = np.asarray(body, dtype=float)
+    H = np.asarray(host, dtype=float)
+    C = H.T @ B  # 3x3 = sum host_i body_i^T
+    U, _, Vt = np.linalg.svd(C)
+    D = np.diag([1.0, 1.0, np.sign(np.linalg.det(U @ Vt))])
+    return U @ D @ Vt
+
+
+def fit_plane_normal(unit_vectors):
+    """Normal of the best-fit plane (PCA smallest-variance direction)."""
+    X = np.asarray(unit_vectors, dtype=float)
+    Xc = X - X.mean(axis=0)
+    _, _, Vt = np.linalg.svd(Xc)
+    return Vt[-1]
+
+
+def nearest_signed_permutation(M):
+    """Nearest signed-permutation mount + residual misalignment angle (deg).
+
+    Column k of M is body-axis k expressed in the host frame, so the label
+    for column k is the host axis it points most nearly along.
+    """
+    M = np.asarray(M, dtype=float)
+    labels = [max(_AXES, key=lambda k: M[:, c] @ _AXES[k]) for c in range(3)]
+    P = np.column_stack([_AXES[lbl] for lbl in labels])
+    R = M @ P.T
+    cos = (np.trace(R) - 1.0) / 2.0
+    misalign = float(np.degrees(np.arccos(np.clip(cos, -1.0, 1.0))))
+    return labels, misalign

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -103,6 +103,17 @@ def _wrap180(x):
     return (x + 180.0) % 360.0 - 180.0
 
 
+def circular_mean_deg(values):
+    """Circular mean (deg) of angle samples; robust to the +/-180 wrap.
+
+    A plain arithmetic mean of angles straddling the +/-180 seam (e.g. yaw
+    near +/-179) collapses toward 0; averaging the unit vectors instead keeps
+    the result on the circle.
+    """
+    a = np.radians(np.asarray(values, dtype=float))
+    return float(np.degrees(np.arctan2(np.sin(a).mean(), np.cos(a).mean())))
+
+
 def el_from_imu(a_unit, M):
     """Signed elevation (deg) for imu_el: arctan2(g_y, g_z) in box frame."""
     g = np.asarray(M, dtype=float) @ np.asarray(a_unit, dtype=float)

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -1,0 +1,51 @@
+"""Pure geometry for the two-IMU rotating-box conversion.
+
+Ported from picohost/notebooks/imu_two_axis_simulation.ipynb. Shared by the
+live PicoIMU handler and the calibrate_imu fit so lab and field run identical
+math. All inverses are direction-only (accel must be preconditioned to a unit
+gravity vector first), so a constant accel scale/bias does not affect output.
+"""
+
+import numpy as np
+
+GRAVITY = 9.80665  # m/s^2
+
+
+def R_x(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]])
+
+
+def R_y(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+
+def R_z(a):
+    c, s = np.cos(a), np.sin(a)
+    return np.array([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+
+
+def fit_accel_sphere(samples):
+    """Algebraic least-squares sphere fit.
+
+    Returns (bias, scale): center and radius of the sphere the accel
+    samples lie on, i.e. the constant accel bias and effective |g|.
+    """
+    p = np.asarray(samples, dtype=float)
+    if p.ndim != 2 or p.shape[1] != 3 or len(p) < 4:
+        raise ValueError("need >=4 (N,3) accel samples to fit a sphere")
+    # |p|^2 = 2 c.p + (r^2 - |c|^2)  ->  linear in [cx,cy,cz,k]
+    A = np.hstack([2.0 * p, np.ones((len(p), 1))])
+    b = np.sum(p**2, axis=1)
+    sol, *_ = np.linalg.lstsq(A, b, rcond=None)
+    bias = sol[:3]
+    scale = float(np.sqrt(sol[3] + bias @ bias))
+    return bias, scale
+
+
+def precondition(a, bias):
+    """(a - bias) normalized to unit length. Accepts (3,) or (N,3)."""
+    a = np.asarray(a, dtype=float) - np.asarray(bias, dtype=float)
+    n = np.linalg.norm(a, axis=-1, keepdims=True)
+    return a / n

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -136,8 +136,11 @@ def blend_az(az_accel_deg, az_yaw_deg, el_deg, theta_cross_deg):
     weight ramps 0 -> 1 as |el| goes 0 -> 2*theta_cross_deg.
     Interpolation takes the shortest circular path from yaw toward accel.
     When w reaches 1 the accel value is returned directly (avoids an
-    off-by-360 at the wrap boundary).
+    off-by-360 at the wrap boundary). A non-positive theta_cross_deg is a
+    misconfiguration and degrades to all-accel rather than dividing by zero.
     """
+    if theta_cross_deg <= 0:
+        return float(az_accel_deg), 1.0
     w = float(np.clip(abs(el_deg) / (2.0 * theta_cross_deg), 0.0, 1.0))
     if w >= 1.0:
         return float(az_accel_deg), w

--- a/picohost/src/picohost/keys.py
+++ b/picohost/src/picohost/keys.py
@@ -12,6 +12,7 @@ or eigsep_observing (``stream:corr``, ``corr_config``, …).
 PICO_CONFIG_KEY = "pico_config"
 POT_CAL_KEY = "pot_calibration"
 CURRENT_CAL_KEY = "current_calibration"
+IMU_CAL_KEY = "imu_calibration"
 MOTOR_POS_KEY = "motor_position"
 PICO_CMD_STREAM = "stream:pico_cmd"
 PICO_RESP_STREAM = "stream:pico_resp"

--- a/picohost/src/picohost/manager.py
+++ b/picohost/src/picohost/manager.py
@@ -53,6 +53,7 @@ from .base import (
 )
 from .buses import (
     CurrentCalStore,
+    ImuCalStore,
     MotorPositionStore,
     PicoClaimStore,
     PicoCmdReader,
@@ -147,6 +148,7 @@ class PicoManager:
             :class:`StatusWriter`, :class:`PicoConfigStore`,
             :class:`PotCalStore` (passed to ``PicoPotentiometer``),
             :class:`CurrentCalStore` (passed to ``PicoLidar``),
+            :class:`ImuCalStore` (passed to ``PicoIMU``),
             :class:`PicoCmdReader`, :class:`PicoRespWriter`, and
             :class:`PicoClaimStore`.
         """
@@ -158,6 +160,7 @@ class PicoManager:
         self._pot_cal_store = PotCalStore(transport)
         self._current_cal_store = CurrentCalStore(transport)
         self._motor_pos_store = MotorPositionStore(transport)
+        self._imu_cal_store = ImuCalStore(transport)
         self._cmd_reader = PicoCmdReader(transport)
         self._resp_writer = PicoRespWriter(transport)
         self._claim_store = PicoClaimStore(transport)
@@ -252,6 +255,8 @@ class PicoManager:
                 kwargs["current_cal_store"] = self._current_cal_store
             elif cls is PicoMotor:
                 kwargs["motor_pos_store"] = self._motor_pos_store
+            elif issubclass(cls, PicoIMU):
+                kwargs["imu_cal_store"] = self._imu_cal_store
             try:
                 pico = cls(port, **kwargs)
                 self.picos[name] = pico

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -4,7 +4,7 @@ import pytest
 from eigsep_redis.testing import DummyTransport
 
 from picohost import calibrate_imu
-from picohost.buses import ImuCalStore
+from picohost.buses import ImuCalStore, PotCalStore
 
 
 def test_build_parser_modes():
@@ -35,6 +35,39 @@ def test_collect_vector_averages_named_fields(monkeypatch):
     assert np.allclose(v, [2.0, 0.0, 9.0])  # mean of 1,2,3 -> 2
 
 
+def test_yaw_collected_with_circular_mean(monkeypatch):
+    """_yaw must reduce its samples circularly (robust to the +/-180 wrap),
+    not with the linear mean that collect_vector applies by default."""
+    cal = calibrate_imu.Calibrator(DummyTransport(), 2, {"imu_az"}, "azimuth")
+
+    def fake_collect(transport, name, fields, n, start_id="$", reducer=None):
+        assert reducer is not None  # _yaw must supply a circular reducer
+        return reducer(np.array([[179.0], [-179.0]]))
+
+    monkeypatch.setattr(calibrate_imu, "collect_vector", fake_collect)
+    assert abs(cal._yaw()) == pytest.approx(180.0, abs=1e-6)  # linear -> ~0
+
+
+def test_main_azimuth_uncalibrated_pot_aborts(monkeypatch):
+    """An alive-but-uncalibrated pot is not a usable az standard: azimuth
+    mode must abort up front, not crash mid-sweep on a None pot angle."""
+    transport = DummyTransport()
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(
+        calibrate_imu,
+        "stream_alive",
+        lambda t, n, timeout_s=5.0: n in ("imu_az", "potmon"),
+    )
+    monkeypatch.setattr(
+        calibrate_imu.Calibrator,
+        "run_sweeps",
+        lambda self: pytest.fail("must abort before sweeps"),
+    )
+    # no PotCalStore uploaded -> pot alive but uncalibrated
+    assert calibrate_imu.main(["--mode", "azimuth"]) == 1
+    assert ImuCalStore(transport).get() is None
+
+
 def test_stream_alive_true_false(monkeypatch):
     """Liveness via blocking "$": True only when a NEW entry arrives.
 
@@ -57,10 +90,10 @@ def test_main_persists_and_pushes(monkeypatch):
     from picohost import imu_geometry as ig
 
     transport = DummyTransport()
+    PotCalStore(transport).upload({"pot_az": [1.0, 0.0]})  # az standard ready
 
     # Fake operator-driven collection: return forward-model sweeps.
     M_az = ig.R_z(-0.3)
-    el_degs = np.linspace(-60, 60, 25)
     phi_degs = np.linspace(0, 359, 24)
 
     def fake_run_sweeps(self):
@@ -138,6 +171,7 @@ def test_main_discard_writes_nothing(monkeypatch):
     from picohost import imu_geometry as ig
 
     transport = DummyTransport()
+    PotCalStore(transport).upload({"pot_az": [1.0, 0.0]})  # az standard ready
 
     M_az = ig.R_z(-0.3)
     phi_degs = np.linspace(0, 359, 24)

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -1,0 +1,210 @@
+import json
+import numpy as np
+import pytest
+from eigsep_redis.testing import DummyTransport
+
+from picohost import calibrate_imu
+from picohost.buses import ImuCalStore
+
+
+def test_build_parser_modes():
+    p = calibrate_imu.build_parser()
+    args = p.parse_args(["--mode", "elevation"])
+    assert args.mode == "elevation"
+    for m in ("elevation", "azimuth", "all"):
+        assert p.parse_args(["--mode", m]).mode == m
+
+
+def test_collect_vector_averages_named_fields(monkeypatch):
+    t = DummyTransport()
+    # publish 3 entries on stream:imu_az
+    for ax in (1.0, 2.0, 3.0):
+        t.r.xadd(
+            "stream:imu_az",
+            {
+                "value": json.dumps(
+                    {"accel_x": ax, "accel_y": 0.0, "accel_z": 9.0}
+                )
+            },
+        )
+    # start_id="0-0" reads from the beginning so the test doesn't race the
+    # "$" (new-entries-only) production default.
+    v = calibrate_imu.collect_vector(
+        t, "imu_az", ("accel_x", "accel_y", "accel_z"), n=3, start_id="0-0"
+    )
+    assert np.allclose(v, [2.0, 0.0, 9.0])  # mean of 1,2,3 -> 2
+
+
+def test_stream_alive_true_false(monkeypatch):
+    """Liveness via blocking "$": True only when a NEW entry arrives.
+
+    Monkeypatch xread directly so the test is deterministic and doesn't
+    depend on fakeredis racing the "$" cursor against pre-loaded entries
+    (a "$" read correctly sees nothing for pre-existing entries).
+    """
+    t = DummyTransport()
+
+    alive = [("stream:imu_az", [(b"1-0", {b"value": b"{}"})])]
+    monkeypatch.setattr(t.r, "xread", lambda *a, **k: alive)
+    assert calibrate_imu.stream_alive(t, "imu_az", timeout_s=0.1) is True
+
+    monkeypatch.setattr(t.r, "xread", lambda *a, **k: [])
+    assert calibrate_imu.stream_alive(t, "imu_el", timeout_s=0.1) is False
+
+
+def test_main_persists_and_pushes(monkeypatch):
+    """End-to-end main(): synthetic sweeps -> fit -> ImuCalStore + proxy push."""
+    from picohost import imu_geometry as ig
+
+    transport = DummyTransport()
+
+    # Fake operator-driven collection: return forward-model sweeps.
+    M_az = ig.R_z(-0.3)
+    el_degs = np.linspace(-60, 60, 25)
+    phi_degs = np.linspace(0, 359, 24)
+
+    def fake_run_sweeps(self):
+        return (
+            {  # el_sweep
+                "imu_el": None,
+                "imu_az": None,
+                "level_index": 12,
+                "direction": 1,
+            },
+            {  # az_level
+                "imu_az": np.array(
+                    [ig.R_z(np.radians(p)).T @ [0, 0, 1.0] for p in phi_degs]
+                ),
+                "yaw_deg": -phi_degs,
+                "pot_deg": -phi_degs + 40.0,
+            },
+            {  # az_tilt
+                "imu_az": np.array(
+                    [
+                        M_az.T
+                        @ (
+                            ig.R_z(np.radians(p)).T
+                            @ [
+                                0,
+                                np.sin(np.radians(40)),
+                                np.cos(np.radians(40)),
+                            ]
+                        )
+                        for p in phi_degs
+                    ]
+                )
+                * ig.GRAVITY,
+                "pot_deg": -phi_degs + 40.0,
+                "imu_el": None,
+            },
+        )
+
+    captured = {}
+
+    class FakeProxy:
+        def __init__(self, *a, **k):
+            pass
+
+        @property
+        def is_available(self):
+            return True
+
+        def send_command(self, action, **kw):
+            captured[action] = kw
+            return {}
+
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(calibrate_imu, "PicoProxy", FakeProxy)
+    monkeypatch.setattr(
+        calibrate_imu.Calibrator, "run_sweeps", fake_run_sweeps
+    )
+    monkeypatch.setattr(
+        calibrate_imu,
+        "stream_alive",
+        lambda t, n, timeout_s=5.0: n == "imu_az" or n == "potmon",
+    )
+    monkeypatch.setattr("builtins.input", lambda *a: "y")  # confirm save
+
+    rc = calibrate_imu.main(["--mode", "azimuth"])
+    assert rc == 0
+    stored = ImuCalStore(transport).get()
+    assert "imu_az" in stored
+    assert "set_calibration" in captured  # live push happened
+    assert "imu_az" in captured["set_calibration"]
+
+
+def test_main_discard_writes_nothing(monkeypatch):
+    """Declining the save prompt persists nothing and pushes nothing."""
+    from picohost import imu_geometry as ig
+
+    transport = DummyTransport()
+
+    M_az = ig.R_z(-0.3)
+    phi_degs = np.linspace(0, 359, 24)
+
+    def fake_run_sweeps(self):
+        return (
+            {
+                "imu_el": None,
+                "imu_az": None,
+                "level_index": 12,
+                "direction": 1,
+            },
+            {
+                "imu_az": np.array(
+                    [ig.R_z(np.radians(p)).T @ [0, 0, 1.0] for p in phi_degs]
+                ),
+                "yaw_deg": -phi_degs,
+                "pot_deg": -phi_degs + 40.0,
+            },
+            {
+                "imu_az": np.array(
+                    [
+                        M_az.T
+                        @ (
+                            ig.R_z(np.radians(p)).T
+                            @ [
+                                0,
+                                np.sin(np.radians(40)),
+                                np.cos(np.radians(40)),
+                            ]
+                        )
+                        for p in phi_degs
+                    ]
+                )
+                * ig.GRAVITY,
+                "pot_deg": -phi_degs + 40.0,
+                "imu_el": None,
+            },
+        )
+
+    captured = {}
+
+    class FakeProxy:
+        def __init__(self, *a, **k):
+            pass
+
+        @property
+        def is_available(self):
+            return True
+
+        def send_command(self, action, **kw):
+            captured[action] = kw
+            return {}
+
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(calibrate_imu, "PicoProxy", FakeProxy)
+    monkeypatch.setattr(
+        calibrate_imu.Calibrator, "run_sweeps", fake_run_sweeps
+    )
+    monkeypatch.setattr(
+        calibrate_imu,
+        "stream_alive",
+        lambda t, n, timeout_s=5.0: n == "imu_az" or n == "potmon",
+    )
+    monkeypatch.setattr("builtins.input", lambda *a: "n")  # decline save
+
+    rc = calibrate_imu.main(["--mode", "azimuth"])
+    assert rc == 0  # clean discard
+    assert ImuCalStore(transport).get() is None  # nothing persisted
+    assert "set_calibration" not in captured  # no live push

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -952,18 +952,42 @@ class TestImuEmulator:
         mag = np.sqrt(emu.accel_x**2 + emu.accel_y**2 + emu.accel_z**2)
         assert abs(mag - 9.81) < 0.1
 
-    def test_euler_from_angles(self):
-        """Setting az/el angles produces matching yaw/pitch.
+    def test_set_orientation_drives_accel_via_forward_model(self):
+        import numpy as np
+        from picohost import imu_geometry as ig
 
-        NOTE: assumes yaw=az, pitch=el — needs hardware verification.
-        See TODO in emulators/imu.py.
-        """
-        emu = ImuEmulator()
-        emu.az_angle = np.pi / 4  # 45 degrees azimuth
-        emu.el_angle = np.pi / 6  # 30 degrees elevation
+        emu = ImuEmulator(app_id=6)  # imu_az, identity mount
+        emu.set_orientation(az_deg=70.0, el_deg=40.0)
         emu.op()
-        assert abs(emu.yaw - 45.0) < 1.0
-        assert abs(emu.pitch - 30.0) < 1.0
+        s = emu.get_status()
+        a = np.array([s["accel_x"], s["accel_y"], s["accel_z"]])
+        a_unit = a / np.linalg.norm(a)
+        el = ig.el_abs_from_imu_az(a_unit, np.eye(3))
+        az = ig.az_from_accel(a_unit, np.eye(3))
+        assert el == pytest.approx(40.0, abs=1e-3)
+        assert az == pytest.approx(70.0, abs=1e-3)
+
+    def test_accel_error_scales_norm(self):
+        import numpy as np
+
+        emu = ImuEmulator(app_id=6)
+        emu.set_orientation(az_deg=0.0, el_deg=20.0)
+        emu.set_accel_error(bias=(0.2, -0.1, 0.0), scale=12.2 / 9.80665)
+        emu.op()
+        s = emu.get_status()
+        a = np.array([s["accel_x"], s["accel_y"], s["accel_z"]])
+        assert np.linalg.norm(a) > 11.0  # inflated like the 0627 data
+
+    def test_mount_changes_body_frame_reading(self):
+        import numpy as np
+
+        emu = ImuEmulator(app_id=3)  # imu_el
+        emu.set_mount(np.array([[0, 1.0, 0], [-1.0, 0, 0], [0, 0, 1.0]]))
+        emu.set_orientation(az_deg=0.0, el_deg=30.0)
+        emu.op()
+        s = emu.get_status()
+        # with this mount the elevation tilt shows up on accel_x not accel_y
+        assert abs(s["accel_x"]) > abs(s["accel_y"])
 
     def test_sensor_failure_triggers_reinit(self):
         """IMU reports error after event timeout, then recovers."""

--- a/picohost/tests/test_imu_calibration.py
+++ b/picohost/tests/test_imu_calibration.py
@@ -47,3 +47,30 @@ def test_clear_removes_key():
     assert store.get() is not None
     store.clear()
     assert store.get() is None
+
+
+def test_upload_merges_preserving_other_sections():
+    # A --mode elevation run uploads only imu_el; a prior imu_az section
+    # must survive (read-modify-write merge, not whole-key replace).
+    store = ImuCalStore(DummyTransport())
+    store.upload(_payload())  # imu_az only
+
+    store.upload(
+        {
+            "imu_el": {"accel_bias": [0, 0, 0], "el_sign": 1},
+            "metadata": {"timestamp": "t2", "mode": "elevation"},
+        }
+    )
+
+    loaded = store.get()
+    assert loaded["imu_az"]["az_accel_offset_deg"] == 30.0  # survived
+    assert loaded["imu_el"]["el_sign"] == 1  # newly added
+    assert loaded["metadata"]["mode"] == "elevation"  # latest run wins
+
+
+def test_upload_replaces_same_section():
+    # Re-calibrating the same IMU overwrites its section (no stale merge).
+    store = ImuCalStore(DummyTransport())
+    store.upload(_payload())
+    store.upload({"imu_az": {"az_accel_offset_deg": 99.0}})
+    assert store.get()["imu_az"] == {"az_accel_offset_deg": 99.0}

--- a/picohost/tests/test_imu_calibration.py
+++ b/picohost/tests/test_imu_calibration.py
@@ -1,0 +1,49 @@
+from eigsep_redis.testing import DummyTransport
+
+from picohost.buses import ImuCalStore
+from picohost.keys import IMU_CAL_KEY
+
+
+def _payload():
+    return {
+        "imu_az": {
+            "accel_bias": [0.1, 0.0, -0.1],
+            "accel_scale": 12.2,
+            "M": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+            "az_accel_offset_deg": 30.0,
+            "az_sign": 1,
+            "az_yaw_offset_deg": 30.0,
+            "az_yaw_sign": 1,
+            "theta_cross_deg": 1.6,
+            "mount_perm": ["+x", "+y", "+z"],
+            "mount_misalign_deg": 0.5,
+        },
+        "metadata": {"timestamp": "t", "mode": "all"},
+    }
+
+
+def test_empty_store_returns_none():
+    assert ImuCalStore(DummyTransport()).get() is None
+
+
+def test_round_trip_preserves_sections():
+    store = ImuCalStore(DummyTransport())
+    store.upload(_payload())
+    loaded = store.get()
+    assert loaded["imu_az"]["az_accel_offset_deg"] == 30.0
+    assert loaded["imu_az"]["M"] == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    assert "upload_time" in loaded  # injected by Transport.upload_dict
+
+
+def test_corrupt_json_returns_none():
+    t = DummyTransport()
+    t.r.set(IMU_CAL_KEY, b"not-json-{")
+    assert ImuCalStore(t).get() is None
+
+
+def test_clear_removes_key():
+    store = ImuCalStore(DummyTransport())
+    store.upload(_payload())
+    assert store.get() is not None
+    store.clear()
+    assert store.get() is None

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+from picohost import imu_geometry as ig
+
+
+def test_rotation_matrices_are_orthonormal():
+    for R in (ig.R_x(0.3), ig.R_y(-1.1), ig.R_z(2.0)):
+        assert np.allclose(R @ R.T, np.eye(3), atol=1e-12)
+        assert np.isclose(np.linalg.det(R), 1.0)
+
+
+def test_rz_rotates_x_into_y():
+    v = ig.R_z(np.pi / 2) @ np.array([1.0, 0.0, 0.0])
+    assert np.allclose(v, [0.0, 1.0, 0.0], atol=1e-12)
+
+
+def test_fit_accel_sphere_recovers_bias_and_scale():
+    rng = np.random.default_rng(0)
+    bias_true = np.array([0.4, -0.2, 0.1])
+    scale_true = 12.2  # mirrors the 0627 ~1.24x anomaly
+    dirs = rng.normal(size=(200, 3))
+    dirs /= np.linalg.norm(dirs, axis=1, keepdims=True)
+    samples = scale_true * dirs + bias_true
+    bias, scale = ig.fit_accel_sphere(samples)
+    assert np.allclose(bias, bias_true, atol=1e-6)
+    assert scale == pytest.approx(scale_true, abs=1e-6)
+
+
+def test_fit_accel_sphere_needs_four_points():
+    with pytest.raises(ValueError):
+        ig.fit_accel_sphere(np.zeros((3, 3)))
+
+
+def test_precondition_subtracts_bias_and_normalizes():
+    a = np.array([0.4 + 5.0, -0.2, 0.1])  # bias + 5*x_hat
+    u = ig.precondition(a, bias=[0.4, -0.2, 0.1])
+    assert np.allclose(u, [1.0, 0.0, 0.0], atol=1e-12)
+
+
+def test_precondition_batched():
+    bias = [0.0, 0.0, 0.0]
+    a = np.array([[3.0, 0.0, 0.0], [0.0, 0.0, -2.0]])
+    u = ig.precondition(a, bias)
+    assert np.allclose(np.linalg.norm(u, axis=1), 1.0)

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -166,3 +166,107 @@ def test_estimate_theta_phi_round_trip():
     theta, phi = ig.estimate_theta_phi_from_accel(a_el, a_az, M_el, M_az)
     assert theta == pytest.approx(theta_t, abs=1e-6)
     assert phi == pytest.approx(phi_t, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Task 8: assign_sweep_theta, cone_angle, register_linear, fit_calibration
+# ---------------------------------------------------------------------------
+
+
+def _el_sweep_accel(thetas_deg, M, bias=(0, 0, 0), scale=1.0):
+    out = []
+    for d in thetas_deg:
+        th = np.radians(d)
+        g = M.T @ np.array([0.0, np.sin(th), np.cos(th)])
+        out.append(scale * ig.GRAVITY * g + np.asarray(bias))
+    return np.array(out)
+
+
+def _az_sweep_accel(theta_deg, phis_deg, M, bias=(0, 0, 0), scale=1.0):
+    out = []
+    th = np.radians(theta_deg)
+    for d in phis_deg:
+        g = M.T @ (ig.R_z(np.radians(d)).T @ [0.0, np.sin(th), np.cos(th)])
+        out.append(scale * ig.GRAVITY * g + np.asarray(bias))
+    return np.array(out)
+
+
+def test_assign_sweep_theta_signed_arc():
+    M = np.eye(3)
+    thetas = np.array([-30.0, -10.0, 0.0, 20.0, 50.0])
+    u = ig.precondition(_el_sweep_accel(thetas, M), [0, 0, 0])
+    level = 2  # index of the 0.0 entry
+    rec = np.degrees(ig.assign_sweep_theta(u, level_index=level, direction=1))
+    assert np.allclose(rec, thetas, atol=1e-6)
+
+
+def test_cone_angle_of_fixed_tilt_az_sweep():
+    phis = np.linspace(0, 360, 24, endpoint=False)
+    u = ig.precondition(_az_sweep_accel(40.0, phis, np.eye(3)), [0, 0, 0])
+    assert np.degrees(ig.cone_angle(u)) == pytest.approx(40.0, abs=1e-6)
+
+
+def test_register_linear_recovers_sign_and_offset():
+    truth = np.array([0.0, 50.0, 100.0, 150.0])
+    pred = -truth + 30.0
+    sign, offset = ig.register_linear(pred, truth)
+    assert sign == pytest.approx(-1.0)
+    # truth = sign*pred + offset  ->  offset = 30
+    assert offset == pytest.approx(30.0, abs=1e-6)
+
+
+def test_fit_calibration_full_reproduces_truth():
+    M_el = ig.R_y(0.25) @ ig.R_x(-0.15)
+    M_az = ig.R_z(-0.5) @ ig.R_x(0.1)
+    bias_az, scale_az = (0.3, -0.2, 0.1), 12.2 / ig.GRAVITY
+    el_degs = np.linspace(-80, 80, 33)
+    phi_degs = np.linspace(0, 359, 36)
+    # az sweeps reported in the POT frame: pot = -phi + 40 (sign -1, offset 40)
+    pot_level = -phi_degs + 40.0
+    pot_tilt = -phi_degs + 40.0
+
+    # one IMU has one (bias, scale): apply bias_az/scale_az to EVERY imu_az
+    # chunk. imu_el here is bias-free (bias=0) and shares its own scale=1.
+    el_sweep = {
+        "imu_el": _el_sweep_accel(el_degs, M_el),
+        "imu_az": _el_sweep_accel(el_degs, M_az, bias_az, scale_az),
+        "level_index": int(np.argmin(np.abs(el_degs))),
+        "direction": 1,
+    }
+    az_level = {
+        "imu_az": _az_sweep_accel(0.0, phi_degs, M_az, bias_az, scale_az),
+        "yaw_deg": -phi_degs,  # yaw tracks -phi at level for this M_az
+        "pot_deg": pot_level,
+    }
+    az_tilt = {
+        "imu_az": _az_sweep_accel(40.0, phi_degs, M_az, bias_az, scale_az),
+        "pot_deg": pot_tilt,
+        "imu_el": _el_sweep_accel(np.full_like(phi_degs, 40.0), M_el),
+    }
+    cal = ig.fit_calibration_from_sweeps(el_sweep, az_level, az_tilt)
+
+    # imu_el mount recovered (up to the fit) -> el reproduces truth
+    a = ig.precondition(
+        _el_sweep_accel([55.0], M_el)[0], cal["imu_el"]["accel_bias"]
+    )
+    assert ig.el_from_imu(a, np.array(cal["imu_el"]["M"])) == pytest.approx(
+        55.0, abs=0.2
+    )
+
+    # imu_az: az reproduces the POT value (pot = -phi + 40) at a tilted pose
+    M_az_fit = np.array(cal["imu_az"]["M"])
+    a_az = ig.precondition(
+        _az_sweep_accel(40.0, [70.0], M_az, bias_az, scale_az)[0],
+        cal["imu_az"]["accel_bias"],
+    )
+    az = ig.az_from_accel(
+        a_az,
+        M_az_fit,
+        cal["imu_az"]["az_sign"],
+        cal["imu_az"]["az_accel_offset_deg"],
+    )
+    assert az == pytest.approx(-70.0 + 40.0, abs=0.5)
+    # cross-check fields present
+    assert (
+        "mount_perm" in cal["imu_az"] and "mount_misalign_deg" in cal["imu_az"]
+    )

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -274,3 +274,13 @@ def test_fit_calibration_full_reproduces_truth():
     # => sign = +1, offset = +40
     assert cal["imu_az"]["az_yaw_sign"] == pytest.approx(1.0)
     assert cal["imu_az"]["az_yaw_offset_deg"] == pytest.approx(40.0, abs=1.0)
+
+
+def test_circular_mean_deg_handles_wrap():
+    # ordinary samples: circular mean matches the arithmetic mean
+    assert ig.circular_mean_deg([10.0, 20.0, 30.0]) == pytest.approx(20.0)
+    # straddling the +/-180 seam: a linear mean would give ~0; circular = 180
+    assert abs(ig.circular_mean_deg([179.0, -179.0])) == pytest.approx(180.0)
+    assert abs(ig.circular_mean_deg([170.0, -170.0])) == pytest.approx(
+        180.0, abs=1e-6
+    )

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -270,3 +270,7 @@ def test_fit_calibration_full_reproduces_truth():
     assert (
         "mount_perm" in cal["imu_az"] and "mount_misalign_deg" in cal["imu_az"]
     )
+    # yaw registration: pot = -phi + 40, yaw = -phi => pot = yaw + 40
+    # => sign = +1, offset = +40
+    assert cal["imu_az"]["az_yaw_sign"] == pytest.approx(1.0)
+    assert cal["imu_az"]["az_yaw_offset_deg"] == pytest.approx(40.0, abs=1.0)

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -151,6 +151,13 @@ def test_blend_az_takes_shortest_circular_path():
     assert mid == pytest.approx(360.0, abs=1e-6)  # halfway across the wrap
 
 
+def test_blend_az_zero_cross_defaults_to_accel():
+    # misconfigured crossover -> degrade to all-accel, never divide by zero
+    az, w = ig.blend_az(104.0, 100.0, el_deg=10.0, theta_cross_deg=0.0)
+    assert az == pytest.approx(104.0)
+    assert w == pytest.approx(1.0)
+
+
 def test_estimate_theta_phi_round_trip():
     M_el, M_az = ig.R_x(0.2), ig.R_z(-0.4) @ ig.R_y(0.1)
     theta_t, phi_t = 35.0, -60.0

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -83,3 +83,79 @@ def test_nearest_signed_permutation_reports_small_misalignment():
     labels, misalign = ig.nearest_signed_permutation(M)
     assert labels == ["+x", "+y", "+z"]
     assert misalign == pytest.approx(4.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Task 3: el/az estimators, tilt blend, accel inverse
+# ---------------------------------------------------------------------------
+
+
+def _accel_el(theta, M=np.eye(3)):
+    """imu_el unit accel for elevation theta (rad): M^T @ [0,sin,cos]."""
+    return M.T @ np.array([0.0, np.sin(theta), np.cos(theta)])
+
+
+def _accel_az(theta, phi, M=np.eye(3)):
+    """imu_az unit accel: M^T @ Rz(phi)^T @ [0,sin(theta),cos(theta)]."""
+    g_box = np.array([0.0, np.sin(theta), np.cos(theta)])
+    return M.T @ (ig.R_z(phi).T @ g_box)
+
+
+def test_el_from_imu_recovers_theta_identity_and_mount():
+    M = ig.R_y(0.5) @ ig.R_x(-0.2)
+    for deg in (-40.0, 0.0, 25.0, 80.0):
+        a = _accel_el(np.radians(deg), M)
+        assert ig.el_from_imu(a, M) == pytest.approx(deg, abs=1e-6)
+
+
+def test_el_abs_from_imu_az_is_unsigned():
+    M = ig.R_z(0.3)
+    a_pos = _accel_az(np.radians(30.0), np.radians(50.0), M)
+    a_neg = _accel_az(np.radians(-30.0), np.radians(50.0), M)
+    assert ig.el_abs_from_imu_az(a_pos, M) == pytest.approx(30.0, abs=1e-6)
+    assert ig.el_abs_from_imu_az(a_neg, M) == pytest.approx(30.0, abs=1e-6)
+
+
+def test_az_from_accel_recovers_phi_with_offset_and_sign():
+    M = ig.R_x(0.1)
+    a = _accel_az(np.radians(35.0), np.radians(70.0), M)
+    # default sign/offset -> raw phi
+    assert ig.az_from_accel(a, M) == pytest.approx(70.0, abs=1e-6)
+    # registered to a pot frame: az = -phi + 200
+    assert ig.az_from_accel(a, M, az_sign=-1.0, az_offset_deg=200.0) == (
+        pytest.approx(130.0, abs=1e-6)
+    )
+
+
+def test_az_from_yaw_applies_sign_and_offset():
+    assert ig.az_from_yaw(10.0, az_yaw_sign=-1.0, az_yaw_offset_deg=5.0) == (
+        pytest.approx(-5.0)
+    )
+
+
+def test_blend_az_picks_yaw_near_level_and_accel_when_tilted():
+    az_y, az_a = 100.0, 104.0
+    near, w_near = ig.blend_az(az_a, az_y, el_deg=0.0, theta_cross_deg=1.6)
+    tilt, w_tilt = ig.blend_az(az_a, az_y, el_deg=45.0, theta_cross_deg=1.6)
+    assert near == pytest.approx(100.0)  # all yaw
+    assert w_near == pytest.approx(0.0)
+    assert tilt == pytest.approx(104.0)  # all accel
+    assert w_tilt == pytest.approx(1.0)
+
+
+def test_blend_az_takes_shortest_circular_path():
+    # yaw 359, accel 1 -> blend should cross 0, not sweep backwards
+    az, w = ig.blend_az(1.0, 359.0, el_deg=45.0, theta_cross_deg=1.6)
+    assert az == pytest.approx(1.0)  # w=1 -> accel; sanity on wrap helper
+    mid, _ = ig.blend_az(1.0, 359.0, el_deg=1.6, theta_cross_deg=1.6)
+    assert mid == pytest.approx(360.0, abs=1e-6)  # halfway across the wrap
+
+
+def test_estimate_theta_phi_round_trip():
+    M_el, M_az = ig.R_x(0.2), ig.R_z(-0.4) @ ig.R_y(0.1)
+    theta_t, phi_t = 35.0, -60.0
+    a_el = _accel_el(np.radians(theta_t), M_el)
+    a_az = _accel_az(np.radians(theta_t), np.radians(phi_t), M_az)
+    theta, phi = ig.estimate_theta_phi_from_accel(a_el, a_az, M_el, M_az)
+    assert theta == pytest.approx(theta_t, abs=1e-6)
+    assert phi == pytest.approx(phi_t, abs=1e-6)

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -43,3 +43,43 @@ def test_precondition_batched():
     a = np.array([[3.0, 0.0, 0.0], [0.0, 0.0, -2.0]])
     u = ig.precondition(a, bias)
     assert np.allclose(np.linalg.norm(u, axis=1), 1.0)
+
+
+def test_kabsch_recovers_known_rotation():
+    M_true = ig.R_z(0.7) @ ig.R_x(0.3)
+    rng = np.random.default_rng(1)
+    body = rng.normal(size=(50, 3))
+    body /= np.linalg.norm(body, axis=1, keepdims=True)
+    host = (M_true @ body.T).T
+    M = ig.kabsch(body, host)
+    assert np.allclose(M, M_true, atol=1e-9)
+    assert np.isclose(np.linalg.det(M), 1.0)
+
+
+def test_fit_plane_normal_of_circle():
+    # points on a circle in the x-y plane -> normal is +/- z
+    ang = np.linspace(0, 2 * np.pi, 40, endpoint=False)
+    pts = np.column_stack([np.cos(ang), np.sin(ang), np.zeros_like(ang)])
+    n = ig.fit_plane_normal(pts)
+    assert np.allclose(np.abs(n), [0, 0, 1], atol=1e-9)
+
+
+def test_nearest_signed_permutation_identity():
+    labels, misalign = ig.nearest_signed_permutation(np.eye(3))
+    assert labels == ["+x", "+y", "+z"]
+    assert misalign == pytest.approx(0.0, abs=1e-9)
+
+
+def test_nearest_signed_permutation_swapped_axes():
+    # body x -> host +y, body y -> host -x, body z -> host +z
+    M = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    labels, misalign = ig.nearest_signed_permutation(M)
+    assert labels == ["+y", "-x", "+z"]
+    assert misalign == pytest.approx(0.0, abs=1e-9)
+
+
+def test_nearest_signed_permutation_reports_small_misalignment():
+    M = ig.R_z(np.radians(4.0))  # 4 deg off identity
+    labels, misalign = ig.nearest_signed_permutation(M)
+    assert labels == ["+x", "+y", "+z"]
+    assert misalign == pytest.approx(4.0, abs=1e-6)

--- a/picohost/tests/test_imu_handler.py
+++ b/picohost/tests/test_imu_handler.py
@@ -188,6 +188,51 @@ def test_imu_el_calibrated_published_dict_is_scalar_only():
     dev.disconnect()
 
 
+def test_imu_az_malformed_cal_still_publishes_raw():
+    """A partial/broken cal section must never suppress the raw firmware tick.
+
+    The handler derives az/el before its single publish; a missing key in the
+    cal must degrade the derived fields to None, not drop the whole record.
+    """
+    dev = DummyPicoIMU("/dev/dummy")
+    # cal missing "M" (and more) -> derivation raises mid-handler
+    dev.set_calibration(imu_az={"accel_bias": [0.0, 0.0, 0.0]})
+    pub = _capture(dev, _az_status(30, 70, 100))
+    assert pub["yaw"] == 100  # raw tick survived
+    assert pub["accel_x"] is not None
+    for k in (
+        "az_deg",
+        "el_deg",
+        "az_from_accel_deg",
+        "az_from_yaw_deg",
+        "az_blend_weight",
+    ):
+        assert pub[k] is None  # derived degraded to None, shape stays stable
+    dev.disconnect()
+
+
+def test_imu_el_malformed_cal_still_publishes_raw():
+    """imu_el counterpart: a broken cal yields el_deg=None, raw preserved."""
+    dev = DummyPicoIMU("/dev/dummy", name="imu_el")
+    dev.set_calibration(imu_el={"accel_bias": [0.0, 0.0, 0.0]})  # missing M
+    th = np.radians(25.0)
+    data = {
+        "sensor_name": "imu_el",
+        "status": "update",
+        "app_id": 3,
+        "yaw": 0.0,
+        "pitch": 0.0,
+        "roll": 0.0,
+        "accel_x": 0.0,
+        "accel_y": float(np.sin(th)),
+        "accel_z": float(np.cos(th)),
+    }
+    pub = _capture(dev, data)
+    assert pub["accel_y"] is not None  # raw survived
+    assert pub["el_deg"] is None
+    dev.disconnect()
+
+
 def test_emulator_to_handler_roundtrip_identity_mount():
     """Forward-model status dict at a known pose; handler recovers az/el
     with a cal whose mount matches the forward model's (identity)."""

--- a/picohost/tests/test_imu_handler.py
+++ b/picohost/tests/test_imu_handler.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pytest
+
+from picohost import imu_geometry as ig
+from picohost.testing import DummyPicoIMU
+
+_SCALARS = (str, int, float, bool, type(None))
+
+# An imu_az calibration with identity mount and a +30 deg pot offset on both
+# az channels, so az = phi + 30 (accel) and az = yaw + 30 (yaw).
+_AZ_CAL = {
+    "accel_bias": [0.0, 0.0, 0.0],
+    "accel_scale": 1.0,
+    "M": [[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]],
+    "az_accel_offset_deg": 30.0,
+    "az_sign": 1.0,
+    "az_yaw_offset_deg": 30.0,
+    "az_yaw_sign": 1.0,
+    "theta_cross_deg": 1.6,
+}
+_EL_CAL = {
+    "accel_bias": [0.0, 0.0, 0.0],
+    "accel_scale": 1.0,
+    "M": [[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]],
+}
+
+
+def _accel_az(theta_deg, phi_deg):
+    th, ph = np.radians(theta_deg), np.radians(phi_deg)
+    return ig.R_z(ph).T @ np.array([0.0, np.sin(th), np.cos(th)])
+
+
+def _capture(dev, data):
+    captured = {}
+    dev._base_redis_handler = lambda d: captured.update(d)
+    dev._imu_redis_handler(data)
+    return captured
+
+
+def _az_status(theta_deg, phi_deg, yaw_deg):
+    ax, ay, az = _accel_az(theta_deg, phi_deg)
+    return {
+        "sensor_name": "imu_az",
+        "status": "update",
+        "app_id": 6,
+        "yaw": yaw_deg,
+        "pitch": 0.0,
+        "roll": 0.0,
+        "accel_x": float(ax),
+        "accel_y": float(ay),
+        "accel_z": float(az),
+    }
+
+
+def test_imu_az_uncalibrated_publishes_none_fields():
+    dev = DummyPicoIMU("/dev/dummy")
+    pub = _capture(dev, _az_status(30, 70, 100))
+    for k in (
+        "az_deg",
+        "el_deg",
+        "az_from_accel_deg",
+        "az_from_yaw_deg",
+        "az_blend_weight",
+    ):
+        assert pub[k] is None
+    # raw fields preserved
+    assert pub["yaw"] == 100
+    dev.disconnect()
+
+
+def test_imu_az_calibrated_reports_az_and_el():
+    dev = DummyPicoIMU("/dev/dummy")
+    dev.set_calibration(imu_az=_AZ_CAL)
+    pub = _capture(dev, _az_status(40.0, 70.0, 100.0))
+    assert pub["el_deg"] == pytest.approx(40.0, abs=1e-3)
+    # tilted -> accel regime -> az = phi + 30 = 100
+    assert pub["az_from_accel_deg"] == pytest.approx(100.0, abs=1e-3)
+    assert pub["az_from_yaw_deg"] == pytest.approx(130.0, abs=1e-3)
+    assert pub["az_blend_weight"] == pytest.approx(1.0)
+    assert pub["az_deg"] == pytest.approx(100.0, abs=1e-3)
+    dev.disconnect()
+
+
+def test_imu_az_near_level_uses_yaw():
+    dev = DummyPicoIMU("/dev/dummy")
+    dev.set_calibration(imu_az=_AZ_CAL)
+    pub = _capture(dev, _az_status(0.0, 0.0, 100.0))
+    assert pub["az_blend_weight"] == pytest.approx(0.0)
+    assert pub["az_deg"] == pytest.approx(130.0, abs=1e-3)  # yaw + 30
+    dev.disconnect()
+
+
+def test_imu_el_reports_el_only_no_az_fields():
+    dev = DummyPicoIMU("/dev/dummy", name="imu_el")
+    dev.set_calibration(imu_el=_EL_CAL)
+    th = np.radians(25.0)
+    data = {
+        "sensor_name": "imu_el",
+        "status": "update",
+        "app_id": 3,
+        "yaw": 0.0,
+        "pitch": 0.0,
+        "roll": 0.0,
+        "accel_x": 0.0,
+        "accel_y": float(np.sin(th)),
+        "accel_z": float(np.cos(th)),
+    }
+    pub = _capture(dev, data)
+    assert pub["el_deg"] == pytest.approx(25.0, abs=1e-3)
+    assert "az_deg" not in pub  # imu_el structurally never reports az
+    dev.disconnect()
+
+
+def test_published_dict_is_scalar_only_both_states():
+    dev = DummyPicoIMU("/dev/dummy")
+    for cal in (None, _AZ_CAL):
+        if cal is not None:
+            dev.set_calibration(imu_az=cal)
+        pub = _capture(dev, _az_status(30, 70, 100))
+        for k, v in pub.items():
+            assert isinstance(v, _SCALARS), f"{k!r} is {type(v).__name__}"
+    dev.disconnect()
+
+
+def test_imu_az_field_set_stable_across_cal_state():
+    dev = DummyPicoIMU("/dev/dummy")
+    before = set(_capture(dev, _az_status(30, 70, 100)))
+    dev.set_calibration(imu_az=_AZ_CAL)
+    after = set(_capture(dev, _az_status(30, 70, 100)))
+    assert before == after
+    dev.disconnect()

--- a/picohost/tests/test_imu_handler.py
+++ b/picohost/tests/test_imu_handler.py
@@ -129,3 +129,18 @@ def test_imu_az_field_set_stable_across_cal_state():
     after = set(_capture(dev, _az_status(30, 70, 100)))
     assert before == after
     dev.disconnect()
+
+
+def test_emulator_to_handler_roundtrip_identity_mount():
+    """Emulator renders a known pose; handler recovers az/el with a cal
+    whose mount matches the emulator's (identity)."""
+    dev = DummyPicoIMU(
+        "/dev/dummy"
+    )  # app_id 3 default -> name imu_el? see note
+    dev.set_calibration(imu_az=_AZ_CAL)
+    # craft an imu_az status straight from the forward model at (el=35, az=80)
+    pub = _capture(dev, _az_status(35.0, 80.0 - 30.0, 80.0 - 30.0))
+    # az_accel_offset is +30 so phi=50 -> az 80; yaw 50 -> az 80
+    assert pub["el_deg"] == pytest.approx(35.0, abs=1e-3)
+    assert pub["az_deg"] == pytest.approx(80.0, abs=1e-3)
+    dev.disconnect()

--- a/picohost/tests/test_imu_handler.py
+++ b/picohost/tests/test_imu_handler.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
+from eigsep_redis.testing import DummyTransport
 
 from picohost import imu_geometry as ig
+from picohost.buses import ImuCalStore
 from picohost.testing import DummyPicoIMU
 
 _SCALARS = (str, int, float, bool, type(None))
@@ -131,12 +133,67 @@ def test_imu_az_field_set_stable_across_cal_state():
     dev.disconnect()
 
 
+def test_imu_cal_store_loads_at_init():
+    """ImuCalStore pre-populated before construction is applied at init time."""
+    transport = DummyTransport()
+    store = ImuCalStore(transport)
+    store.upload({"imu_az": _AZ_CAL})
+    dev = DummyPicoIMU("/dev/dummy", imu_cal_store=store)
+    try:
+        assert dev._imu_cal.get("imu_az") == _AZ_CAL
+    finally:
+        dev.disconnect()
+
+
+def test_imu_el_uncalibrated_publishes_none_el_no_az_keys():
+    """Uncalibrated imu_el: el_deg is None and no az keys are emitted."""
+    dev = DummyPicoIMU("/dev/dummy", name="imu_el")
+    th = np.radians(25.0)
+    data = {
+        "sensor_name": "imu_el",
+        "status": "update",
+        "app_id": 3,
+        "yaw": 0.0,
+        "pitch": 0.0,
+        "roll": 0.0,
+        "accel_x": 0.0,
+        "accel_y": float(np.sin(th)),
+        "accel_z": float(np.cos(th)),
+    }
+    pub = _capture(dev, data)
+    assert pub["el_deg"] is None
+    assert "az_deg" not in pub
+    dev.disconnect()
+
+
+def test_imu_el_calibrated_published_dict_is_scalar_only():
+    """Calibrated imu_el: every published value is a scalar (no lists/dicts)."""
+    dev = DummyPicoIMU("/dev/dummy", name="imu_el")
+    dev.set_calibration(imu_el=_EL_CAL)
+    th = np.radians(25.0)
+    data = {
+        "sensor_name": "imu_el",
+        "status": "update",
+        "app_id": 3,
+        "yaw": 0.0,
+        "pitch": 0.0,
+        "roll": 0.0,
+        "accel_x": 0.0,
+        "accel_y": float(np.sin(th)),
+        "accel_z": float(np.cos(th)),
+    }
+    pub = _capture(dev, data)
+    for k, v in pub.items():
+        assert isinstance(v, _SCALARS), f"{k!r} is {type(v).__name__}"
+    dev.disconnect()
+
+
 def test_emulator_to_handler_roundtrip_identity_mount():
-    """Emulator renders a known pose; handler recovers az/el with a cal
-    whose mount matches the emulator's (identity)."""
+    """Forward-model status dict at a known pose; handler recovers az/el
+    with a cal whose mount matches the forward model's (identity)."""
     dev = DummyPicoIMU(
         "/dev/dummy"
-    )  # app_id 3 default -> name imu_el? see note
+    )  # handler keys off data["sensor_name"], not the device name
     dev.set_calibration(imu_az=_AZ_CAL)
     # craft an imu_az status straight from the forward model at (el=35, az=80)
     pub = _capture(dev, _az_status(35.0, 80.0 - 30.0, 80.0 - 30.0))

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -12,7 +12,7 @@ import pytest
 from eigsep_redis import HeartbeatReader
 from eigsep_redis.testing import DummyTransport
 
-from picohost.buses import PicoConfigStore
+from picohost.buses import ImuCalStore, PicoConfigStore
 from picohost.keys import (
     PICO_CMD_STREAM,
     PICO_CONFIG_KEY,
@@ -29,6 +29,7 @@ from picohost.manager import (
     _BLOCKED_ACTIONS,
 )
 from picohost.testing import (
+    DummyPicoIMU,
     DummyPicoMotor,
     DummyPicoPeltier,
     DummyPicoRFSwitch,
@@ -515,6 +516,32 @@ class TestDiscoverNew:
         )
         mgr._discover_new()
         assert mgr.picos == {}
+
+    def test_imu_cal_store_passed_to_pico_imu(self, mgr, monkeypatch):
+        """_register_devices wires imu_cal_store into PicoIMU at init."""
+        import picohost.manager as mgr_mod
+
+        _AZ_CAL = {
+            "accel_bias": [0.0, 0.0, 0.0],
+            "accel_scale": 1.0,
+            "M": [[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]],
+            "az_accel_offset_deg": 30.0,
+            "az_sign": 1.0,
+            "az_yaw_offset_deg": 30.0,
+            "az_yaw_sign": 1.0,
+            "theta_cross_deg": 1.6,
+        }
+        # Pre-populate the manager's ImuCalStore before discovery.
+        mgr._imu_cal_store.upload({"imu_az": _AZ_CAL})
+        monkeypatch.setitem(mgr_mod.PICO_CLASSES, "imu_az", DummyPicoIMU)
+        mgr._register_devices(
+            [{"app_id": 6, "port": "/dev/dummy", "usb_serial": ""}]
+        )
+        dev = mgr.picos["imu_az"]
+        try:
+            assert dev._imu_cal.get("imu_az") == _AZ_CAL
+        finally:
+            dev.disconnect()
 
     def test_mute_probe_does_not_adopt(self, mgr, monkeypatch):
         import picohost.manager as mgr_mod

--- a/picohost/tests/test_manager.py
+++ b/picohost/tests/test_manager.py
@@ -12,7 +12,7 @@ import pytest
 from eigsep_redis import HeartbeatReader
 from eigsep_redis.testing import DummyTransport
 
-from picohost.buses import ImuCalStore, PicoConfigStore
+from picohost.buses import PicoConfigStore
 from picohost.keys import (
     PICO_CMD_STREAM,
     PICO_CONFIG_KEY,

--- a/picohost/tests/test_protocol_conformance.py
+++ b/picohost/tests/test_protocol_conformance.py
@@ -385,13 +385,18 @@ class TestImuProtocol:
         assert emu.get_status()["status"] == "error"
 
     def test_euler_angles_are_degrees(self):
-        """RVC output is in degrees."""
-        emu = ImuEmulator()
-        emu.az_angle = 0.5  # ~28.6 degrees
+        """RVC output is in degrees, not radians.
+
+        For imu_el with identity mount and el=30°, the forward model
+        produces roll≈30 (degrees).  If the emitter used radians the
+        value would be ~0.52, which is distinguishable from 30.
+        """
+        emu = ImuEmulator(app_id=3)  # imu_el
+        emu.set_orientation(az_deg=0.0, el_deg=30.0)
         emu.op()
         status = emu.get_status()
-        # yaw should be close to degrees(0.5) ≈ 28.6
-        assert abs(status["yaw"] - 28.6) < 1.0
+        # roll encodes the elevation rotation for imu_el with identity mount
+        assert abs(status["roll"] - 30.0) < 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Gives the two BNO08x IMUs an azimuth/elevation conversion: `imu_az` → az + el, `imu_el` → el (independent cross-check). A shared pure-math module (`imu_geometry`) is used **identically** by the live redis handler and the lab calibration tool, so field and bench agree by construction. Firmware (C) is unchanged — RVC passthrough already existed.

Design decisions are grounded in the 0627 field data (`eigsep_observing/notebooks/motor_pot_imu/`):
- **Motor is a mover, not fit truth** — it slips ~19.5° RMS (verified real slip, not lag). The **calibrated pot is the azimuth standard**; **gravity is the elevation standard**.
- **Direction-only inverse** — accel is bias-subtracted and normalized before any inverse, so the conversion is immune to the measured ~1.24× accel-magnitude anomaly (a constant scale/bias cancels). The anomaly is flagged for a separate firmware check.
- **az = yaw + accel-φ blend** registered to the pot frame (yaw near level, drift-free accel-φ when tilted).

## What's included
- `imu_geometry.py` — rotations, accel **sphere fit** (bias/scale) + preconditioning, **Kabsch** mount fit, nearest-signed-permutation cross-check, el/az estimators, tilt blend, and `fit_calibration_from_sweeps`. 100% covered.
- `ImuCalStore` (Redis key `imu_calibration`) — parallel to `PotCalStore`/`CurrentCalStore`; **wired into `PicoManager`** so a rebooted Pico comes up calibrated from Redis.
- `PicoIMU` live handler — additive, scalar-only, field-set stable, `None` when uncalibrated; `imu_el` never emits az. `set_calibration` for live push.
- `ImuEmulator` driven by a real `(az, el, mount)` forward model (removes the stale `yaw=az` assumption).
- `calibrate_imu` tool (`elevation`/`azimuth`/`all`) — stop-settle-average sweeps, `$`-blocking liveness gate, graceful degradation (calibrates whatever IMUs are alive), `BGSAVE` + live push.

## Lab procedure
Run `calibrate-pot` first (pot = az standard), then three sweeps: full-circle elevation (both el-axes + level zero), az near-level (yaw→pot), az tilted (az-axis + accel-φ→pot). See the design doc.

## Graceful degradation
`imu_az` calibrates standalone (el+az); `imu_el` standalone (el only). Elevation needs only gravity; azimuth additionally needs the pot. **Note:** `imu_az` is only calibrated alongside the az sweeps (which require the pot) — without the pot, the tool calibrates `imu_el` and skips `imu_az` with a warning (fail-safe).

## Out of scope
Long-term, cross-sensor time-series fusion of IMU components with the pot lives in `eigsep_observing`. A fast `rezero-el` mode is a deferred follow-on. The ~1.24× firmware accel-scale check is tracked separately.

## Testing
Full suite **616 passed** locally (3 `CmdLoopEndToEnd` deselected — pre-existing py3.14-only flaky; CI runs 3.9–3.12). Built test-first; a final whole-branch review caught and fixed a Critical (missing manager wiring) plus several test gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)