### PR TITLE
feat(current): record system_current cal in metadata (symmetric) + manual recovery

### DIFF
--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "picohost"
-version = "3.11.0"
+version = "3.10.0"
 description = "Host control and management tools for Raspberry Pi Pico devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/picohost/pyproject.toml
+++ b/picohost/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "picohost"
-version = "3.10.0"
+version = "3.11.0"
 description = "Host control and management tools for Raspberry Pi Pico devices"
 readme = "README.md"
 license = {text = "MIT"}

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -964,8 +964,9 @@ class PicoLidar(PicoDevice):
     ``metadata['system_current']`` entry so the user-facing key never names
     lidar. The publish stays additive and scalar-only: raw
     ``current_voltage``, derived ``current_a``, and the two cal scalars
-    ``current_cal_slope`` (A/V) / ``current_cal_intercept`` (A) that project
-    it — all three ``None`` when uncalibrated (no nominal fallback).
+    ``current_cal_slope`` (A/V) / ``current_cal_intercept`` (A) that describe
+    it (the stored line ``I = slope*V + intercept``) — all three ``None``
+    when uncalibrated (no nominal fallback).
     """
 
     def __init__(self, *args, current_cal_store=None, **kwargs):
@@ -974,13 +975,13 @@ class PicoLidar(PicoDevice):
         ----------
         current_cal_store : picohost.buses.CurrentCalStore, optional
             Redis-backed two-point current calibration. When provided and
-            the store holds a cal, ``(V0, slope)`` is applied before the
-            first status tick, so a rebooted lidar Pico comes up calibrated
+            the store holds a cal, ``(slope, intercept)`` is applied before
+            the first status tick, so a rebooted lidar Pico comes up calibrated
             from Redis. With no cal loaded, ``current_a`` and the published
             cal scalars are ``None`` (no nominal fallback). Other args/kwargs
             pass through to :class:`PicoDevice`.
         """
-        # (V0, slope) at the ADC pin: I = (V_adc - V0) / slope. None ⇒
+        # (slope, intercept) at the ADC pin: I = slope*V_adc + intercept. None ⇒
         # uncalibrated: current_a and the published cal scalars are None
         # (no nominal fallback). Set before super().__init__ so the handler
         # never sees an undefined attribute.
@@ -1009,7 +1010,7 @@ class PicoLidar(PicoDevice):
         Parameters
         ----------
         system_current_params : sequence of (float, float), optional
-            ``(V0, slope)`` such that ``I = (V_adc - V0) / slope``.
+            ``(slope, intercept)`` such that ``I = slope*V_adc + intercept``.
             ``calibrate-current`` pushes this to the running device so a new
             cal takes effect on the next status tick without a restart.
         """
@@ -1017,22 +1018,19 @@ class PicoLidar(PicoDevice):
             self._current_cal = tuple(system_current_params)
 
     def _current_fields(self, v_adc):
-        """Project the loaded cal onto published (current_a, slope, intercept).
+        """Return published (current_a, cal_slope, cal_intercept) for v_adc.
 
-        Returns the amps-vs-volts line actually applied to ``v_adc`` so the
-        published row is self-describing: ``current_a == slope * v_adc +
-        intercept``. All three are ``None`` when no measured two-point cal is
-        loaded — there is no nominal fallback, so an uncalibrated current
-        sensor reports ``None`` rather than a guessed value (mirrors potmon's
+        The stored cal IS the amps-vs-volts line (slope A/V, intercept A) that
+        the metadata/file records verbatim, so publishing is a passthrough:
+        ``current_a == cal_slope * v_adc + cal_intercept``. All three are
+        ``None`` when no cal is loaded — there is no nominal fallback, so an
+        uncalibrated current sensor reports ``None`` (mirrors potmon's
         uncalibrated angle).
         """
         if self._current_cal is None:
             return None, None, None
-        v0, slope = self._current_cal
-        cal_slope = 1.0 / slope
-        cal_intercept = -v0 / slope
-        current_a = cal_slope * v_adc + cal_intercept
-        return current_a, cal_slope, cal_intercept
+        cal_slope, cal_intercept = self._current_cal
+        return cal_slope * v_adc + cal_intercept, cal_slope, cal_intercept
 
     def _lidar_redis_handler(self, data):
         """Split the merged lidar line into two metadata keys.

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -962,8 +962,10 @@ class PicoLidar(PicoDevice):
     other ADC). The firmware merges the raw ``current_voltage`` into the lidar
     status line; this class fans that out into a separate
     ``metadata['system_current']`` entry so the user-facing key never names
-    lidar. The publish stays additive (raw ``current_voltage`` + derived
-    ``current_a``) and scalar-only.
+    lidar. The publish stays additive and scalar-only: raw
+    ``current_voltage``, derived ``current_a``, and the two cal scalars
+    ``current_cal_slope`` (A/V) / ``current_cal_intercept`` (A) that project
+    it — all three ``None`` when uncalibrated (no nominal fallback).
     """
 
     def __init__(self, *args, current_cal_store=None, **kwargs):

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -966,14 +966,6 @@ class PicoLidar(PicoDevice):
     ``current_a``) and scalar-only.
     """
 
-    # ACS724-10AB (bidirectional, Vcc/2 zero point, 200 mV/A) read through a
-    # 3.32k (top) / 4.64k (bottom) divider into GP26 (DMM-measured values).
-    # These constants give the nominal transfer function used until a measured
-    # calibration is uploaded.
-    _DIVIDER_RATIO = 4.64 / (3.32 + 4.64)  # = 0.5829 (measured)
-    _SENSOR_VQ = 2.5  # volts at 0 A (Vcc/2)
-    _SENSOR_SENSITIVITY = 0.2  # volts per amp
-
     def __init__(self, *args, current_cal_store=None, **kwargs):
         """
         Parameters
@@ -982,11 +974,13 @@ class PicoLidar(PicoDevice):
             Redis-backed two-point current calibration. When provided and
             the store holds a cal, ``(V0, slope)`` is applied before the
             first status tick, so a rebooted lidar Pico comes up calibrated
-            from Redis. Falls back to the nominal transfer function when
-            absent. Other args/kwargs pass through to :class:`PicoDevice`.
+            from Redis. With no cal loaded, ``current_a`` and the published
+            cal scalars are ``None`` (no nominal fallback). Other args/kwargs
+            pass through to :class:`PicoDevice`.
         """
         # (V0, slope) at the ADC pin: I = (V_adc - V0) / slope. None ⇒
-        # nominal conversion. Set before super().__init__ so the handler
+        # uncalibrated: current_a and the published cal scalars are None
+        # (no nominal fallback). Set before super().__init__ so the handler
         # never sees an undefined attribute.
         self._current_cal = None
         # Warn-once latch: trips if a lidar status line ever arrives without
@@ -1020,17 +1014,23 @@ class PicoLidar(PicoDevice):
         if system_current_params is not None:
             self._current_cal = tuple(system_current_params)
 
-    def _v_to_current(self, v_adc):
-        """Convert the raw ADC-pin voltage to amps.
+    def _current_fields(self, v_adc):
+        """Project the loaded cal onto published (current_a, slope, intercept).
 
-        Uses the measured two-point cal ``(V0, slope)`` when one is loaded,
-        otherwise the nominal ACS724 + divider transfer function.
+        Returns the amps-vs-volts line actually applied to ``v_adc`` so the
+        published row is self-describing: ``current_a == slope * v_adc +
+        intercept``. All three are ``None`` when no measured two-point cal is
+        loaded — there is no nominal fallback, so an uncalibrated current
+        sensor reports ``None`` rather than a guessed value (mirrors potmon's
+        uncalibrated angle).
         """
-        if self._current_cal is not None:
-            v0, slope = self._current_cal
-            return (v_adc - v0) / slope
-        v_sensor = v_adc / self._DIVIDER_RATIO
-        return (v_sensor - self._SENSOR_VQ) / self._SENSOR_SENSITIVITY
+        if self._current_cal is None:
+            return None, None, None
+        v0, slope = self._current_cal
+        cal_slope = 1.0 / slope
+        cal_intercept = -v0 / slope
+        current_a = cal_slope * v_adc + cal_intercept
+        return current_a, cal_slope, cal_intercept
 
     def _lidar_redis_handler(self, data):
         """Split the merged lidar line into two metadata keys.
@@ -1045,12 +1045,15 @@ class PicoLidar(PicoDevice):
         v = data.pop("current_voltage", None)
         self._base_redis_handler(data)
         if v is not None:
+            current_a, cal_slope, cal_intercept = self._current_fields(v)
             self._base_redis_handler(
                 {
                     "sensor_name": "system_current",
                     "status": "update",
                     "current_voltage": v,
-                    "current_a": self._v_to_current(v),
+                    "current_a": current_a,
+                    "current_cal_slope": cal_slope,
+                    "current_cal_intercept": cal_intercept,
                 }
             )
         elif (

--- a/picohost/src/picohost/buses.py
+++ b/picohost/src/picohost/buses.py
@@ -185,12 +185,12 @@ class CurrentCalStore:
     Persistent single-key store for the whole-system current monitor.
 
     The value under :data:`CURRENT_CAL_KEY` is a JSON object shaped like
-    ``{"system_current": [V0, slope], "metadata": {...},
+    ``{"system_current": [slope, intercept], "metadata": {...},
     "upload_time": ...}`` — the canonical ``upload_time`` field is injected
     by :meth:`Transport.upload_dict` at the top level. ``system_current`` is
-    the two-point calibration: ``V0`` is the raw ADC voltage at 0 A and
-    ``slope`` is V/A *at the ADC pin* (it absorbs both the divider ratio and
-    the ACS724 sensitivity), so ``I = (V_adc - V0) / slope``.
+    the two-point calibration in amps-vs-volts form: ``slope`` (A/V) and
+    ``intercept`` (A), stored exactly as published, so
+    ``I = slope*V_adc + intercept``.
 
     ``calibrate-current`` uploads after each calibration run. A fresh
     :class:`picohost.PicoLidar` reads this store at ``__init__`` time when
@@ -208,9 +208,9 @@ class CurrentCalStore:
         Parameters
         ----------
         cal : dict
-            Must carry a ``system_current`` entry, a ``(V0, slope)`` pair
-            (list or tuple). Extra fields (e.g. ``metadata``) are preserved
-            verbatim.
+            Must carry a ``system_current`` entry, a ``(slope, intercept)``
+            pair (list or tuple). Extra fields (e.g. ``metadata``) are
+            preserved verbatim.
         """
         self.transport.upload_dict(cal, CURRENT_CAL_KEY)
 
@@ -221,8 +221,8 @@ class CurrentCalStore:
         -------
         dict or None
             ``None`` if no calibration has been uploaded, or if the stored
-            JSON fails to decode. The caller falls back to the nominal
-            transfer function.
+            JSON fails to decode. The device then stays uncalibrated
+            (``current_a`` publishes as ``None``).
         """
         raw = self.transport.get_raw(CURRENT_CAL_KEY)
         if raw is None:
@@ -232,7 +232,7 @@ class CurrentCalStore:
         except json.JSONDecodeError as e:
             logger.warning(
                 f"Corrupted {CURRENT_CAL_KEY} in Redis ({e}); "
-                "falling back to nominal current conversion."
+                "the device stays uncalibrated (current_a=None)."
             )
             return None
 

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -16,10 +16,12 @@ the fit to two places:
      tick without restarting the manager.
 
 The two-point fit folds both the ACS724's untrimmed zero offset and the
-divider/resistor tolerance into a single measured ``(V0, slope)`` at the
-ADC pin, so ``I = (V_adc - V0) / slope`` — no reliance on nominal resistor
-values. Point 1 is the system at 0 A (load off); point 2 is a known
-reference current read from an inline ammeter.
+divider/resistor tolerance into a single measured line ``I = slope*V_adc +
+intercept`` (A/V, A) — no reliance on nominal resistor values. This is the
+same amps-vs-volts pair that is published and saved to the file, so it can be
+restored verbatim (see ``--mode manual``, added separately). Point 1 is the
+system at 0 A (load off); point 2 is a known reference current read from an
+inline ammeter.
 
 Requires PicoManager to be running and the ``lidar`` device healthy. The
 script never touches the serial port itself, so it can be invoked
@@ -90,8 +92,21 @@ def collect_samples(transport, n):
     return float(np.mean(samples))
 
 
+def _to_amps_per_volt(v0, slope_vpera):
+    """Convert a fit's physical (V0, slope V/A) to the stored amps-vs-volts
+    pair (slope A/V, intercept A) for ``I = slope_a*V + intercept_a``.
+
+    A fit produces ``V = slope_vpera*I + V0`` (voltage is the noisy measured
+    quantity), so ``slope_a = 1/slope_vpera`` and
+    ``intercept_a = -V0/slope_vpera``.
+    """
+    slope_a = 1.0 / slope_vpera
+    return (float(slope_a), float(-v0 * slope_a))
+
+
 def compute_two_point(v0, v1, i_ref):
-    """Compute ``(V0, slope)`` for ``I = (V_adc - V0) / slope``.
+    """Compute the stored ``(slope, intercept)`` for
+    ``I = slope*V_adc + intercept``.
 
     ``v0`` is the raw ADC voltage at 0 A, ``v1`` at the known reference
     current ``i_ref``. The slope absorbs the divider ratio and the sensor
@@ -109,7 +124,7 @@ def compute_two_point(v0, v1, i_ref):
         return None
     slope = (v1 - v0) / i_ref
     _warn_on_slope(slope)
-    return (float(v0), float(slope))
+    return _to_amps_per_volt(v0, slope)
 
 
 def _warn_on_slope(slope):
@@ -155,10 +170,11 @@ def compute_multi_point(currents, voltages):
     Returns
     -------
     tuple or None
-        ``((V0, slope), quality)`` where ``quality`` is a dict with
-        ``residual_rms_v``, ``residual_rms_a`` and ``r_squared``; or
-        ``None`` (with a printed reason) when the points cannot define a
-        gain. Downstream conversion is ``I = (V_adc - V0) / slope``.
+        ``(stored (slope, intercept), quality)`` where ``quality`` is a
+        dict with ``residual_rms_v``, ``residual_rms_a`` and
+        ``r_squared``; or ``None`` (with a printed reason) when the
+        points cannot define a gain. Downstream conversion is
+        ``I = slope*V_adc + intercept``.
     """
     currents = np.asarray(currents, dtype=float)
     voltages = np.asarray(voltages, dtype=float)
@@ -186,7 +202,7 @@ def compute_multi_point(currents, voltages):
         "residual_rms_a": residual_rms_a,
         "r_squared": r_squared,
     }
-    return ((float(v0), float(slope)), quality)
+    return (_to_amps_per_volt(v0, slope), quality)
 
 
 def collect_two_point(transport, n_samples):
@@ -280,12 +296,12 @@ def collect_multi_point(transport, n_samples, currents=None):
 
 def _print_point_table(currents, voltages, cal):
     """Print a per-point I / V / residual table so a bad point is obvious."""
-    v0, slope = cal
+    slope_a, intercept_a = cal
     print("\n  point  I_ref [A]  V_adc [V]  resid [mV]  resid [mA]")
     for idx, (i, v) in enumerate(zip(currents, voltages), start=1):
-        fit_v = slope * i + v0
-        dv = v - fit_v
-        di = dv / slope if slope else float("inf")
+        fit_i = slope_a * v + intercept_a
+        di = i - fit_i
+        dv = di / slope_a if slope_a else float("inf")
         print(f"  {idx:>5}{i:11.4f}{v:11.4f}{dv * 1e3:12.2f}{di * 1e3:12.2f}")
 
 
@@ -464,7 +480,7 @@ def main():
             file=sys.stderr,
         )
 
-    print(f"  system_current: I = (V_adc - {cal[0]:.4f}) / {cal[1]:.4f}")
+    print(f"  system_current: I = {cal[0]:.6g}*V + {cal[1]:.6g}")
 
 
 if __name__ == "__main__":

--- a/picohost/src/picohost/calibrate_current.py
+++ b/picohost/src/picohost/calibrate_current.py
@@ -32,6 +32,15 @@ Usage:
     calibrate-current --mode multi         # N-point, loop until done
     calibrate-current --currents 0,1,2,5,8 # N-point preset sweep
     calibrate-current --n-samples 20
+    calibrate-current --mode manual --slope 8.4223 --intercept -12.5248 \\
+        --note "restored from corr_20260629.h5"
+
+--mode manual is a recovery path: it writes the operator-supplied
+current_cal_slope (A/V) / current_cal_intercept (A) — read straight off a
+saved correlator .h5 — directly to Redis, even when the lidar Pico is down.
+No backward-compat: after upgrading to this picohost, an existing
+current_calibration stored in the old (V0, slope) form is reinterpreted as
+(slope, intercept); re-run calibrate-current (any mode) to re-establish it.
 """
 
 from argparse import ArgumentParser
@@ -340,11 +349,13 @@ def main():
     parser.add_argument(
         "-m",
         "--mode",
-        choices=["two-point", "multi"],
+        choices=["two-point", "multi", "manual"],
         default="two-point",
         help=(
             "Calibration mode: 'two-point' (default) for the 0 A + one "
-            "reference flow, 'multi' for an N-point least-squares fit."
+            "reference flow, 'multi' for an N-point least-squares fit, "
+            "'manual' to write a hand-supplied --slope/--intercept directly "
+            "(recovery, no sampling)."
         ),
     )
     parser.add_argument(
@@ -353,6 +364,33 @@ def main():
         help=(
             "Comma-separated known currents (A) for a preset multi-point "
             "sweep, e.g. '0,1,2,5,8'. Implies --mode multi (>= 3 points)."
+        ),
+    )
+    parser.add_argument(
+        "--slope",
+        type=float,
+        default=None,
+        help=(
+            "Slope (A/V) for --mode manual — the file's current_cal_slope. "
+            "Required for that mode."
+        ),
+    )
+    parser.add_argument(
+        "--intercept",
+        type=float,
+        default=None,
+        help=(
+            "Intercept (A) for --mode manual — the file's "
+            "current_cal_intercept. Required for that mode."
+        ),
+    )
+    parser.add_argument(
+        "--note",
+        type=str,
+        default=None,
+        help=(
+            "Free-text provenance recorded in the calibration metadata, "
+            "e.g. 'restored from corr_20260629.h5'. Useful with --mode manual."
         ),
     )
     parser.add_argument(
@@ -379,7 +417,11 @@ def main():
     transport = Transport(host=args.redis_host, port=args.redis_port)
     lidar_proxy = PicoProxy(LIDAR_NAME, transport, source="calibrate-current")
 
-    if not lidar_proxy.is_available:
+    # Manual recovery writes the operator-supplied cal straight to Redis, so
+    # it must work even when the lidar Pico is down (the cal loads on the next
+    # PicoManager start). Every other mode samples the live stream, so it
+    # still hard-requires the device.
+    if mode != "manual" and not lidar_proxy.is_available:
         print(
             f"{LIDAR_NAME} is not reachable via PicoManager. "
             "Start the manager and confirm the lidar Pico is enumerated.",
@@ -387,71 +429,102 @@ def main():
         )
         sys.exit(1)
 
-    print(
-        f"{mode} current calibration ({args.n_samples} samples/point).\n"
-        f"Reading voltages from {CURRENT_STREAM}."
-    )
-
-    try:
-        if mode == "multi":
-            if preset is not None and len(preset) < 3:
-                print(
-                    "--currents needs >= 3 points for a multi-point fit.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-            currents, voltages = collect_multi_point(
-                transport, args.n_samples, preset
-            )
-        else:
-            v0, v1, i_ref = collect_two_point(transport, args.n_samples)
-    except (RuntimeError, ConnectionError) as exc:
-        print(f"Calibration sample collection failed: {exc}", file=sys.stderr)
-        sys.exit(1)
-
-    if mode == "multi":
-        result = compute_multi_point(currents, voltages)
-        if result is None:
-            print("\nCalibration failed. Exiting.", file=sys.stderr)
-            sys.exit(1)
-        cal, quality = result
-        _print_point_table(currents, voltages, cal)
-        print(
-            f"\n  residual RMS: {quality['residual_rms_v'] * 1e3:.2f} mV "
-            f"({quality['residual_rms_a'] * 1e3:.2f} mA), "
-            f"r^2 = {quality['r_squared']:.5f}"
-        )
-        threshold = _residual_threshold_a(currents)
-        if quality["residual_rms_a"] > threshold:
+    if mode == "manual":
+        if args.slope is None or args.intercept is None:
             print(
-                f"\n  WARNING: residual "
-                f"{quality['residual_rms_a'] * 1e3:.2f} mA exceeds "
-                f"{threshold * 1e3:.1f} mA — possible bad point or sensor "
-                "nonlinearity."
+                "--mode manual requires both --slope and --intercept.",
+                file=sys.stderr,
             )
-            ans = input("  Store this calibration anyway? [y/N]: ").strip()
-            if ans.lower() not in ("y", "yes"):
-                print("Aborted; calibration not stored.", file=sys.stderr)
-                sys.exit(1)
-        cal_data = _build_multi_cal_data(
-            cal, args.n_samples, currents, voltages, quality
-        )
-    else:
-        cal = compute_two_point(v0, v1, i_ref)
-        if cal is None:
-            print("\nCalibration failed. Exiting.", file=sys.stderr)
             sys.exit(1)
+        if abs(args.slope) < 1e-12:
+            print(
+                "--mode manual: --slope must be non-zero (A/V).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        cal = (float(args.slope), float(args.intercept))
+        # Sanity-check the implied V/A sensitivity (the fits' native units).
+        _warn_on_slope(1.0 / args.slope)
+        print(f"\nManual calibration: I = {cal[0]:.6g}*V + {cal[1]:.6g}")
         cal_data = {
             "system_current": list(cal),
             "metadata": {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-                "mode": "two-point",
-                "v0": float(v0),
-                "v1": float(v1),
-                "i_ref": float(i_ref),
-                "n_samples": args.n_samples,
+                "mode": "manual",
             },
         }
+    else:
+        print(
+            f"{mode} current calibration ({args.n_samples} samples/point).\n"
+            f"Reading voltages from {CURRENT_STREAM}."
+        )
+
+        try:
+            if mode == "multi":
+                if preset is not None and len(preset) < 3:
+                    print(
+                        "--currents needs >= 3 points for a multi-point fit.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                currents, voltages = collect_multi_point(
+                    transport, args.n_samples, preset
+                )
+            else:
+                v0, v1, i_ref = collect_two_point(transport, args.n_samples)
+        except (RuntimeError, ConnectionError) as exc:
+            print(
+                f"Calibration sample collection failed: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if mode == "multi":
+            result = compute_multi_point(currents, voltages)
+            if result is None:
+                print("\nCalibration failed. Exiting.", file=sys.stderr)
+                sys.exit(1)
+            cal, quality = result
+            _print_point_table(currents, voltages, cal)
+            print(
+                f"\n  residual RMS: {quality['residual_rms_v'] * 1e3:.2f} mV "
+                f"({quality['residual_rms_a'] * 1e3:.2f} mA), "
+                f"r^2 = {quality['r_squared']:.5f}"
+            )
+            threshold = _residual_threshold_a(currents)
+            if quality["residual_rms_a"] > threshold:
+                print(
+                    f"\n  WARNING: residual "
+                    f"{quality['residual_rms_a'] * 1e3:.2f} mA exceeds "
+                    f"{threshold * 1e3:.1f} mA — possible bad point or sensor "
+                    "nonlinearity."
+                )
+                ans = input("  Store this calibration anyway? [y/N]: ").strip()
+                if ans.lower() not in ("y", "yes"):
+                    print("Aborted; calibration not stored.", file=sys.stderr)
+                    sys.exit(1)
+            cal_data = _build_multi_cal_data(
+                cal, args.n_samples, currents, voltages, quality
+            )
+        else:
+            cal = compute_two_point(v0, v1, i_ref)
+            if cal is None:
+                print("\nCalibration failed. Exiting.", file=sys.stderr)
+                sys.exit(1)
+            cal_data = {
+                "system_current": list(cal),
+                "metadata": {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "mode": "two-point",
+                    "v0": float(v0),
+                    "v1": float(v1),
+                    "i_ref": float(i_ref),
+                    "n_samples": args.n_samples,
+                },
+            }
+
+    if args.note:
+        cal_data["metadata"]["note"] = args.note
 
     # Persist to Redis first — if the live push later fails, the cal is
     # still stored and will load on the next PicoManager restart.
@@ -465,19 +538,26 @@ def main():
         "BGSAVE triggered."
     )
 
-    # Push to the running PicoLidar so the new cal takes effect on the
-    # next status tick.
-    try:
-        lidar_proxy.send_command(
-            "set_calibration",
-            system_current_params=list(cal),
-        )
-        print("Live PicoLidar updated with new calibration.")
-    except (TimeoutError, RuntimeError) as e:
+    # Push to the running PicoLidar so the new cal takes effect on the next
+    # status tick. Skip when the device is down (manual recovery path) — the
+    # Redis write above already restored it for the next PicoManager start.
+    if lidar_proxy.is_available:
+        try:
+            lidar_proxy.send_command(
+                "set_calibration",
+                system_current_params=list(cal),
+            )
+            print("Live PicoLidar updated with new calibration.")
+        except (TimeoutError, RuntimeError) as e:
+            print(
+                f"Live cal push failed: {e}\n"
+                "Calibration is stored in Redis; restart PicoManager to apply.",
+                file=sys.stderr,
+            )
+    else:
         print(
-            f"Live cal push failed: {e}\n"
-            "Calibration is stored in Redis; restart PicoManager to apply.",
-            file=sys.stderr,
+            "Lidar Pico not reachable; calibration stored in Redis and "
+            "loads on the next PicoManager restart."
         )
 
     print(f"  system_current: I = {cal[0]:.6g}*V + {cal[1]:.6g}")

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -1071,13 +1071,13 @@ class TestLidarRedisHandler:
 
     The current entry is decoupled from the lidar I2C status. current_a and
     the cal scalars (current_cal_slope A/V, current_cal_intercept A) come from
-    the measured two-point cal projected to amps-vs-volts; all three are None
+    the measured two-point cal stored in amps-vs-volts form; all three are None
     when no cal is loaded (no nominal fallback). Every added field is a scalar
     (scalar-only contract on picohost.base.redis_handler).
     """
 
-    # A measured two-point cal (V0, slope_VperA): I = (V - V0) / slope.
-    _CAL = (1.4871, 0.11873)
+    # Measured cal stored in the amps-vs-volts form (slope A/V, intercept A).
+    _CAL = (8.4223, -12.5248)
 
     def _capture(self, lidar, data):
         published = []
@@ -1115,13 +1115,13 @@ class TestLidarRedisHandler:
         finally:
             lidar.disconnect()
 
-    def test_calibrated_publishes_projected_cal_and_invariant(self):
-        """With a measured cal loaded the handler emits the amps-vs-volts
-        projection, and current_a == slope*V + intercept exactly."""
+    def test_calibrated_publishes_cal_and_invariant(self):
+        """With a measured cal loaded the handler passes the stored
+        amps-vs-volts pair through and current_a == slope*V + intercept."""
         lidar = DummyPicoLidar("/dev/dummy")
         try:
             lidar._current_cal = self._CAL
-            v0, slope = self._CAL
+            cal_slope, cal_intercept = self._CAL
             v_adc = 1.84
             pub = self._capture(
                 lidar,
@@ -1134,12 +1134,11 @@ class TestLidarRedisHandler:
                 },
             )
             sc = pub[1]
-            assert sc["current_cal_slope"] == pytest.approx(1.0 / slope)
-            assert sc["current_cal_intercept"] == pytest.approx(-v0 / slope)
+            assert sc["current_cal_slope"] == cal_slope
+            assert sc["current_cal_intercept"] == cal_intercept
             assert sc["current_a"] == pytest.approx(
-                sc["current_cal_slope"] * v_adc + sc["current_cal_intercept"]
+                cal_slope * v_adc + cal_intercept
             )
-            assert sc["current_a"] == pytest.approx((v_adc - v0) / slope)
         finally:
             lidar.disconnect()
 

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -1069,23 +1069,28 @@ class TestLidarRedisHandler:
     """PicoLidar fans the merged lidar status line into two metadata
     publishes: distance under 'lidar', current under 'system_current'.
 
-    The current entry is decoupled from the lidar I2C status, and its
-    derived current_a follows the nominal ACS724 + 3.3k/4.7k divider
-    transfer function. Every added field is a scalar (scalar-only contract
-    on picohost.base.redis_handler).
+    The current entry is decoupled from the lidar I2C status. current_a and
+    the cal scalars (current_cal_slope A/V, current_cal_intercept A) come from
+    the measured two-point cal projected to amps-vs-volts; all three are None
+    when no cal is loaded (no nominal fallback). Every added field is a scalar
+    (scalar-only contract on picohost.base.redis_handler).
     """
 
+    # A measured two-point cal (V0, slope_VperA): I = (V - V0) / slope.
+    _CAL = (1.4871, 0.11873)
+
     def _capture(self, lidar, data):
-        """Run the handler and return the list of dicts the base handler
-        would publish, in order."""
         published = []
         lidar._base_redis_handler = lambda d: published.append(dict(d))
         lidar._lidar_redis_handler(data)
         return published
 
-    def test_splits_into_lidar_and_system_current(self):
+    def test_splits_into_lidar_and_system_current_uncalibrated(self):
+        """No measured cal: current_a and both cal fields are None; the raw
+        current_voltage still rides along on its own system_current entry."""
         lidar = DummyPicoLidar("/dev/dummy")
         try:
+            assert lidar._current_cal is None  # boots uncalibrated
             pub = self._capture(
                 lidar,
                 {
@@ -1093,26 +1098,31 @@ class TestLidarRedisHandler:
                     "status": "update",
                     "app_id": 4,
                     "distance_m": 1.23,
-                    "current_voltage": 2.5 * (4.64 / 7.96),  # = Vq * k → 0 A
+                    "current_voltage": 0.7057,
                 },
             )
             assert [p["sensor_name"] for p in pub] == [
                 "lidar",
                 "system_current",
             ]
-            # lidar entry keeps distance, drops the current field
             assert pub[0]["distance_m"] == 1.23
             assert "current_voltage" not in pub[0]
-            # system_current entry carries raw + derived
-            assert pub[1]["current_voltage"] == 2.5 * (4.64 / 7.96)
-            assert pub[1]["current_a"] == pytest.approx(0.0, abs=1e-6)
+            sc = pub[1]
+            assert sc["current_voltage"] == 0.7057
+            assert sc["current_a"] is None
+            assert sc["current_cal_slope"] is None
+            assert sc["current_cal_intercept"] is None
         finally:
             lidar.disconnect()
 
-    def test_current_conversion_at_five_amps(self):
+    def test_calibrated_publishes_projected_cal_and_invariant(self):
+        """With a measured cal loaded the handler emits the amps-vs-volts
+        projection, and current_a == slope*V + intercept exactly."""
         lidar = DummyPicoLidar("/dev/dummy")
         try:
-            # 5 A → Vsensor = 2.5 + 0.2*5 = 3.5 V → Vadc = 3.5 * (4.64/7.96)
+            lidar._current_cal = self._CAL
+            v0, slope = self._CAL
+            v_adc = 1.84
             pub = self._capture(
                 lidar,
                 {
@@ -1120,29 +1130,37 @@ class TestLidarRedisHandler:
                     "status": "update",
                     "app_id": 4,
                     "distance_m": 0.0,
-                    "current_voltage": 3.5 * (4.64 / 7.96),
+                    "current_voltage": v_adc,
                 },
             )
-            assert pub[1]["current_a"] == pytest.approx(5.0, abs=1e-6)
+            sc = pub[1]
+            assert sc["current_cal_slope"] == pytest.approx(1.0 / slope)
+            assert sc["current_cal_intercept"] == pytest.approx(-v0 / slope)
+            assert sc["current_a"] == pytest.approx(
+                sc["current_cal_slope"] * v_adc + sc["current_cal_intercept"]
+            )
+            assert sc["current_a"] == pytest.approx((v_adc - v0) / slope)
         finally:
             lidar.disconnect()
 
     def test_current_status_decoupled_from_lidar_error(self):
+        """A lidar I2C error does not taint the current half's status."""
         lidar = DummyPicoLidar("/dev/dummy")
         try:
+            lidar._current_cal = self._CAL
             pub = self._capture(
                 lidar,
                 {
                     "sensor_name": "lidar",
-                    "status": "error",  # lidar I2C failed this cycle
+                    "status": "error",
                     "app_id": 4,
                     "distance_m": 9.9,
-                    "current_voltage": 2.9 * (4.64 / 7.96),  # 2 A
+                    "current_voltage": 1.60,
                 },
             )
-            assert pub[0]["status"] == "error"  # lidar half still errors
-            assert pub[1]["status"] == "update"  # current half independent
-            assert pub[1]["current_a"] == pytest.approx(2.0, abs=1e-6)
+            assert pub[0]["status"] == "error"
+            assert pub[1]["status"] == "update"
+            assert pub[1]["current_a"] is not None
         finally:
             lidar.disconnect()
 

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -2,8 +2,8 @@
 Tests for the whole-system current-monitor calibration.
 
 Covers three layers, mirroring the potentiometer calibration suite:
-  - ``compute_two_point``: the (V0, slope) fit from a 0 A point and a
-    known-reference-current point.
+  - ``compute_two_point``: the amps-vs-volts (slope, intercept) from a 0 A
+    point and a known-reference-current point.
   - ``CurrentCalStore``: the Redis-backed cal store round-trip / error paths.
   - ``PicoLidar``: cal loaded at __init__, applied in ``_current_fields`` and
     the redis handler, and updated live via ``set_calibration``.
@@ -27,12 +27,13 @@ from picohost.testing import DummyPicoLidar
 
 
 class TestComputeTwoPoint:
-    """The two-point fit folds offset and gain into (V0, slope)."""
+    """The two-point fit folds offset and gain into (slope, intercept)."""
 
-    def test_fit_returns_v0_and_slope(self):
-        # 0 A → 1.0 V, 5 A → 2.0 V  ⇒  V0 = 1.0, slope = (2-1)/5 = 0.2 V/A
+    def test_fit_returns_slope_and_intercept(self):
+        # 0 A → 1.0 V, 5 A → 2.0 V ⇒ V0=1.0, slope=0.2 V/A ⇒
+        # slope_a = 1/0.2 = 5.0 A/V, intercept_a = -1.0/0.2 = -5.0 A
         cal = compute_two_point(1.0, 2.0, 5.0)
-        assert cal == pytest.approx((1.0, 0.2))
+        assert cal == pytest.approx((5.0, -5.0))
 
     def test_zero_reference_current_rejected(self):
         """A 0 A 'reference' can't define a slope → None (caller aborts)."""
@@ -44,7 +45,7 @@ class TestComputeTwoPoint:
 
 
 class TestComputeMultiPoint:
-    """Least-squares (V0, slope) fit over N known currents."""
+    """Least-squares fit converted to the stored (slope, intercept)."""
 
     def _clean_line(self):
         # V = 0.1175 * I + 1.469  (nominal ACS724 + divider line)
@@ -54,9 +55,12 @@ class TestComputeMultiPoint:
 
     def test_recovers_slope_and_intercept(self):
         currents, voltages = self._clean_line()
-        (v0, slope), quality = compute_multi_point(currents, voltages)
-        assert v0 == pytest.approx(1.469, abs=1e-6)
-        assert slope == pytest.approx(0.1175, abs=1e-6)
+        # V=1.469+0.1175*I ⇒ slope_a=1/0.1175≈8.5106, intercept_a=-1.469/0.1175≈-12.5021
+        (slope_a, intercept_a), quality = compute_multi_point(
+            currents, voltages
+        )
+        assert slope_a == pytest.approx(8.5106, abs=1e-3)
+        assert intercept_a == pytest.approx(-12.5021, abs=1e-3)
         assert quality["r_squared"] == pytest.approx(1.0, abs=1e-9)
         assert quality["residual_rms_v"] == pytest.approx(0.0, abs=1e-9)
         assert quality["residual_rms_a"] == pytest.approx(0.0, abs=1e-9)
@@ -66,11 +70,13 @@ class TestComputeMultiPoint:
         currents = [0.0, 1.0, 2.0, 5.0, 8.0]
         voltages = [1.469 + 0.1175 * i for i in currents]
         voltages[2] += 0.05  # 50 mV kink
-        (_v0, slope), quality = compute_multi_point(currents, voltages)
+        (slope_a, _intercept), quality = compute_multi_point(
+            currents, voltages
+        )
         assert quality["residual_rms_v"] > 0.0
-        # residual in amps is residual_v / slope, kept positive.
+        # residual_rms_a = residual_rms_v / slope_VperA = residual_rms_v * slope_a
         assert quality["residual_rms_a"] == pytest.approx(
-            quality["residual_rms_v"] / slope, rel=1e-9
+            quality["residual_rms_v"] * abs(slope_a), rel=1e-9
         )
         assert quality["r_squared"] < 1.0
 
@@ -79,6 +85,23 @@ class TestComputeMultiPoint:
 
     def test_zero_voltage_spread_rejected(self):
         assert compute_multi_point([0.0, 1.0, 2.0], [1.5, 1.5, 1.5]) is None
+
+    def test_point_table_zero_residuals_on_clean_line(self, capsys):
+        """The per-point QA table reads the cal as (slope_a, intercept_a):
+        a clean line prints ~0 residuals. Guards against the old (V0, slope)
+        misbinding, which prints garbage residuals for a perfect line."""
+        currents, voltages = self._clean_line()
+        cal, _quality = compute_multi_point(currents, voltages)
+        cc._print_point_table(currents, voltages, cal)
+        out = capsys.readouterr().out
+        rows = 0
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) == 5 and parts[0].isdigit():
+                rows += 1
+                assert abs(float(parts[3])) < 0.01  # resid mV
+                assert abs(float(parts[4])) < 0.01  # resid mA
+        assert rows == len(currents)
 
 
 class TestCurrentCalStore:
@@ -131,17 +154,19 @@ class TestPicoLidarCurrentCal:
     def test_cal_from_redis_applied_at_init(self):
         transport = DummyTransport()
         store = CurrentCalStore(transport)
-        store.upload({"system_current": [1.0, 0.2]})
+        store.upload(
+            {"system_current": [1.0, 0.2]}
+        )  # slope_a=1.0, intercept_a=0.2
         lidar = DummyPicoLidar("/dev/dummy", current_cal_store=store)
         try:
             assert lidar.is_current_calibrated
             assert lidar._current_cal == (1.0, 0.2)
-            # I = (V_adc - V0) / slope = (1.2 - 1.0)/0.2 = 1.0 A
+            # I = slope*V + intercept = 1.0*1.2 + 0.2 = 1.4 A
             assert lidar._current_fields(1.2)[0] == pytest.approx(
-                1.0, abs=1e-9
+                1.4, abs=1e-9
             )
             assert lidar._current_fields(1.0)[0] == pytest.approx(
-                0.0, abs=1e-9
+                1.2, abs=1e-9
             )
         finally:
             lidar.disconnect()
@@ -151,8 +176,9 @@ class TestPicoLidarCurrentCal:
         try:
             lidar.set_calibration(system_current_params=[1.0, 0.2])
             assert lidar.is_current_calibrated
+            # 1.0*1.4 + 0.2 = 1.6 A
             assert lidar._current_fields(1.4)[0] == pytest.approx(
-                2.0, abs=1e-9
+                1.6, abs=1e-9
             )
         finally:
             lidar.disconnect()
@@ -176,7 +202,8 @@ class TestPicoLidarCurrentCal:
             )
             current = published[1]
             assert current["sensor_name"] == "system_current"
-            assert current["current_a"] == pytest.approx(1.0, abs=1e-9)
+            # 1.0*1.2 + 0.2 = 1.4 A
+            assert current["current_a"] == pytest.approx(1.4, abs=1e-9)
         finally:
             lidar.disconnect()
 

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -300,6 +300,19 @@ class _FakeProxy:
         return None
 
 
+class _FakeProxyDown(_FakeProxy):
+    """PicoProxy stand-in reporting the device unreachable. Pushing to a
+    down device is a bug — the live push must be skipped — so send_command
+    fails loudly if the guard is ever removed."""
+
+    is_available = False
+
+    def send_command(self, *args, **kwargs):
+        raise AssertionError(
+            "send_command must not be called when the device is down"
+        )
+
+
 class _FakeTransport:
     """Stand-in for Transport with a no-op ``.r.bgsave()``."""
 
@@ -429,3 +442,96 @@ class TestMainDispatch:
         meta = uploaded[0]["metadata"]
         assert meta["mode"] == "multi"
         assert meta["n_points"] == 4
+
+    def test_manual_uploads_slope_intercept_verbatim(self, monkeypatch):
+        """--mode manual writes the supplied (slope, intercept) verbatim
+        with a 'manual' mode tag and the note."""
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "calibrate-current",
+                "--mode",
+                "manual",
+                "--slope",
+                "8.4223",
+                "--intercept",
+                "-12.5248",
+                "--note",
+                "restored from corr_20260629.h5",
+            ],
+        )
+        cc.main()
+        assert len(uploaded) == 1
+        assert uploaded[0]["system_current"] == [8.4223, -12.5248]
+        meta = uploaded[0]["metadata"]
+        assert meta["mode"] == "manual"
+        assert meta["note"] == "restored from corr_20260629.h5"
+
+    def test_manual_writes_even_when_device_down(self, monkeypatch):
+        """Recovery path: manual writes Redis and skips the live push when
+        the lidar Pico is unreachable."""
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxyDown)
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "calibrate-current",
+                "--mode",
+                "manual",
+                "--slope",
+                "8.4223",
+                "--intercept",
+                "-12.5248",
+            ],
+        )
+        cc.main()
+        assert len(uploaded) == 1
+        assert uploaded[0]["system_current"] == [8.4223, -12.5248]
+
+    def test_manual_missing_intercept_exits_without_upload(self, monkeypatch):
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
+        monkeypatch.setattr(
+            "sys.argv",
+            ["calibrate-current", "--mode", "manual", "--slope", "8.4"],
+        )
+        with pytest.raises(SystemExit):
+            cc.main()
+        assert uploaded == []
+
+    def test_manual_zero_slope_exits_without_upload(self, monkeypatch):
+        uploaded = []
+        monkeypatch.setattr(cc, "Transport", _FakeTransport)
+        monkeypatch.setattr(cc, "PicoProxy", _FakeProxy)
+        monkeypatch.setattr(
+            cc, "CurrentCalStore", _spy_store_factory(uploaded)
+        )
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "calibrate-current",
+                "--mode",
+                "manual",
+                "--slope",
+                "0",
+                "--intercept",
+                "1.0",
+            ],
+        )
+        with pytest.raises(SystemExit):
+            cc.main()
+        assert uploaded == []

--- a/picohost/tests/test_calibrate_current.py
+++ b/picohost/tests/test_calibrate_current.py
@@ -5,7 +5,7 @@ Covers three layers, mirroring the potentiometer calibration suite:
   - ``compute_two_point``: the (V0, slope) fit from a 0 A point and a
     known-reference-current point.
   - ``CurrentCalStore``: the Redis-backed cal store round-trip / error paths.
-  - ``PicoLidar``: cal loaded at __init__, applied in ``_v_to_current`` and
+  - ``PicoLidar``: cal loaded at __init__, applied in ``_current_fields`` and
     the redis handler, and updated live via ``set_calibration``.
 """
 
@@ -119,15 +119,12 @@ class TestCurrentCalStore:
 class TestPicoLidarCurrentCal:
     """PicoLidar loads, applies, and live-updates the current cal."""
 
-    def test_uncalibrated_uses_nominal_conversion(self):
-        """No cal store → nominal ACS724 + divider transfer function."""
+    def test_uncalibrated_returns_none(self):
+        """No cal store → no nominal fallback; all three fields are None."""
         lidar = DummyPicoLidar("/dev/dummy")
         try:
             assert not lidar.is_current_calibrated
-            # V_adc at 0 A is Vq*k = 2.5 * (4.64/7.96) = 1.45729
-            assert lidar._v_to_current(2.5 * (4.64 / 7.96)) == pytest.approx(
-                0.0, abs=1e-6
-            )
+            assert lidar._current_fields(1.46) == (None, None, None)
         finally:
             lidar.disconnect()
 
@@ -140,8 +137,12 @@ class TestPicoLidarCurrentCal:
             assert lidar.is_current_calibrated
             assert lidar._current_cal == (1.0, 0.2)
             # I = (V_adc - V0) / slope = (1.2 - 1.0)/0.2 = 1.0 A
-            assert lidar._v_to_current(1.2) == pytest.approx(1.0, abs=1e-9)
-            assert lidar._v_to_current(1.0) == pytest.approx(0.0, abs=1e-9)
+            assert lidar._current_fields(1.2)[0] == pytest.approx(
+                1.0, abs=1e-9
+            )
+            assert lidar._current_fields(1.0)[0] == pytest.approx(
+                0.0, abs=1e-9
+            )
         finally:
             lidar.disconnect()
 
@@ -150,7 +151,9 @@ class TestPicoLidarCurrentCal:
         try:
             lidar.set_calibration(system_current_params=[1.0, 0.2])
             assert lidar.is_current_calibrated
-            assert lidar._v_to_current(1.4) == pytest.approx(2.0, abs=1e-9)
+            assert lidar._current_fields(1.4)[0] == pytest.approx(
+                2.0, abs=1e-9
+            )
         finally:
             lidar.disconnect()
 


### PR DESCRIPTION
## What

Makes the `system_current` (ACS724) calibration self-documenting in the metadata **and** stores it in the exact form it publishes, so it can be recovered from a saved file — potmon parity.

**1. Publish the cal as scalars.** `PicoLidar._lidar_redis_handler` now emits `current_cal_slope` (A/V) and `current_cal_intercept` (A) on every `system_current` entry, so the applied cal lands in every metadata/corr file instead of having to be reverse-engineered by fitting.

**2. Symmetric storage (store == publish == file).** `CurrentCalStore` / `PicoLidar._current_cal` / `set_calibration` hold the amps-vs-volts pair `[slope_a, intercept_a]` for `I = slope·V + intercept` — the same two numbers that are published and saved. `_current_fields` is a passthrough. The two-point/multi fits still fit the physical `V = slope·I + V0` line (voltage is the noisy measured quantity) and convert to the stored pair via `_to_amps_per_volt` only at the end, so fit quality/provenance is unchanged.

**3. No nominal fallback.** The datasheet nominal path (`_DIVIDER_RATIO`/`_SENSOR_VQ`/`_SENSOR_SENSITIVITY`/old `_v_to_current`) is removed. Uncalibrated ⇒ `current_a` and both cal scalars publish as `None` (mirrors potmon's uncalibrated angle) rather than a guessed, untrimmed-offset current.

**4. `--mode manual` recovery.** Mirrors `calibrate-pot --mode manual`:
```
calibrate-current --mode manual --slope 8.4223 --intercept -12.5248 \
    --note "restored from corr_20260629.h5"
```
Writes the operator-supplied `(current_cal_slope, current_cal_intercept)` — read straight off a saved corr `.h5` — verbatim to Redis (no conversion, since store == file), **even when the lidar Pico is down** (loads on next PicoManager start; live push skipped). Errors on a missing flag or `slope==0`; sanity-warns on the implied V/A.

## Version
picohost `3.10.0 → 3.11.0`.

## No backward-compat (deploy note)
An existing `current_calibration` in the old `[V0, slope]` form is reinterpreted as `[slope, intercept]` under this code — re-run `calibrate-current` (any mode, incl. `--mode manual`) after upgrading to re-establish it. (The current field cal is a floating-input artifact anyway.)

## Cross-repo
Consumer schema in **eigsep_observing** adds `current_cal_slope`/`current_cal_intercept` and pins `picohost>=3.11.0` — draft PR EIGSEP/eigsep_observing#178, blocked on the 3.11.0 PyPI release.

## Tests
`pytest tests/test_base.py tests/test_calibrate_current.py` → **97 passed**, ruff clean. Covers the amps-vs-volts round-trip + invariant, uncalibrated all-`None`, the per-point QA table, and manual mode (verbatim write, device-down skip-push, missing-flag/zero-slope errors). Final whole-branch review: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)