### PR TITLE
fix(calibrate-imu): guard error-streaming IMU; clear operator message instead of SVD crash (#132)

### DIFF
--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -289,7 +289,13 @@ def main(argv=None):
             return 1
 
     cal = Calibrator(transport, args.n_samples, alive, args.mode)
-    el_sweep, az_level, az_tilt = cal.run_sweeps()
+    try:
+        el_sweep, az_level, az_tilt = cal.run_sweeps()
+    except RuntimeError as e:
+        # A fault that begins mid-sweep makes collect_vector abort with a
+        # named RuntimeError; surface it cleanly rather than as a traceback.
+        print(f"Sweep aborted: {e}", file=sys.stderr)
+        return 1
     try:
         sections = fit_calibration_from_sweeps(
             el_sweep, az_level, az_tilt, theta_cross_deg=args.theta_cross_deg

--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -33,21 +33,25 @@ IMU_AZ, IMU_EL, POTMON = "imu_az", "imu_el", "potmon"
 
 
 def collect_vector(transport, name, fields, n, start_id="$", reducer=None):
-    """Reduce `n` fresh entries of `fields` from stream:<name>.
+    """Reduce `n` fresh VALID entries of `fields` from stream:<name>.
 
     Reads only entries published after this call starts (``start_id``
     defaults to ``"$"``), so repeated calls within one sweep don't
-    double-count the same firmware tick. Mirrors
-    :func:`calibrate_pot.collect_samples`' fail-fast semantics: if no new
-    entries arrive within ``SAMPLE_TIMEOUT_S``, raise rather than average a
-    stale value. Tests pass ``start_id="0-0"`` to read pre-loaded entries.
+    double-count the same firmware tick. Frames whose ``status`` is
+    ``"error"`` carry junk (a faulted IMU streams accel=[0,0,0]) and are
+    skipped. To avoid looping forever on a sustained fault, abort once
+    ``n`` consecutive error frames have been skipped, naming the stream.
+    Mirrors :func:`calibrate_pot.collect_samples`' fail-fast semantics: if
+    no new entries arrive within ``SAMPLE_TIMEOUT_S``, raise rather than
+    average a stale value. Tests pass ``start_id="0-0"`` to read pre-loaded
+    entries.
 
     ``reducer`` maps the ``(n, len(fields))`` sample array to the reduced
     result; it defaults to a per-field arithmetic mean. Pass a circular
     reducer for angle fields (e.g. yaw) that wrap at +/-180.
     """
     stream = f"stream:{name}"
-    rows, last_id = [], start_id
+    rows, last_id, consec_err = [], start_id, 0
     while len(rows) < n:
         resp = transport.r.xread(
             {stream: last_id},
@@ -60,9 +64,19 @@ def collect_vector(transport, name, fields, n, start_id="$", reducer=None):
             )
         for _s, msgs in resp:
             for msg_id, f in msgs:
-                value = json.loads(f[b"value"])
-                rows.append([float(value[k]) for k in fields])
                 last_id = msg_id
+                value = json.loads(f[b"value"])
+                if value.get("status") == "error":
+                    consec_err += 1
+                    if consec_err >= n:
+                        raise RuntimeError(
+                            f"{name}: {consec_err} consecutive status=error "
+                            f"frames (sensor faulted); collected only "
+                            f"{len(rows)}/{n} valid samples."
+                        )
+                    continue
+                consec_err = 0
+                rows.append([float(value[k]) for k in fields])
     arr = np.asarray(rows, dtype=float)
     return arr.mean(axis=0) if reducer is None else reducer(arr)
 

--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -29,6 +29,7 @@ from .proxy import PicoProxy
 logger = logging.getLogger(__name__)
 
 SAMPLE_TIMEOUT_S = 5.0
+STATUS_SAMPLES = 5  # frames to sample when classifying a stream's liveness
 IMU_AZ, IMU_EL, POTMON = "imu_az", "imu_el", "potmon"
 
 
@@ -81,17 +82,51 @@ def collect_vector(transport, name, fields, n, start_id="$", reducer=None):
     return arr.mean(axis=0) if reducer is None else reducer(arr)
 
 
-def stream_alive(transport, name, timeout_s=SAMPLE_TIMEOUT_S):
-    """True if stream:<name> publishes a NEW entry within timeout_s.
+def stream_status(
+    transport, name, timeout_s=SAMPLE_TIMEOUT_S, samples=STATUS_SAMPLES
+):
+    """Classify stream:<name> as 'healthy', 'faulted', or 'dead'.
 
-    Uses a blocking ``$`` read so a dead-but-stale stream (old entries, no
-    current publisher) reads False — the graceful-degradation gate must not
-    treat a crashed IMU as alive and feed its junk into the fit.
+    Blocks on a ``$`` cursor so a stale stream (old entries, no live
+    publisher) reads 'dead' — the graceful-degradation gate must not treat
+    a crashed IMU as alive. Samples up to ``samples`` fresh frames within
+    ``timeout_s``:
+
+      - no frame arrives           -> 'dead'    (no live publisher)
+      - >=1 frame status=='update' -> 'healthy'
+      - frames arrive, all error   -> 'faulted' (publisher up, sensor down;
+                                       these frames carry accel=[0,0,0])
+
+    A single-frame check is too noisy (one stray error frame on a healthy
+    sensor would false-trip), so 'faulted' requires a full window with no
+    'update'.
     """
-    resp = transport.r.xread(
-        {f"stream:{name}": "$"}, block=int(timeout_s * 1000), count=1
-    )
-    return bool(resp)
+    stream = f"stream:{name}"
+    last_id, seen_any, remaining = "$", False, samples
+    while remaining > 0:
+        resp = transport.r.xread(
+            {stream: last_id}, block=int(timeout_s * 1000), count=remaining
+        )
+        if not resp:
+            break
+        for _s, msgs in resp:
+            for msg_id, f in msgs:
+                value = json.loads(f[b"value"])
+                if value.get("status") == "update":
+                    return "healthy"
+                seen_any = True
+                last_id = msg_id
+                remaining -= 1
+    return "faulted" if seen_any else "dead"
+
+
+def stream_alive(transport, name, timeout_s=SAMPLE_TIMEOUT_S):
+    """True only if stream:<name> is publishing valid (status=update) frames.
+
+    Thin wrapper over :func:`stream_status`; a faulted or dead stream is not
+    alive for calibration.
+    """
+    return stream_status(transport, name, timeout_s=timeout_s) == "healthy"
 
 
 class Calibrator:

--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -241,9 +241,7 @@ def main(argv=None):
     logging.basicConfig(level=logging.INFO)
     transport = Transport(host=args.redis_host, port=args.redis_port)
 
-    states = {
-        n: stream_status(transport, n) for n in (IMU_AZ, IMU_EL, POTMON)
-    }
+    states = {n: stream_status(transport, n) for n in (IMU_AZ, IMU_EL, POTMON)}
     alive = {n for n, s in states.items() if s == "healthy"}
     # A faulted IMU (publisher up, sensor down) streams status=error frames
     # with accel=[0,0,0]. Without this gate it would pass a naive liveness
@@ -257,14 +255,16 @@ def main(argv=None):
                 f"(sensor faulted -- check wiring/power).",
                 file=sys.stderr,
             )
-        ans = input(
-            f"Continue calibration without {', '.join(faulted_imus)}? "
-            f"[y to continue / Enter to abort]: "
-        ).strip().lower()
-        if ans not in ("y", "yes"):
-            print(
-                "Aborted -- fix the sensor(s) and rerun.", file=sys.stderr
+        ans = (
+            input(
+                f"Continue calibration without {', '.join(faulted_imus)}? "
+                f"[y to continue / Enter to abort]: "
             )
+            .strip()
+            .lower()
+        )
+        if ans not in ("y", "yes"):
+            print("Aborted -- fix the sensor(s) and rerun.", file=sys.stderr)
             return 1
     if IMU_AZ not in alive and IMU_EL not in alive:
         print("No IMU streams alive; nothing to calibrate.", file=sys.stderr)

--- a/picohost/src/picohost/calibrate_imu.py
+++ b/picohost/src/picohost/calibrate_imu.py
@@ -241,7 +241,31 @@ def main(argv=None):
     logging.basicConfig(level=logging.INFO)
     transport = Transport(host=args.redis_host, port=args.redis_port)
 
-    alive = {n for n in (IMU_AZ, IMU_EL, POTMON) if stream_alive(transport, n)}
+    states = {
+        n: stream_status(transport, n) for n in (IMU_AZ, IMU_EL, POTMON)
+    }
+    alive = {n for n, s in states.items() if s == "healthy"}
+    # A faulted IMU (publisher up, sensor down) streams status=error frames
+    # with accel=[0,0,0]. Without this gate it would pass a naive liveness
+    # check and poison the fit with a cryptic 'SVD did not converge'. Surface
+    # it and let the operator fix wiring (abort) or proceed without it.
+    faulted_imus = [n for n in (IMU_AZ, IMU_EL) if states[n] == "faulted"]
+    if faulted_imus:
+        for n in faulted_imus:
+            print(
+                f"{n}: stream is publishing only status=error "
+                f"(sensor faulted -- check wiring/power).",
+                file=sys.stderr,
+            )
+        ans = input(
+            f"Continue calibration without {', '.join(faulted_imus)}? "
+            f"[y to continue / Enter to abort]: "
+        ).strip().lower()
+        if ans not in ("y", "yes"):
+            print(
+                "Aborted -- fix the sensor(s) and rerun.", file=sys.stderr
+            )
+            return 1
     if IMU_AZ not in alive and IMU_EL not in alive:
         print("No IMU streams alive; nothing to calibrate.", file=sys.stderr)
         return 1
@@ -266,9 +290,15 @@ def main(argv=None):
 
     cal = Calibrator(transport, args.n_samples, alive, args.mode)
     el_sweep, az_level, az_tilt = cal.run_sweeps()
-    sections = fit_calibration_from_sweeps(
-        el_sweep, az_level, az_tilt, theta_cross_deg=args.theta_cross_deg
-    )
+    try:
+        sections = fit_calibration_from_sweeps(
+            el_sweep, az_level, az_tilt, theta_cross_deg=args.theta_cross_deg
+        )
+    except ValueError as e:
+        # Backstop: a degenerate/zero-norm fit (e.g. a fault that slipped in
+        # mid-sweep) names its cause here instead of an opaque SVD failure.
+        print(f"Fit failed: {e}", file=sys.stderr)
+        return 1
     if not sections:
         print("Fit produced no sections.", file=sys.stderr)
         return 1

--- a/picohost/src/picohost/imu_geometry.py
+++ b/picohost/src/picohost/imu_geometry.py
@@ -40,14 +40,29 @@ def fit_accel_sphere(samples):
     b = np.sum(p**2, axis=1)
     sol, *_ = np.linalg.lstsq(A, b, rcond=None)
     bias = sol[:3]
-    scale = float(np.sqrt(sol[3] + bias @ bias))
+    scale = float(np.sqrt(max(sol[3] + bias @ bias, 0.0)))
+    if not np.isfinite(scale) or scale < 1e-6:
+        raise ValueError(
+            "fit_accel_sphere: degenerate accel sphere (scale "
+            f"{scale:.3g} ~ 0; sensor likely faulted: all accel=[0,0,0])"
+        )
     return bias, scale
 
 
 def precondition(a, bias):
-    """(a - bias) normalized to unit length. Accepts (3,) or (N,3)."""
+    """(a - bias) normalized to unit length. Accepts (3,) or (N,3).
+
+    Raises ValueError on a zero-norm vector (a faulted IMU streams
+    accel=[0,0,0], which would otherwise normalize to NaN and surface
+    several calls later as an opaque ``SVD did not converge``).
+    """
     a = np.asarray(a, dtype=float) - np.asarray(bias, dtype=float)
     n = np.linalg.norm(a, axis=-1, keepdims=True)
+    if np.any(n < 1e-9):
+        raise ValueError(
+            "precondition: zero-norm accel vector "
+            "(sensor likely faulted: accel=[0,0,0])"
+        )
     return a / n
 
 

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -55,8 +55,8 @@ def test_main_azimuth_uncalibrated_pot_aborts(monkeypatch):
     monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
     monkeypatch.setattr(
         calibrate_imu,
-        "stream_alive",
-        lambda t, n, timeout_s=5.0: n in ("imu_az", "potmon"),
+        "stream_status",
+        lambda t, n, **k: "healthy" if n in ("imu_az", "potmon") else "dead",
     )
     monkeypatch.setattr(
         calibrate_imu.Calibrator,
@@ -138,8 +138,8 @@ def test_main_persists_and_pushes(monkeypatch):
     )
     monkeypatch.setattr(
         calibrate_imu,
-        "stream_alive",
-        lambda t, n, timeout_s=5.0: n == "imu_az" or n == "potmon",
+        "stream_status",
+        lambda t, n, **k: "healthy" if n in ("imu_az", "potmon") else "dead",
     )
     monkeypatch.setattr("builtins.input", lambda *a: "y")  # confirm save
 
@@ -218,8 +218,8 @@ def test_main_discard_writes_nothing(monkeypatch):
     )
     monkeypatch.setattr(
         calibrate_imu,
-        "stream_alive",
-        lambda t, n, timeout_s=5.0: n == "imu_az" or n == "potmon",
+        "stream_status",
+        lambda t, n, **k: "healthy" if n in ("imu_az", "potmon") else "dead",
     )
     monkeypatch.setattr("builtins.input", lambda *a: "n")  # decline save
 
@@ -294,3 +294,79 @@ def test_stream_alive_delegates_to_status(monkeypatch):
     monkeypatch.setattr(calibrate_imu, "stream_status",
                         lambda *a, **k: "faulted")
     assert calibrate_imu.stream_alive(DummyTransport(), "imu_el") is False
+
+
+def _answers(*seq):
+    """Return an input() stand-in that yields the given answers in order."""
+    it = iter(seq)
+    return lambda *a, **k: next(it)
+
+
+def test_main_faulted_imu_aborts_by_default(monkeypatch):
+    """imu_el publishing only status=error: main names it and aborts (return
+    1) when the operator does not opt to continue — never reaching the fit."""
+    transport = DummyTransport()
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(
+        calibrate_imu, "stream_status",
+        lambda t, n, **k: "faulted" if n == "imu_el" else "healthy",
+    )
+    monkeypatch.setattr(
+        calibrate_imu.Calibrator, "run_sweeps",
+        lambda self: pytest.fail("must abort before sweeps"),
+    )
+    monkeypatch.setattr("builtins.input", _answers(""))  # Enter = abort
+    assert calibrate_imu.main(["--mode", "elevation"]) == 1
+    assert ImuCalStore(transport).get() is None
+
+
+def test_main_faulted_imu_continue_skips_it(monkeypatch):
+    """Operator opts to continue without the faulted imu_el: main proceeds and
+    imu_el is absent from the alive set handed to the Calibrator."""
+    transport = DummyTransport()
+    PotCalStore(transport).upload({"pot_az": [1.0, 0.0]})
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(
+        calibrate_imu, "stream_status",
+        lambda t, n, **k: "faulted" if n == "imu_el" else "healthy",
+    )
+    seen = {}
+
+    def fake_run_sweeps(self):
+        seen["alive"] = set(self.alive)
+        # Minimal empty sweeps -> no sections -> main returns 1 cleanly.
+        return (
+            {"imu_el": None, "imu_az": None, "level_index": 0, "direction": 1},
+            {"imu_az": None, "yaw_deg": None, "pot_deg": None},
+            {"imu_az": None, "pot_deg": None, "imu_el": None},
+        )
+
+    monkeypatch.setattr(calibrate_imu.Calibrator, "run_sweeps", fake_run_sweeps)
+    monkeypatch.setattr("builtins.input", _answers("y"))  # continue past fault
+    calibrate_imu.main(["--mode", "all"])
+    assert "imu_el" not in seen["alive"]
+    assert "imu_az" in seen["alive"]
+
+
+def test_main_fit_valueerror_is_clean(monkeypatch):
+    """A backstop ValueError from the fit surfaces as a clean return 1, not an
+    uncaught traceback."""
+    transport = DummyTransport()
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(
+        calibrate_imu, "stream_status", lambda t, n, **k: "healthy"
+    )
+    monkeypatch.setattr(
+        calibrate_imu.Calibrator, "run_sweeps",
+        lambda self: ({"imu_el": None, "imu_az": None, "level_index": 0,
+                       "direction": 1},
+                      {"imu_az": None, "yaw_deg": None, "pot_deg": None},
+                      {"imu_az": None, "pot_deg": None, "imu_el": None}),
+    )
+
+    def boom(*a, **k):
+        raise ValueError("degenerate accel sphere")
+
+    monkeypatch.setattr(calibrate_imu, "fit_calibration_from_sweeps", boom)
+    monkeypatch.setattr("builtins.input", _answers("y"))
+    assert calibrate_imu.main(["--mode", "elevation"]) == 1

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -68,8 +68,6 @@ def test_main_azimuth_uncalibrated_pot_aborts(monkeypatch):
     assert ImuCalStore(transport).get() is None
 
 
-
-
 def test_main_persists_and_pushes(monkeypatch):
     """End-to-end main(): synthetic sweeps -> fit -> ImuCalStore + proxy push."""
     from picohost import imu_geometry as ig
@@ -237,10 +235,38 @@ def test_collect_vector_skips_error_frames():
     """status=error frames carry junk (accel=[0,0,0]); collect_vector must
     drop them and average only the valid samples."""
     t = DummyTransport()
-    _xadd(t, "stream:imu_el", status="error", accel_x=0.0, accel_y=0.0, accel_z=0.0)
-    _xadd(t, "stream:imu_el", status="update", accel_x=2.0, accel_y=0.0, accel_z=8.0)
-    _xadd(t, "stream:imu_el", status="error", accel_x=0.0, accel_y=0.0, accel_z=0.0)
-    _xadd(t, "stream:imu_el", status="update", accel_x=4.0, accel_y=0.0, accel_z=10.0)
+    _xadd(
+        t,
+        "stream:imu_el",
+        status="error",
+        accel_x=0.0,
+        accel_y=0.0,
+        accel_z=0.0,
+    )
+    _xadd(
+        t,
+        "stream:imu_el",
+        status="update",
+        accel_x=2.0,
+        accel_y=0.0,
+        accel_z=8.0,
+    )
+    _xadd(
+        t,
+        "stream:imu_el",
+        status="error",
+        accel_x=0.0,
+        accel_y=0.0,
+        accel_z=0.0,
+    )
+    _xadd(
+        t,
+        "stream:imu_el",
+        status="update",
+        accel_x=4.0,
+        accel_y=0.0,
+        accel_z=10.0,
+    )
     v = calibrate_imu.collect_vector(
         t, "imu_el", ("accel_x", "accel_y", "accel_z"), n=2, start_id="0-0"
     )
@@ -252,7 +278,14 @@ def test_collect_vector_all_error_raises_named():
     naming the stream and the valid/required counts — not block or NaN."""
     t = DummyTransport()
     for _ in range(3):
-        _xadd(t, "stream:imu_el", status="error", accel_x=0.0, accel_y=0.0, accel_z=0.0)
+        _xadd(
+            t,
+            "stream:imu_el",
+            status="error",
+            accel_x=0.0,
+            accel_y=0.0,
+            accel_z=0.0,
+        )
     with pytest.raises(RuntimeError, match="imu_el.*status=error"):
         calibrate_imu.collect_vector(
             t, "imu_el", ("accel_x", "accel_y", "accel_z"), n=3, start_id="0-0"
@@ -262,8 +295,21 @@ def test_collect_vector_all_error_raises_named():
 def test_stream_status_healthy(monkeypatch):
     """An update frame -> healthy."""
     t = DummyTransport()
-    resp = [("stream:imu_az", [(b"1-0", {b"value": json.dumps(
-        {"status": "update", "accel_x": 0.0}).encode()})])]
+    resp = [
+        (
+            "stream:imu_az",
+            [
+                (
+                    b"1-0",
+                    {
+                        b"value": json.dumps(
+                            {"status": "update", "accel_x": 0.0}
+                        ).encode()
+                    },
+                )
+            ],
+        )
+    ]
     monkeypatch.setattr(t.r, "xread", lambda *a, **k: resp)
     assert calibrate_imu.stream_status(t, "imu_az", timeout_s=0.1) == "healthy"
 
@@ -272,10 +318,25 @@ def test_stream_status_faulted(monkeypatch):
     """Frames arriving but all status=error -> faulted (publisher up, sensor
     down). Drained one window then an empty read ends the loop."""
     t = DummyTransport()
-    err = [("stream:imu_el", [(b"1-0", {b"value": json.dumps(
-        {"status": "error", "accel_x": 0.0}).encode()})])]
+    err = [
+        (
+            "stream:imu_el",
+            [
+                (
+                    b"1-0",
+                    {
+                        b"value": json.dumps(
+                            {"status": "error", "accel_x": 0.0}
+                        ).encode()
+                    },
+                )
+            ],
+        )
+    ]
     calls = [err, []]  # first read: an error frame; second: nothing more
-    monkeypatch.setattr(t.r, "xread", lambda *a, **k: calls.pop(0) if calls else [])
+    monkeypatch.setattr(
+        t.r, "xread", lambda *a, **k: calls.pop(0) if calls else []
+    )
     assert calibrate_imu.stream_status(t, "imu_el", timeout_s=0.1) == "faulted"
 
 
@@ -288,11 +349,13 @@ def test_stream_status_dead(monkeypatch):
 
 def test_stream_alive_delegates_to_status(monkeypatch):
     """stream_alive is True only for a healthy stream."""
-    monkeypatch.setattr(calibrate_imu, "stream_status",
-                        lambda *a, **k: "healthy")
+    monkeypatch.setattr(
+        calibrate_imu, "stream_status", lambda *a, **k: "healthy"
+    )
     assert calibrate_imu.stream_alive(DummyTransport(), "imu_az") is True
-    monkeypatch.setattr(calibrate_imu, "stream_status",
-                        lambda *a, **k: "faulted")
+    monkeypatch.setattr(
+        calibrate_imu, "stream_status", lambda *a, **k: "faulted"
+    )
     assert calibrate_imu.stream_alive(DummyTransport(), "imu_el") is False
 
 
@@ -308,11 +371,13 @@ def test_main_faulted_imu_aborts_by_default(monkeypatch):
     transport = DummyTransport()
     monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
     monkeypatch.setattr(
-        calibrate_imu, "stream_status",
+        calibrate_imu,
+        "stream_status",
         lambda t, n, **k: "faulted" if n == "imu_el" else "healthy",
     )
     monkeypatch.setattr(
-        calibrate_imu.Calibrator, "run_sweeps",
+        calibrate_imu.Calibrator,
+        "run_sweeps",
         lambda self: pytest.fail("must abort before sweeps"),
     )
     monkeypatch.setattr("builtins.input", _answers(""))  # Enter = abort
@@ -327,7 +392,8 @@ def test_main_faulted_imu_continue_skips_it(monkeypatch):
     PotCalStore(transport).upload({"pot_az": [1.0, 0.0]})
     monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
     monkeypatch.setattr(
-        calibrate_imu, "stream_status",
+        calibrate_imu,
+        "stream_status",
         lambda t, n, **k: "faulted" if n == "imu_el" else "healthy",
     )
     seen = {}
@@ -341,7 +407,9 @@ def test_main_faulted_imu_continue_skips_it(monkeypatch):
             {"imu_az": None, "pot_deg": None, "imu_el": None},
         )
 
-    monkeypatch.setattr(calibrate_imu.Calibrator, "run_sweeps", fake_run_sweeps)
+    monkeypatch.setattr(
+        calibrate_imu.Calibrator, "run_sweeps", fake_run_sweeps
+    )
 
     prompts = []
 
@@ -353,7 +421,9 @@ def test_main_faulted_imu_continue_skips_it(monkeypatch):
     calibrate_imu.main(["--mode", "all"])
     assert "imu_el" not in seen["alive"]
     assert "imu_az" in seen["alive"]
-    assert any("imu_el" in p for p in prompts)  # operator was actually prompted
+    assert any(
+        "imu_el" in p for p in prompts
+    )  # operator was actually prompted
 
 
 def test_main_fit_valueerror_is_clean(monkeypatch):
@@ -365,19 +435,23 @@ def test_main_fit_valueerror_is_clean(monkeypatch):
         calibrate_imu, "stream_status", lambda t, n, **k: "healthy"
     )
     monkeypatch.setattr(
-        calibrate_imu.Calibrator, "run_sweeps",
-        lambda self: ({"imu_el": None, "imu_az": None, "level_index": 0,
-                       "direction": 1},
-                      {"imu_az": None, "yaw_deg": None, "pot_deg": None},
-                      {"imu_az": None, "pot_deg": None, "imu_el": None}),
+        calibrate_imu.Calibrator,
+        "run_sweeps",
+        lambda self: (
+            {"imu_el": None, "imu_az": None, "level_index": 0, "direction": 1},
+            {"imu_az": None, "yaw_deg": None, "pot_deg": None},
+            {"imu_az": None, "pot_deg": None, "imu_el": None},
+        ),
     )
 
     def boom(*a, **k):
         raise ValueError("degenerate accel sphere")
 
     monkeypatch.setattr(calibrate_imu, "fit_calibration_from_sweeps", boom)
-    monkeypatch.setattr("builtins.input",
-                        lambda *a, **k: pytest.fail("no prompt expected before fit error"))
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda *a, **k: pytest.fail("no prompt expected before fit error"),
+    )
     assert calibrate_imu.main(["--mode", "elevation"]) == 1
 
 
@@ -390,6 +464,7 @@ def test_main_sweep_runtimeerror_is_clean(monkeypatch):
     monkeypatch.setattr(
         calibrate_imu, "stream_status", lambda t, n, **k: "healthy"
     )
+
     def boom(self):
         raise RuntimeError(
             "imu_el: 3 consecutive status=error frames (sensor faulted); "

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -233,7 +233,7 @@ def _xadd(t, stream, **fields):
     t.r.xadd(stream, {"value": json.dumps(fields)})
 
 
-def test_collect_vector_skips_error_frames(monkeypatch):
+def test_collect_vector_skips_error_frames():
     """status=error frames carry junk (accel=[0,0,0]); collect_vector must
     drop them and average only the valid samples."""
     t = DummyTransport()
@@ -247,7 +247,7 @@ def test_collect_vector_skips_error_frames(monkeypatch):
     assert np.allclose(v, [3.0, 0.0, 9.0])  # mean of the two valid frames
 
 
-def test_collect_vector_all_error_raises_named(monkeypatch):
+def test_collect_vector_all_error_raises_named():
     """A faulted IMU (every frame status=error) must abort with a message
     naming the stream and the valid/required counts — not block or NaN."""
     t = DummyTransport()
@@ -342,10 +342,18 @@ def test_main_faulted_imu_continue_skips_it(monkeypatch):
         )
 
     monkeypatch.setattr(calibrate_imu.Calibrator, "run_sweeps", fake_run_sweeps)
-    monkeypatch.setattr("builtins.input", _answers("y"))  # continue past fault
+
+    prompts = []
+
+    def spy_input(prompt=""):
+        prompts.append(prompt)
+        return "y"
+
+    monkeypatch.setattr("builtins.input", spy_input)
     calibrate_imu.main(["--mode", "all"])
     assert "imu_el" not in seen["alive"]
     assert "imu_az" in seen["alive"]
+    assert any("imu_el" in p for p in prompts)  # operator was actually prompted
 
 
 def test_main_fit_valueerror_is_clean(monkeypatch):
@@ -368,5 +376,25 @@ def test_main_fit_valueerror_is_clean(monkeypatch):
         raise ValueError("degenerate accel sphere")
 
     monkeypatch.setattr(calibrate_imu, "fit_calibration_from_sweeps", boom)
-    monkeypatch.setattr("builtins.input", _answers("y"))
+    monkeypatch.setattr("builtins.input",
+                        lambda *a, **k: pytest.fail("no prompt expected before fit error"))
+    assert calibrate_imu.main(["--mode", "elevation"]) == 1
+
+
+def test_main_sweep_runtimeerror_is_clean(monkeypatch):
+    """A RuntimeError raised by collect_vector during a sweep (sustained fault
+    beginning mid-sweep) must surface as a clean return 1, not an uncaught
+    traceback."""
+    transport = DummyTransport()
+    monkeypatch.setattr(calibrate_imu, "Transport", lambda **kw: transport)
+    monkeypatch.setattr(
+        calibrate_imu, "stream_status", lambda t, n, **k: "healthy"
+    )
+    def boom(self):
+        raise RuntimeError(
+            "imu_el: 3 consecutive status=error frames (sensor faulted); "
+            "collected only 0/10 valid samples."
+        )
+
+    monkeypatch.setattr(calibrate_imu.Calibrator, "run_sweeps", boom)
     assert calibrate_imu.main(["--mode", "elevation"]) == 1

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -242,3 +242,33 @@ def test_main_discard_writes_nothing(monkeypatch):
     assert rc == 0  # clean discard
     assert ImuCalStore(transport).get() is None  # nothing persisted
     assert "set_calibration" not in captured  # no live push
+
+
+def _xadd(t, stream, **fields):
+    t.r.xadd(stream, {"value": json.dumps(fields)})
+
+
+def test_collect_vector_skips_error_frames(monkeypatch):
+    """status=error frames carry junk (accel=[0,0,0]); collect_vector must
+    drop them and average only the valid samples."""
+    t = DummyTransport()
+    _xadd(t, "stream:imu_el", status="error", accel_x=0.0, accel_y=0.0, accel_z=0.0)
+    _xadd(t, "stream:imu_el", status="update", accel_x=2.0, accel_y=0.0, accel_z=8.0)
+    _xadd(t, "stream:imu_el", status="error", accel_x=0.0, accel_y=0.0, accel_z=0.0)
+    _xadd(t, "stream:imu_el", status="update", accel_x=4.0, accel_y=0.0, accel_z=10.0)
+    v = calibrate_imu.collect_vector(
+        t, "imu_el", ("accel_x", "accel_y", "accel_z"), n=2, start_id="0-0"
+    )
+    assert np.allclose(v, [3.0, 0.0, 9.0])  # mean of the two valid frames
+
+
+def test_collect_vector_all_error_raises_named(monkeypatch):
+    """A faulted IMU (every frame status=error) must abort with a message
+    naming the stream and the valid/required counts — not block or NaN."""
+    t = DummyTransport()
+    for _ in range(3):
+        _xadd(t, "stream:imu_el", status="error", accel_x=0.0, accel_y=0.0, accel_z=0.0)
+    with pytest.raises(RuntimeError, match="imu_el.*status=error"):
+        calibrate_imu.collect_vector(
+            t, "imu_el", ("accel_x", "accel_y", "accel_z"), n=3, start_id="0-0"
+        )

--- a/picohost/tests/test_calibrate_imu.py
+++ b/picohost/tests/test_calibrate_imu.py
@@ -68,21 +68,6 @@ def test_main_azimuth_uncalibrated_pot_aborts(monkeypatch):
     assert ImuCalStore(transport).get() is None
 
 
-def test_stream_alive_true_false(monkeypatch):
-    """Liveness via blocking "$": True only when a NEW entry arrives.
-
-    Monkeypatch xread directly so the test is deterministic and doesn't
-    depend on fakeredis racing the "$" cursor against pre-loaded entries
-    (a "$" read correctly sees nothing for pre-existing entries).
-    """
-    t = DummyTransport()
-
-    alive = [("stream:imu_az", [(b"1-0", {b"value": b"{}"})])]
-    monkeypatch.setattr(t.r, "xread", lambda *a, **k: alive)
-    assert calibrate_imu.stream_alive(t, "imu_az", timeout_s=0.1) is True
-
-    monkeypatch.setattr(t.r, "xread", lambda *a, **k: [])
-    assert calibrate_imu.stream_alive(t, "imu_el", timeout_s=0.1) is False
 
 
 def test_main_persists_and_pushes(monkeypatch):
@@ -272,3 +257,40 @@ def test_collect_vector_all_error_raises_named(monkeypatch):
         calibrate_imu.collect_vector(
             t, "imu_el", ("accel_x", "accel_y", "accel_z"), n=3, start_id="0-0"
         )
+
+
+def test_stream_status_healthy(monkeypatch):
+    """An update frame -> healthy."""
+    t = DummyTransport()
+    resp = [("stream:imu_az", [(b"1-0", {b"value": json.dumps(
+        {"status": "update", "accel_x": 0.0}).encode()})])]
+    monkeypatch.setattr(t.r, "xread", lambda *a, **k: resp)
+    assert calibrate_imu.stream_status(t, "imu_az", timeout_s=0.1) == "healthy"
+
+
+def test_stream_status_faulted(monkeypatch):
+    """Frames arriving but all status=error -> faulted (publisher up, sensor
+    down). Drained one window then an empty read ends the loop."""
+    t = DummyTransport()
+    err = [("stream:imu_el", [(b"1-0", {b"value": json.dumps(
+        {"status": "error", "accel_x": 0.0}).encode()})])]
+    calls = [err, []]  # first read: an error frame; second: nothing more
+    monkeypatch.setattr(t.r, "xread", lambda *a, **k: calls.pop(0) if calls else [])
+    assert calibrate_imu.stream_status(t, "imu_el", timeout_s=0.1) == "faulted"
+
+
+def test_stream_status_dead(monkeypatch):
+    """No frame within the window -> dead."""
+    t = DummyTransport()
+    monkeypatch.setattr(t.r, "xread", lambda *a, **k: [])
+    assert calibrate_imu.stream_status(t, "imu_el", timeout_s=0.1) == "dead"
+
+
+def test_stream_alive_delegates_to_status(monkeypatch):
+    """stream_alive is True only for a healthy stream."""
+    monkeypatch.setattr(calibrate_imu, "stream_status",
+                        lambda *a, **k: "healthy")
+    assert calibrate_imu.stream_alive(DummyTransport(), "imu_az") is True
+    monkeypatch.setattr(calibrate_imu, "stream_status",
+                        lambda *a, **k: "faulted")
+    assert calibrate_imu.stream_alive(DummyTransport(), "imu_el") is False

--- a/picohost/tests/test_imu_geometry.py
+++ b/picohost/tests/test_imu_geometry.py
@@ -284,3 +284,30 @@ def test_circular_mean_deg_handles_wrap():
     assert abs(ig.circular_mean_deg([170.0, -170.0])) == pytest.approx(
         180.0, abs=1e-6
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Math backstops (zero-norm and degenerate accel guards)
+# ---------------------------------------------------------------------------
+
+
+def test_precondition_rejects_zero_norm_vector():
+    """A faulted IMU streams accel=[0,0,0]; with a zero bias that normalizes
+    to NaN. precondition must raise a descriptive ValueError instead."""
+    with pytest.raises(ValueError, match="zero-norm"):
+        ig.precondition(np.zeros((4, 3)), np.zeros(3))
+
+
+def test_precondition_accepts_normal_vectors():
+    """Guard must not disturb the normal path: real |g| accel preconditions
+    to unit vectors."""
+    a = np.array([[0.0, 0.0, 9.81], [9.81, 0.0, 0.0]])
+    u = ig.precondition(a, np.zeros(3))
+    assert np.allclose(np.linalg.norm(u, axis=-1), 1.0)
+
+
+def test_fit_accel_sphere_rejects_degenerate_scale():
+    """All-zero accel samples fit a sphere of radius 0; that degenerate scale
+    must raise, not silently feed scale=0 into a divide."""
+    with pytest.raises(ValueError, match="degenerate"):
+        ig.fit_accel_sphere(np.zeros((6, 3)))

--- a/picohost/uv.lock
+++ b/picohost/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.8.0"
+version = "3.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## Summary

Fixes #132. A faulted-but-publishing IMU (every frame `status: "error"`, `accel = [0,0,0]`) used to pass `calibrate-imu`'s liveness gate, feed zeros into the mount fit, and crash with a cryptic `LinAlgError: SVD did not converge`. Now the operator gets a clear, actionable message — and the crash is structurally prevented, not just caught.

Three composing layers of defense (host-only; no firmware/emulator changes):

1. **Liveness gate + operator prompt** — a three-state `stream_status` classifier (`healthy` / `faulted` / `dead`) replaces the naive "any new entry → alive" check. A faulted IMU is dropped from the `alive` set; `main()` prints why and prompts the operator to fix wiring (abort) or proceed without it. Mode `all` still calibrates the healthy IMU (graceful degradation).
2. **Ingest filter** — `collect_vector` drops `status=="error"` frames and aborts with a stream-named `RuntimeError` after `n` consecutive error frames, so a fault that begins *mid-sweep* (the intermittent case) can't poison the fit either.
3. **Math backstop** — `precondition` / `fit_accel_sphere` raise a descriptive `ValueError` on zero-norm / degenerate input instead of emitting `NaN`; `main()` wraps the sweep and fit so any residual path exits cleanly with a named message.

The result: a faulted IMU yields `imu_el: stream is publishing only status=error (sensor faulted -- check wiring/power)` plus a prompt, never `SVD did not converge`.

## Why this shape

The starting idea was a single startup prompt on `status=error`. That handles the all-error-from-boot case (what the field hit) but not a fault that begins *during* a sweep — so the ingest filter and math backstop close that gap. `base.py` is deliberately untouched: its live-conversion call to `precondition` is already wrapped in `try/except`, so the new `ValueError` is caught there and degrades a derived field to `None` instead of `NaN` (a strict improvement).

## Commits

- `fix(imu_geometry)`: reject zero-norm/degenerate accel with clear ValueError
- `fix(calibrate-imu)`: drop status=error frames in collect_vector, abort on sustained fault
- `feat(calibrate-imu)`: three-state stream_status classifier (healthy/faulted/dead)
- `feat(calibrate-imu)`: gate faulted IMU at startup with operator prompt, guard fit
- `fix(calibrate-imu)`: clean abort on mid-sweep fault; harden faulted-prompt test

## Testing

- `test_calibrate_imu.py` + `test_imu_geometry.py`: 43 passed, pristine. New coverage: error-frame skipping & sustained-fault abort; `stream_status` healthy/faulted/dead; faulted-IMU abort (non-vacuous gate) and continue-with-prompt; clean exit on both sweep `RuntimeError` and fit `ValueError`.
- Full suite green apart from two pre-existing flaky timing tests in untouched subsystems (`test_proxy`, `test_manager_integration`) that pass in isolation.
- Host-only diff (4 files); `imu_geometry.py` at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
