### PR TITLE
feat(calibrate-pot): manual mode to restore pot cal + slope sanity check

### DIFF
--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -18,17 +18,28 @@ Requires PicoManager to be running and the ``potmon`` device to be
 healthy. The script never touches the serial port itself, so it can
 be invoked alongside the manager.
 
-Four modes:
+Five modes:
   --mode minmax   : bench, collect at min and max (2-point fit, default)
   --mode turns    : bench, collect at every full turn (least-squares)
   --mode azimuth  : in-box, operator drives the motor; sweep over the
                     operating turn, slope fit, zero pinned to motor-home
   --mode rezero   : in-box, re-pin the zero using the stored slope (fast;
                     needs only motor access)
+  --mode manual   : recovery, write a hand-supplied --slope/--intercept
+                    directly (no sweep) to restore the cal after a
+                    catastrophic Redis loss (e.g. Pi swap); the two numbers
+                    are read off a recent correlator .h5. Writes Redis even
+                    when the pot is down (loads on the next manager start).
+
+Every mode runs a physical slope sanity check: a 3.75-turn pot over the
+~3.3 V ADC range has a slope of ~409 deg/V, so a slope off by more than
+1.5x prints a WARNING and requires a typed 'yes' to save.
 
 Usage:
     calibrate-pot --mode azimuth
     calibrate-pot --mode rezero
+    calibrate-pot --mode manual --slope 409.1 --intercept -400.0 \\
+        --note "restored from corr_20260615.h5"
 """
 
 from argparse import ArgumentParser
@@ -68,6 +79,14 @@ HOME_AZ_TOL_DEG = 5.0
 # azimuth by more than this (deg) anywhere in the swept window, relative
 # to the calibration already stored in Redis.
 WILDLY_DIFFERENT_WARN_DEG = 30.0
+# Physical sanity bound on the slope, independent of the stored cal. A
+# full-travel `turns`-turn pot whose wiper spans ADC_VREF has a slope of
+# turns*360/Vref deg/V (~409 for the installed 3.75-turn pot over 3.3 V).
+# Warn (and escalate the save to a typed 'yes') when the computed or
+# operator-supplied |slope| is off by more than this factor — catches
+# order-of-magnitude typos (manual mode) and gross sweep/turn-count errors.
+# 1.5x -> an in-range window of ~273..614 deg/V for the installed pot.
+SLOPE_SANITY_FACTOR = 1.5
 
 
 def collect_samples(transport, n):
@@ -242,6 +261,28 @@ def predicted_angle_divergence(new_cal, old_cal, voltages):
     )
 
 
+def expected_slope_mag(turns, vref=ADC_VREF):
+    """Expected |slope| in deg/V for a full-travel ``turns``-turn pot.
+
+    The wiper spans ~0..``vref``, so a pot of ``turns`` full turns
+    (``turns*360`` mechanical degrees) gives ``turns*360/vref`` deg/V.
+    """
+    return turns * 360.0 / vref
+
+
+def slope_out_of_range(m, turns, vref=ADC_VREF, factor=SLOPE_SANITY_FACTOR):
+    """True when ``|m|`` diverges from the expected slope by more than ``factor``.
+
+    Magnitude-only (slope sign is a wiring-direction convention). A zero
+    slope, or a non-positive expected slope, is always out of range.
+    """
+    expected = expected_slope_mag(turns, vref)
+    if expected <= 0 or m == 0:
+        return True
+    ratio = max(abs(m) / expected, expected / abs(m))
+    return ratio > factor
+
+
 def collect_minmax(transport, n_samples, total_degrees):
     """Collect at min and max only (2-point calibration)."""
     input("\nSet the az potentiometer to MINIMUM position, then press Enter.")
@@ -369,17 +410,16 @@ def rezero(transport, n_samples):
     return (m, b), v0
 
 
-def prompt_save(diverged):
+def prompt_save(require_confirm):
     """Ask whether to persist the calibration. Returns True to save.
 
     Safe default: bare Enter (or anything other than y/yes) discards. When
-    ``diverged`` is True the operator must type the full word ``yes`` to
-    confirm overwriting a sharply different stored calibration.
+    ``require_confirm`` is True (a flagged calibration — sharply different
+    from the stored one, or a slope that fails the physical sanity check)
+    the operator must type the full word ``yes`` to confirm.
     """
-    if diverged:
-        resp = (
-            input("Type 'yes' to confirm the large change: ").strip().lower()
-        )
+    if require_confirm:
+        resp = input("Type 'yes' to confirm: ").strip().lower()
         return resp == "yes"
     resp = input("Save this calibration? [y/N]: ").strip().lower()
     return resp in ("y", "yes")
@@ -413,13 +453,36 @@ def build_parser():
         "-m",
         "--mode",
         type=str,
-        choices=["minmax", "turns", "azimuth", "rezero"],
+        choices=["minmax", "turns", "azimuth", "rezero", "manual"],
         default="minmax",
         help=(
             "Calibration mode. Bench: 'minmax' (2-point), 'turns' "
             "(per-turn least-squares). In-box (motor-driven): 'azimuth' "
             "(sweep + zero pinned to motor-home), 'rezero' (re-pin zero "
-            "with the stored slope). Default: minmax."
+            "with the stored slope). Recovery: 'manual' (write a "
+            "hand-supplied --slope/--intercept directly, no sweep). "
+            "Default: minmax."
+        ),
+    )
+    parser.add_argument(
+        "--slope",
+        type=float,
+        default=None,
+        help="Slope m (deg/V) for --mode manual. Required for that mode.",
+    )
+    parser.add_argument(
+        "--intercept",
+        type=float,
+        default=None,
+        help="Intercept b (deg) for --mode manual. Required for that mode.",
+    )
+    parser.add_argument(
+        "--note",
+        type=str,
+        default=None,
+        help=(
+            "Free-text provenance recorded in the calibration metadata, "
+            "e.g. 'restored from corr_20260615.h5'. Useful with --mode manual."
         ),
     )
     parser.add_argument(
@@ -468,10 +531,23 @@ def main():
         print("turns must be positive.", file=sys.stderr)
         sys.exit(1)
 
+    if args.mode == "manual" and (
+        args.slope is None or args.intercept is None
+    ):
+        print(
+            "--mode manual requires both --slope and --intercept.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     transport = Transport(host=args.redis_host, port=args.redis_port)
     pot_proxy = PicoProxy(POTMON_NAME, transport, source="calibrate-pot")
 
-    if not pot_proxy.is_available:
+    # Manual mode is a recovery path: it needs nothing from the pot to
+    # compute the cal, so it writes Redis even when the pot is down (the
+    # cal then loads on the next PicoManager start). Every other mode
+    # samples the live stream, so it still hard-requires the pot.
+    if args.mode != "manual" and not pot_proxy.is_available:
         print(
             f"{POTMON_NAME} is not reachable via PicoManager. "
             "Start the manager and confirm the pot Pico is enumerated.",
@@ -526,6 +602,10 @@ def main():
                 resid = compute_fit_residuals(
                     voltages, angles, free[0], free[1]
                 )
+        elif args.mode == "manual":
+            # Recovery path: no sweep — the operator supplies (m, b) directly.
+            cal = (args.slope, args.intercept)
+            voltages, angles = [], []
         else:  # rezero
             cal, v0 = rezero(transport, args.n_samples)
             voltages, angles = [v0], [0.0]
@@ -571,27 +651,29 @@ def main():
                 "one side — risk of hitting the pot's hard stop in operation."
             )
 
-    cal_data = {
-        "pot_az": list(cal),
-        "metadata": {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "mode": args.mode,
-            "n_points": len(angles),
-            "pot_az_voltages": [float(v) for v in voltages],
-            "angles": [float(a) for a in angles],
-            "n_samples": args.n_samples,
-        },
+    metadata = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "mode": args.mode,
     }
+    # Manual mode has no sweep, so the sample-derived fields are meaningless.
+    if args.mode != "manual":
+        metadata["n_points"] = len(angles)
+        metadata["pot_az_voltages"] = [float(v) for v in voltages]
+        metadata["angles"] = [float(a) for a in angles]
+        metadata["n_samples"] = args.n_samples
     if args.mode in ("minmax", "turns"):
-        cal_data["metadata"]["turns"] = float(args.turns)
-        cal_data["metadata"]["total_degrees"] = total_degrees
+        metadata["turns"] = float(args.turns)
+        metadata["total_degrees"] = total_degrees
     if args.mode == "azimuth":
-        cal_data["metadata"]["motor_cfg"] = motor_cfg
-        cal_data["metadata"]["free_fit_intercept"] = float(free[1])
-        cal_data["metadata"]["residual_max_deg"] = resid["max_abs_deg"]
-        cal_data["metadata"]["residual_rms_deg"] = resid["rms_deg"]
+        metadata["motor_cfg"] = motor_cfg
+        metadata["free_fit_intercept"] = float(free[1])
+        metadata["residual_max_deg"] = resid["max_abs_deg"]
+        metadata["residual_rms_deg"] = resid["rms_deg"]
     if args.mode == "rezero":
-        cal_data["metadata"]["slope_reused"] = True
+        metadata["slope_reused"] = True
+    if args.note:
+        metadata["note"] = args.note
+    cal_data = {"pot_az": list(cal), "metadata": metadata}
 
     # Show the operator what was computed, then compare against the stored
     # calibration before writing anything.
@@ -600,7 +682,12 @@ def main():
         print(f"  ({len(angles)} points used for least-squares fit)")
 
     stored = PotCalStore(transport).get()
-    divergence = predicted_angle_divergence(cal, stored, voltages)
+    # Manual mode has no swept window to compare; the operator is typing
+    # authoritative numbers, so skip the divergence-vs-stored check.
+    if args.mode == "manual":
+        divergence = None
+    else:
+        divergence = predicted_angle_divergence(cal, stored, voltages)
     diverged = (
         divergence is not None and divergence > WILDLY_DIFFERENT_WARN_DEG
     )
@@ -614,7 +701,19 @@ def main():
         print(f"  stored: angle = {m_old:.4f} * V + {b_old:.4f}")
         print(f"  new:    angle = {cal[0]:.4f} * V + {cal[1]:.4f}")
 
-    if not prompt_save(diverged):
+    # Physical sanity bound on the slope (all modes), independent of any
+    # stored cal — the main guard against a fat-fingered manual --slope.
+    slope_bad = slope_out_of_range(cal[0], args.turns)
+    if slope_bad:
+        expected = expected_slope_mag(args.turns)
+        print(
+            f"\nWARNING: slope |{cal[0]:.1f}| deg/V is more than "
+            f"{SLOPE_SANITY_FACTOR:g}x off the expected ~{expected:.0f} deg/V "
+            f"for a {args.turns:g}-turn pot over {ADC_VREF:.1f} V. "
+            "Check the wiring, --turns, or a typo in the slope."
+        )
+
+    if not prompt_save(diverged or slope_bad):
         print("Discarded. Nothing written to Redis or the live pot.")
         return
 
@@ -632,7 +731,15 @@ def main():
     )
 
     # Push to the running PicoPotentiometer so the new cal takes effect on
-    # the next status tick.
+    # the next status tick. Skip when the pot is known-down (manual recovery
+    # path) to avoid a guaranteed ~5 s timeout — the Redis write above already
+    # restored it for the next PicoManager start.
+    if not pot_proxy.is_available:
+        print(
+            "Pot not reachable; calibration is stored in Redis and "
+            "loads on the next PicoManager restart."
+        )
+        return
     try:
         pot_proxy.send_command(
             "set_calibration",

--- a/picohost/tests/test_calibrate_pot.py
+++ b/picohost/tests/test_calibrate_pot.py
@@ -150,6 +150,31 @@ def test_default_turns_matches_installed_pot():
     assert p.parse_args(["-t", "10"]).turns == pytest.approx(10.0)
 
 
+def test_build_parser_accepts_manual_mode_and_args():
+    p = calibrate_pot.build_parser()
+    a = p.parse_args(
+        [
+            "--mode",
+            "manual",
+            "--slope",
+            "409.0",
+            "--intercept",
+            "-400.0",
+            "--note",
+            "restored from corr_20260615.h5",
+        ]
+    )
+    assert a.mode == "manual"
+    assert a.slope == pytest.approx(409.0)
+    assert a.intercept == pytest.approx(-400.0)
+    assert a.note == "restored from corr_20260615.h5"
+    # Defaults when omitted: slope/intercept None, note None.
+    d = p.parse_args([])
+    assert d.slope is None
+    assert d.intercept is None
+    assert d.note is None
+
+
 def test_build_parser_accepts_new_modes_and_motor_cfg():
     p = calibrate_pot.build_parser()
 
@@ -531,3 +556,239 @@ def test_prompt_save_diverged_requires_full_yes(monkeypatch):
     for ans, expected in cases:
         monkeypatch.setattr("builtins.input", lambda *a, **k: ans)
         assert calibrate_pot.prompt_save(True) is expected
+
+
+# ---------------------------------------------------------------------------
+# slope sanity check (all modes)
+# ---------------------------------------------------------------------------
+
+
+def test_expected_slope_mag_installed_pot():
+    # 3.75-turn pot whose wiper spans the 3.3 V ADC range:
+    #   3.75 * 360 / 3.3 = 409.09... deg/V
+    assert calibrate_pot.expected_slope_mag(3.75) == pytest.approx(
+        3.75 * 360.0 / 3.3
+    )
+    assert calibrate_pot.expected_slope_mag(3.75) == pytest.approx(
+        409.09, abs=0.1
+    )
+
+
+def test_slope_out_of_range_in_window():
+    # Expected ~409 deg/V; factor 1.5 -> in-range ~273..614 deg/V.
+    assert calibrate_pot.slope_out_of_range(409.0, 3.75) is False
+    assert calibrate_pot.slope_out_of_range(300.0, 3.75) is False
+    assert calibrate_pot.slope_out_of_range(600.0, 3.75) is False
+    # Sign is irrelevant — magnitude only.
+    assert calibrate_pot.slope_out_of_range(-409.0, 3.75) is False
+
+
+def test_slope_out_of_range_flags_gross_errors():
+    # An order-of-magnitude typo in either direction is flagged.
+    assert calibrate_pot.slope_out_of_range(40.9, 3.75) is True
+    assert calibrate_pot.slope_out_of_range(4090.0, 3.75) is True
+    # Just outside the 1.5x window on each side.
+    assert calibrate_pot.slope_out_of_range(200.0, 3.75) is True
+    assert calibrate_pot.slope_out_of_range(700.0, 3.75) is True
+    # A zero slope is never sane.
+    assert calibrate_pot.slope_out_of_range(0.0, 3.75) is True
+
+
+# ---------------------------------------------------------------------------
+# manual mode main()
+# ---------------------------------------------------------------------------
+
+
+def _manual_argv(slope, intercept, *extra):
+    return [
+        "calibrate-pot",
+        "--mode",
+        "manual",
+        "--slope",
+        str(slope),
+        "--intercept",
+        str(intercept),
+        *extra,
+    ]
+
+
+def test_main_manual_stores_and_pushes(monkeypatch):
+    """--mode manual writes the typed slope/intercept and pushes live."""
+    dummy_transport = DummyTransport()
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _manual_argv(409.0, -400.0, "--note", "restored from corr_x.h5"),
+    )
+
+    calibrate_pot.main()
+
+    stored = PotCalStore(dummy_transport).get()
+    assert stored["pot_az"] == pytest.approx([409.0, -400.0])
+    assert stored["metadata"]["mode"] == "manual"
+    assert stored["metadata"]["note"] == "restored from corr_x.h5"
+    # No sweep happened, so no sample arrays in the metadata.
+    assert "pot_az_voltages" not in stored["metadata"]
+    assert "angles" not in stored["metadata"]
+
+    assert len(fake_proxy.calls) == 1
+    action, kwargs = fake_proxy.calls[0]
+    assert action == "set_calibration"
+    assert kwargs["pot_az_params"] == pytest.approx([409.0, -400.0])
+
+
+def test_main_manual_requires_slope_and_intercept(monkeypatch):
+    """--mode manual without both numbers exits(1) and writes nothing."""
+    dummy_transport = DummyTransport()
+    _fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    # --intercept given but --slope omitted.
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["calibrate-pot", "--mode", "manual", "--intercept", "-400.0"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        calibrate_pot.main()
+    assert exc.value.code == 1
+    assert PotCalStore(dummy_transport).get() is None
+
+
+def test_main_manual_redis_first_when_pot_unavailable(monkeypatch, capsys):
+    """Manual mode writes Redis even when the pot is down; no live push."""
+    dummy_transport = DummyTransport()
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    fake_proxy.is_available = False  # pot not reachable (e.g. fresh Pi)
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", _manual_argv(409.0, -400.0))
+
+    calibrate_pot.main()
+
+    # Durable restore happened despite the pot being down.
+    stored = PotCalStore(dummy_transport).get()
+    assert stored["pot_az"] == pytest.approx([409.0, -400.0])
+    # No live push was attempted (would have timed out).
+    assert fake_proxy.calls == []
+    assert "loads on" in capsys.readouterr().out.lower()
+
+
+def test_main_manual_overwrites_existing_without_divergence(
+    monkeypatch, capsys
+):
+    """Manual mode skips the divergence check (no swept window) and overwrites
+    any existing stored cal without crashing."""
+    dummy_transport = DummyTransport()
+    # A wildly different stored cal must NOT trigger the divergence warning,
+    # and the empty swept window must NOT crash predicted_angle_divergence.
+    PotCalStore(dummy_transport).upload({"pot_az": [50.0, -50.0]})
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", _manual_argv(409.0, -400.0))
+
+    calibrate_pot.main()
+
+    out = capsys.readouterr().out
+    assert "differs from the stored one" not in out
+    stored = PotCalStore(dummy_transport).get()
+    assert stored["pot_az"] == pytest.approx([409.0, -400.0])
+
+
+def test_main_manual_bad_slope_warns_and_requires_full_yes(
+    monkeypatch, capsys
+):
+    """An off-by-10x --slope prints a WARNING and a bare 'y' is not enough."""
+    dummy_transport = DummyTransport()
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    # slope 4090 deg/V is ~10x the expected ~409 -> out of range.
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", _manual_argv(4090.0, -400.0))
+
+    calibrate_pot.main()
+
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "expected" in out.lower()
+    # Bare 'y' must NOT save under the escalated (typed 'yes') gate.
+    assert PotCalStore(dummy_transport).get() is None
+    assert fake_proxy.calls == []
+
+
+def test_main_manual_bad_slope_full_yes_saves(monkeypatch):
+    """The same off-slope save goes through when the operator types 'yes'."""
+    dummy_transport = DummyTransport()
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "yes")
+    monkeypatch.setattr(sys, "argv", _manual_argv(4090.0, -400.0))
+
+    calibrate_pot.main()
+
+    assert PotCalStore(dummy_transport).get()["pot_az"] == pytest.approx(
+        [4090.0, -400.0]
+    )
+    assert len(fake_proxy.calls) == 1
+
+
+def test_main_manual_sane_slope_no_escalation(monkeypatch, capsys):
+    """A sane --slope (~409) prints no slope warning and saves on a bare 'y'."""
+    dummy_transport = DummyTransport()
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", _manual_argv(409.0, -400.0))
+
+    calibrate_pot.main()
+
+    out = capsys.readouterr().out
+    assert "off the expected" not in out.lower()
+    assert PotCalStore(dummy_transport).get()["pot_az"] == pytest.approx(
+        [409.0, -400.0]
+    )
+
+
+def test_main_manual_triggers_bgsave(monkeypatch):
+    """Saving in manual mode forces an RDB snapshot (durable restore)."""
+    dummy_transport = DummyTransport()
+    _fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    bgsave_calls = []
+    monkeypatch.setattr(
+        dummy_transport.r, "bgsave", lambda *a, **k: bgsave_calls.append(1)
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", _manual_argv(409.0, -400.0))
+
+    calibrate_pot.main()
+
+    assert bgsave_calls == [1]


### PR DESCRIPTION
## Summary

Adds a 5th `calibrate-pot` mode, `--mode manual`, and a physical slope sanity check that applies to **all** modes.

### `--mode manual --slope M --intercept B [--note ...]`
The recovery path after a catastrophic Redis loss (e.g. a Pi swap, which loses `dump.rdb`). Every recorded correlator `.h5` embeds `pot_az_cal_slope`/`pot_az_cal_intercept`, so the operator reads the two numbers off a recent `.h5` and types them in. No file format, no `.h5` parsing — it reuses the existing `PotCalStore` upload + `BGSAVE` + live `set_calibration` plumbing.

- **Redis-first**: skips the live-pot hard gate and always writes the durable Redis cal even when the pot is down (loads on the next PicoManager start), then pushes live **best-effort only when the pot is reachable** (avoids a guaranteed ~5 s timeout otherwise).
- No sweep → the divergence-vs-stored check is skipped and the metadata omits the sample-derived fields (`{"pot_az":[m,b],"metadata":{"timestamp","mode":"manual"[,"note"]}}`).
- Missing `--slope`/`--intercept` → clean `exit(1)`.

### Slope sanity check (all modes)
A full-travel `turns`-turn pot whose wiper spans the ADC range has slope `~turns*360/Vref` (≈409 °/V for the installed 3.75-turn pot over 3.3 V). A slope off by more than `SLOPE_SANITY_FACTOR` (1.5× → ~273–614 °/V) prints a WARNING and **escalates the save to a typed `yes`**. This is manual mode's only guard (no stored cal to diverge from) and catches an order-of-magnitude `--slope` typo. Magnitude-only (slope sign is a wiring-direction convention). `prompt_save`'s `diverged` param generalized to `require_confirm`.

## Testing
- TDD throughout — every behavior watched fail before implementing.
- New unit + integration tests: pure-helper boundaries (`expected_slope_mag`/`slope_out_of_range`, incl. `m==0`), manual round-trip + metadata, missing-args exit, Redis-first when the pot is down, overwrite-without-crash when a stored cal exists, BGSAVE, slope-bad escalation vs. sane-slope plain save, `--note`.
- Full picohost suite **583 passed** (3 known py3.14 `CmdLoopEndToEnd`-flaky deselected, CI runs 3.9–3.12), ruff + format clean.

No firmware change; `calibrate-pot` is a script (not an app), so no emulator is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)