### PR TITLE
feat(calibrate-pot): default to azimuth mode

### DIFF
--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -19,10 +19,11 @@ healthy. The script never touches the serial port itself, so it can
 be invoked alongside the manager.
 
 Five modes:
-  --mode minmax   : bench, collect at min and max (2-point fit, default)
+  --mode minmax   : bench, collect at min and max (2-point fit)
   --mode turns    : bench, collect at every full turn (least-squares)
   --mode azimuth  : in-box, operator drives the motor; sweep over the
                     operating turn, slope fit, zero pinned to motor-home
+                    (default)
   --mode rezero   : in-box, re-pin the zero using the stored slope (fast;
                     needs only motor access)
   --mode manual   : recovery, write a hand-supplied --slope/--intercept
@@ -454,14 +455,14 @@ def build_parser():
         "--mode",
         type=str,
         choices=["minmax", "turns", "azimuth", "rezero", "manual"],
-        default="minmax",
+        default="azimuth",
         help=(
             "Calibration mode. Bench: 'minmax' (2-point), 'turns' "
             "(per-turn least-squares). In-box (motor-driven): 'azimuth' "
             "(sweep + zero pinned to motor-home), 'rezero' (re-pin zero "
             "with the stored slope). Recovery: 'manual' (write a "
             "hand-supplied --slope/--intercept directly, no sweep). "
-            "Default: minmax."
+            "Default: azimuth."
         ),
     )
     parser.add_argument(

--- a/picohost/tests/test_calibrate_pot.py
+++ b/picohost/tests/test_calibrate_pot.py
@@ -185,7 +185,7 @@ def test_build_parser_accepts_new_modes_and_motor_cfg():
     assert p.parse_args(["--mode", "rezero"]).mode == "rezero"
 
     d = p.parse_args([])
-    assert d.mode == "minmax"  # unchanged default
+    assert d.mode == "azimuth"  # in-box calibration is the common case
     assert d.step_angle_deg == pytest.approx(1.8)
     assert d.gear_teeth == 113
     assert d.microstep == 1


### PR DESCRIPTION
## Summary
- Change the `calibrate-pot` `--mode` default from `minmax` to `azimuth` — the in-box, motor-driven calibration is the standard field procedure, so a bare `calibrate-pot` now does the right thing without flags
- Update the module docstring and `--mode` help text to mark `azimuth` as the default
- Update the parser test to assert the new default

## Test plan
- [x] `pytest tests/test_calibrate_pot.py` — 43 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)