### PR TITLE
feat(calibrate-pot): motor-driven auto mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ The boundary between `picohost` and the sister `eigsep_observing` repo is drawn 
 
 **Rule of thumb:** if a script coordinates more than one Pico, it belongs in `eigsep_observing`. Science operations (e.g., a motor scan with intermittent VNA observations) always live in `eigsep_observing` and should log their execution runtime to Redis.
 
-**Infrastructure utilities** that *happen* to talk to Redis — `calibrate_pot`, `flash_picos`, `PicoManager` itself — are part of the Pico stack and belong in `picohost`. The test is "is this about the Pico stack?" vs. "is this about doing science?".
+**Infrastructure utilities** that *happen* to talk to Redis — `calibrate_pot`, `flash_picos`, `PicoManager` itself — are part of the Pico stack and belong in `picohost`. The test is "is this about the Pico stack?" vs. "is this about doing science?". Calibration utilities in this category (`calibrate_pot`, `calibrate_imu`) may command the motor via `PicoProxy` for calibration purposes — e.g. `calibrate_pot --mode auto` drives its own azimuth sweep instead of relying on an operator at the keyboard. That does mean these scripts coordinate two Picos (mover + sensor), but the coordination exists to calibrate the Pico stack, not to do science, so the exception still applies.
 
 ## CI / Release
 

--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -1075,6 +1075,20 @@ class PicoLidar(PicoDevice):
             )
 
 
+#: ADC reference voltage for the pot wiper. Mirrors firmware POTMON_VREF
+#: (src/potmon.h); the wiper spans ~0..POT_VREF, so the ADC rails
+#: approximate the pot's electrical ends.
+POT_VREF = 3.3
+#: Margin (V) from an ADC rail below which ``pot_az_near_rail`` publishes
+#: True. A railed pot still reports a steady, plausible voltage, so this
+#: flag is the stream-level tell that the absolute azimuth reference is
+#: compromised (e.g. accumulated motor slip walking a scan toward a
+#: rail). Deliberately wider than calibrate-pot's hard abort margin
+#: (RAIL_GUARD_V there): the flag is an ops early warning, the abort is
+#: "the data is already clipped".
+POT_NEAR_RAIL_V = 0.2
+
+
 class PicoPotentiometer(PicoDevice):
     """Potentiometer monitoring device with voltage-to-angle calibration."""
 
@@ -1135,19 +1149,28 @@ class PicoPotentiometer(PicoDevice):
             self.redis_handler = self._pot_redis_handler
 
     def _pot_redis_handler(self, data):
-        """Add per-component cal scalars and angle before uploading to Redis.
+        """Add per-component cal scalars, angle, and rail flag before upload.
 
         Augments the raw voltage payload with the calibration slope and
         intercept (flattened into scalar fields per the
-        :func:`redis_handler` scalar-only contract) and the derived
-        angle. All added fields are ``None`` when the corresponding pot
-        is uncalibrated, so the published shape is stable regardless of
-        calibration state.
+        :func:`redis_handler` scalar-only contract), the derived angle,
+        and a ``<key>_near_rail`` bool (voltage within
+        :data:`POT_NEAR_RAIL_V` of an ADC rail — wiper at risk of
+        clipping, absolute reference no longer trustworthy). All added
+        fields are ``None`` when their input is missing (no calibration,
+        or no voltage for the rail flag), so the published shape is
+        stable regardless of state.
         """
         data = data.copy()
         for key in ("pot_az",):
             cal = self._cal[key]
             v = data.get(f"{key}_voltage")
+            if v is not None:
+                data[f"{key}_near_rail"] = bool(
+                    v <= POT_NEAR_RAIL_V or v >= POT_VREF - POT_NEAR_RAIL_V
+                )
+            else:
+                data[f"{key}_near_rail"] = None
             if cal is not None:
                 m, b = cal
                 data[f"{key}_cal_slope"] = float(m)

--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -18,12 +18,16 @@ Requires PicoManager to be running and the ``potmon`` device to be
 healthy. The script never touches the serial port itself, so it can
 be invoked alongside the manager.
 
-Five modes:
+Six modes:
   --mode minmax   : bench, collect at min and max (2-point fit)
   --mode turns    : bench, collect at every full turn (least-squares)
   --mode azimuth  : in-box, operator drives the motor; sweep over the
                     operating turn, slope fit, zero pinned to motor-home
                     (default)
+  --mode auto     : in-box, calibrate-pot drives the motor itself through
+                    the same sweep as azimuth (moves are non-blocking;
+                    settle is detected by polling stream:motor) -- no
+                    operator needed at each stop, just to home first
   --mode rezero   : in-box, re-pin the zero using the stored slope (fast;
                     needs only motor access)
   --mode manual   : recovery, write a hand-supplied --slope/--intercept
@@ -38,6 +42,7 @@ Every mode runs a physical slope sanity check: a 3.75-turn pot over the
 
 Usage:
     calibrate-pot --mode azimuth
+    calibrate-pot --mode auto
     calibrate-pot --mode rezero
     calibrate-pot --mode manual --slope 409.1 --intercept -400.0 \\
         --note "restored from corr_20260615.h5"
@@ -48,6 +53,7 @@ import json
 import logging
 import math
 import sys
+import time
 from datetime import datetime, timezone
 
 import numpy as np
@@ -76,6 +82,14 @@ HEADROOM_WARN_DEG = 72.0
 # Motor az should read ~0 at home; warn beyond this if the operator
 # forgot to home before pressing Enter.
 HOME_AZ_TOL_DEG = 5.0
+# --mode auto: a commanded move is considered settled once two
+# consecutive stream:motor reads agree with each other and with the
+# target within this many degrees.
+SETTLE_TOL_DEG = 2.0
+# --mode auto: overall budget to settle a single commanded move.
+# Comfortably larger than a full 360 deg turn (~2 min at the installed
+# motor's default speed).
+SETTLE_TIMEOUT_S = 180.0
 # Warn before saving if the new calibration would move the predicted
 # azimuth by more than this (deg) anywhere in the swept window, relative
 # to the calibration already stored in Redis.
@@ -122,10 +136,13 @@ def collect_samples(transport, n):
 def read_motor_az_steps(transport, start_id="$"):
     """Return the current az_pos (motor steps) from ``stream:motor``.
 
-    Read-only: calibrate-pot never commands the motor. Mirrors
-    :func:`collect_samples`' fail-fast semantics — if PicoManager isn't
-    publishing motor status within ``SAMPLE_TIMEOUT_S``, raise rather
-    than silently using a stale value.
+    Read-only itself (this call never commands the motor), but
+    ``--mode auto`` does command the motor elsewhere via
+    :func:`collect_auto` and then uses this function to poll for
+    settle. Mirrors :func:`collect_samples`' fail-fast semantics — if
+    PicoManager isn't publishing motor status within
+    ``SAMPLE_TIMEOUT_S``, raise rather than silently using a stale
+    value.
     """
     resp = transport.r.xread(
         {MOTOR_STREAM: start_id},
@@ -343,6 +360,20 @@ def collect_per_turn(transport, n_samples, turns):
     return voltages, angles
 
 
+def _warn_if_not_homed(az_home):
+    """Print the "did you home the motor?" warning if ``az_home`` is off.
+
+    Shared by :func:`collect_azimuth` (operator-driven) and
+    :func:`collect_auto` (motor-driven) so the message can't drift
+    between the two sweep modes.
+    """
+    if abs(az_home) > HOME_AZ_TOL_DEG:
+        print(
+            f"  WARNING: motor az reads {az_home:.1f} deg at 'home' "
+            "(expected ~0). Did you home the motor first?"
+        )
+
+
 def collect_azimuth(transport, n_samples, motor_cfg):
     """In-box sweep: operator drives the motor; we record (az, voltage).
 
@@ -353,11 +384,7 @@ def collect_azimuth(transport, n_samples, motor_cfg):
     """
     input("\nDrive the motor to HOME (az 0), stop there, then press Enter.")
     az_home = read_motor_az_deg(transport, **motor_cfg)
-    if abs(az_home) > HOME_AZ_TOL_DEG:
-        print(
-            f"  WARNING: motor az reads {az_home:.1f} deg at 'home' "
-            "(expected ~0). Did you home the motor first?"
-        )
+    _warn_if_not_homed(az_home)
     print("  averaging samples...")
     v0 = collect_samples(transport, n_samples)
     print(
@@ -383,6 +410,137 @@ def collect_azimuth(transport, n_samples, motor_cfg):
         print(f"  az={az:8.2f} deg: pot_az={v:.4f} V")
         voltages.append(v)
         angles.append(az)
+
+    return voltages, angles, v0
+
+
+def _wait_for_settle(
+    transport,
+    motor_cfg,
+    target_deg,
+    *,
+    tol_deg=SETTLE_TOL_DEG,
+    timeout_s=SETTLE_TIMEOUT_S,
+):
+    """Poll ``stream:motor`` until az settles at ``target_deg``.
+
+    Moves are commanded non-blocking (see :func:`collect_auto`), so the
+    caller must poll for settle itself rather than waiting on the proxy.
+    "Settled" requires two consecutive reads that agree with each other
+    and with the target within ``tol_deg`` -- a single sample could catch
+    the motor mid-move if it happens to cross the tolerance band. Returns
+    the settled az. Raises ``TimeoutError`` if the motor hasn't settled
+    within ``timeout_s``.
+    """
+    deadline = time.monotonic() + timeout_s
+    prev_az = None
+    while time.monotonic() < deadline:
+        az = read_motor_az_deg(transport, start_id="$", **motor_cfg)
+        if (
+            prev_az is not None
+            and abs(az - target_deg) <= tol_deg
+            and abs(az - prev_az) <= tol_deg
+        ):
+            return az
+        prev_az = az
+    raise TimeoutError(
+        f"Motor did not settle at {target_deg:.1f} deg (tol {tol_deg:.1f} "
+        f"deg) within {timeout_s:.0f}s (last read: {prev_az})"
+    )
+
+
+def collect_auto(
+    transport,
+    motor_proxy,
+    n_samples,
+    motor_cfg,
+    n_stops=8,
+    settle_tol_deg=SETTLE_TOL_DEG,
+    settle_timeout_s=SETTLE_TIMEOUT_S,
+):
+    """In-box sweep: calibrate-pot drives the motor itself.
+
+    Same sweep as :func:`collect_azimuth`, but instead of an operator
+    driving the motor and pressing Enter at each stop, this commands the
+    motor through ``n_stops`` stops evenly spaced over one 360 deg
+    operating turn (default 8 -> 45 deg spacing). The operator is
+    assumed to have homed the motor beforehand (az~=0 at the start of
+    this call); the first sample (at the assumed-home position) defines
+    az=0 and v0, exactly as in :func:`collect_azimuth`.
+
+    Moves are sent non-blocking (``wait_for_stop=False``) because the
+    manager runs routed commands synchronously on its command thread and
+    a full-turn move can take ~2 minutes -- blocking there would stall
+    every other command against the fleet. Settle is instead detected by
+    this function polling ``stream:motor`` (:func:`_wait_for_settle`).
+
+    The motor is soft-claimed via ``motor_proxy`` for the duration of the
+    sweep and released in a ``finally`` block (claims are advisory, not
+    enforced -- see ``manager.py``). Returns ``(voltages, angles, v0)``,
+    matching :func:`collect_azimuth`.
+
+    Raises
+    ------
+    RuntimeError, TimeoutError
+        On any command or settle failure mid-sweep. This function never
+        returns a partial result on failure -- the exception propagates
+        before ``return``, so the caller cannot mistakenly save a fit
+        from an interrupted sweep.
+    """
+    claim_ttl = int(settle_timeout_s * (n_stops + 2))
+    motor_proxy.send_command("claim", ttl=claim_ttl)
+    try:
+        az_home = read_motor_az_deg(transport, **motor_cfg)
+        _warn_if_not_homed(az_home)
+        print("  averaging samples...")
+        v0 = collect_samples(transport, n_samples)
+        print(
+            f"  home: az=0.00 deg (motor reads {az_home:.2f}), "
+            f"pot_az={v0:.4f} V"
+        )
+        voltages = [v0]
+        angles = [0.0]
+
+        for i in range(1, n_stops + 1):
+            target = i * (360.0 / n_stops)
+            print(f"\nMoving to az {target:.1f} deg...")
+            motor_proxy.send_command(
+                "az_target_deg",
+                target_deg=target,
+                wait_for_start=False,
+                wait_for_stop=False,
+            )
+            az = _wait_for_settle(
+                transport,
+                motor_cfg,
+                target,
+                tol_deg=settle_tol_deg,
+                timeout_s=settle_timeout_s,
+            )
+            print("  averaging samples...")
+            v = collect_samples(transport, n_samples)
+            print(
+                f"  az={az:8.2f} deg (target {target:.1f}): pot_az={v:.4f} V"
+            )
+            voltages.append(v)
+            angles.append(az)
+
+        print("\nReturning motor to home (az 0)...")
+        motor_proxy.send_command(
+            "az_target_deg",
+            target_deg=0.0,
+            wait_for_start=False,
+            wait_for_stop=False,
+        )
+        _wait_for_settle(
+            transport,
+            motor_cfg,
+            0.0,
+            tol_deg=settle_tol_deg,
+            timeout_s=settle_timeout_s,
+        )
+    finally:
+        motor_proxy.send_command("release")
 
     return voltages, angles, v0
 
@@ -454,15 +612,27 @@ def build_parser():
         "-m",
         "--mode",
         type=str,
-        choices=["minmax", "turns", "azimuth", "rezero", "manual"],
+        choices=["minmax", "turns", "azimuth", "auto", "rezero", "manual"],
         default="azimuth",
         help=(
             "Calibration mode. Bench: 'minmax' (2-point), 'turns' "
             "(per-turn least-squares). In-box (motor-driven): 'azimuth' "
-            "(sweep + zero pinned to motor-home), 'rezero' (re-pin zero "
+            "(operator drives the motor; sweep + zero pinned to "
+            "motor-home), 'auto' (calibrate-pot drives the motor itself "
+            "through the same sweep -- non-blocking moves, settle "
+            "detected by polling stream:motor), 'rezero' (re-pin zero "
             "with the stored slope). Recovery: 'manual' (write a "
             "hand-supplied --slope/--intercept directly, no sweep). "
             "Default: azimuth."
+        ),
+    )
+    parser.add_argument(
+        "--n-stops",
+        type=int,
+        default=8,
+        help=(
+            "Number of stops after home for --mode auto, evenly spaced "
+            "over one 360 deg turn (default: 8, i.e. 45 deg spacing)."
         ),
     )
     parser.add_argument(
@@ -532,6 +702,10 @@ def main():
         print("turns must be positive.", file=sys.stderr)
         sys.exit(1)
 
+    if args.mode == "auto" and args.n_stops <= 0:
+        print("n-stops must be positive.", file=sys.stderr)
+        sys.exit(1)
+
     if args.mode == "manual" and (
         args.slope is None or args.intercept is None
     ):
@@ -555,6 +729,21 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Auto mode additionally commands the motor itself, so it hard-requires
+    # the motor's heartbeat too (azimuth mode only reads the motor stream,
+    # which the pot-availability check above doesn't cover either, but that
+    # mode is operator-driven so a stalled read just blocks on input()).
+    motor_proxy = None
+    if args.mode == "auto":
+        motor_proxy = PicoProxy(MOTOR_NAME, transport, source="calibrate-pot")
+        if not motor_proxy.is_available:
+            print(
+                f"{MOTOR_NAME} is not reachable via PicoManager. "
+                "Start the manager and confirm the motor Pico is enumerated.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     total_degrees = 360.0 * args.turns
 
@@ -586,10 +775,19 @@ def main():
                 transport, args.n_samples, args.turns
             )
             cal = compute_linear_fit(voltages, angles)
-        elif args.mode == "azimuth":
-            voltages, angles, v0 = collect_azimuth(
-                transport, args.n_samples, motor_cfg
-            )
+        elif args.mode in ("azimuth", "auto"):
+            if args.mode == "azimuth":
+                voltages, angles, v0 = collect_azimuth(
+                    transport, args.n_samples, motor_cfg
+                )
+            else:
+                voltages, angles, v0 = collect_auto(
+                    transport,
+                    motor_proxy,
+                    args.n_samples,
+                    motor_cfg,
+                    n_stops=args.n_stops,
+                )
             if len(voltages) < 2:
                 print(
                     "\nNeed at least one stop beyond home to fit a slope.",
@@ -610,7 +808,7 @@ def main():
         else:  # rezero
             cal, v0 = rezero(transport, args.n_samples)
             voltages, angles = [v0], [0.0]
-    except (RuntimeError, ConnectionError) as exc:
+    except (RuntimeError, ConnectionError, TimeoutError) as exc:
         print(f"Calibration sample collection failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -619,7 +817,7 @@ def main():
         sys.exit(1)
 
     if free is not None and resid is not None:
-        print("\nLinearity check (azimuth fit):")
+        print(f"\nLinearity check ({args.mode} fit):")
         print(f"  slope m = {cal[0]:.4f} deg/V")
         print(
             f"  intercept: pinned b = {cal[1]:.4f}  (free-fit b = {free[1]:.4f})"
@@ -665,11 +863,13 @@ def main():
     if args.mode in ("minmax", "turns"):
         metadata["turns"] = float(args.turns)
         metadata["total_degrees"] = total_degrees
-    if args.mode == "azimuth":
+    if args.mode in ("azimuth", "auto"):
         metadata["motor_cfg"] = motor_cfg
         metadata["free_fit_intercept"] = float(free[1])
         metadata["residual_max_deg"] = resid["max_abs_deg"]
         metadata["residual_rms_deg"] = resid["rms_deg"]
+    if args.mode == "auto":
+        metadata["n_stops"] = args.n_stops
     if args.mode == "rezero":
         metadata["slope_reused"] = True
     if args.note:

--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -25,9 +25,10 @@ Six modes:
                     operating turn, slope fit, zero pinned to motor-home
                     (default)
   --mode auto     : in-box, calibrate-pot drives the motor itself through
-                    the same sweep as azimuth (moves are non-blocking;
-                    settle is detected by polling stream:motor) -- no
-                    operator needed at each stop, just to home first
+                    a -180..+180 deg sweep -- the production operating
+                    window (moves are non-blocking; settle is detected by
+                    polling stream:motor) -- no operator needed at each
+                    stop, just to home first
   --mode rezero   : in-box, re-pin the zero using the stored slope (fast;
                     needs only motor access)
   --mode manual   : recovery, write a hand-supplied --slope/--intercept
@@ -36,9 +37,17 @@ Six modes:
                     are read off a recent correlator .h5. Writes Redis even
                     when the pot is down (loads on the next manager start).
 
-Every mode runs a physical slope sanity check: a 3.75-turn pot over the
-~3.3 V ADC range has a slope of ~409 deg/V, so a slope off by more than
-1.5x prints a WARNING and requires a typed 'yes' to save.
+Rail guards: near the ADC rails (0 / 3.3 V) the wiper clips and the pot
+silently stops tracking azimuth, so every in-box sample is rejected
+within RAIL_GUARD_V of a rail, --mode auto refuses to start a sweep
+whose predicted window would rail (slope from the stored cal, falling
+back to the field-measured ~320 deg/V), and the settle poll aborts --
+halting the motor -- if the pot rails mid-move.
+
+Every mode runs a slope sanity check against an expected magnitude
+(bench modes: the physical turns*360/Vref, ~409 deg/V for the installed
+3.75-turn pot; in-box modes: the field-measured ~320 deg/V). A slope off
+by more than 1.5x prints a WARNING and requires a typed 'yes' to save.
 
 Usage:
     calibrate-pot --mode azimuth
@@ -59,6 +68,7 @@ from datetime import datetime, timezone
 import numpy as np
 from eigsep_redis import Transport
 
+from .base import POT_VREF
 from .buses import PotCalStore
 from .motor import GEAR_TEETH, MICROSTEP, STEP_ANGLE_DEG, steps_to_deg
 from .proxy import PicoProxy
@@ -74,8 +84,28 @@ MOTOR_STREAM = f"stream:{MOTOR_NAME}"
 # short enough to fail fast when the manager isn't actually publishing.
 SAMPLE_TIMEOUT_S = 5.0
 # Pot wiper spans ~0..Vref, so the ADC rails approximate the pot's
-# electrical ends. Mirrors firmware POTMON_VREF (src/potmon.h).
-ADC_VREF = 3.3
+# electrical ends. Single-sourced from picohost.base (which mirrors
+# firmware POTMON_VREF, src/potmon.h).
+ADC_VREF = POT_VREF
+# Field-measured slope of the installed az drive (~320 deg/V as of
+# 2026-07), noticeably below the physical turns*360/Vref ~409 deg/V a
+# full-span 3.75-turn pot would give. Used as the slope expectation for
+# in-box modes and as the preflight fallback when no calibration is
+# stored — the physical value would under-predict the voltage a sweep
+# consumes and could green-light a sweep that rails. Bench modes keep
+# the physical derivation (the bench sweep spans the pot's full travel
+# by construction).
+EMPIRICAL_SLOPE_DEG_PER_V = 320.0
+# Hard abort margin to the ADC rails: an in-box sampled (or mid-move
+# observed) pot voltage this close to 0/Vref is treated as clipped —
+# it still looks plausible but no longer tracks azimuth. Narrower than
+# picohost.base.POT_NEAR_RAIL_V (the ops early-warning stream flag).
+RAIL_GUARD_V = 0.1
+# --mode auto sweeps the production operating window: ±180 deg around
+# motor-home. Keeping the swept window equal to the operating window
+# means the post-fit headroom report certifies exactly the range a
+# production scan will visit.
+SWEEP_HALF_RANGE_DEG = 180.0
 # Warn if the operating window leaves less than this much travel (in az
 # degrees) before a rail/electrical end (~0.2 turn).
 HEADROOM_WARN_DEG = 72.0
@@ -104,13 +134,14 @@ SETTLE_TIMEOUT_S = 180.0
 # azimuth by more than this (deg) anywhere in the swept window, relative
 # to the calibration already stored in Redis.
 WILDLY_DIFFERENT_WARN_DEG = 30.0
-# Physical sanity bound on the slope, independent of the stored cal. A
-# full-travel `turns`-turn pot whose wiper spans ADC_VREF has a slope of
-# turns*360/Vref deg/V (~409 for the installed 3.75-turn pot over 3.3 V).
-# Warn (and escalate the save to a typed 'yes') when the computed or
-# operator-supplied |slope| is off by more than this factor — catches
-# order-of-magnitude typos (manual mode) and gross sweep/turn-count errors.
-# 1.5x -> an in-range window of ~273..614 deg/V for the installed pot.
+# Sanity bound on the slope, independent of the stored cal. Warn (and
+# escalate the save to a typed 'yes') when the computed or
+# operator-supplied |slope| is off from the expected magnitude by more
+# than this factor — catches order-of-magnitude typos (manual mode) and
+# gross sweep/turn-count errors. The expectation is mode-dependent:
+# bench modes use the physical turns*360/Vref (~409 deg/V for the
+# installed 3.75-turn pot), in-box modes use the field-measured
+# EMPIRICAL_SLOPE_DEG_PER_V (~320 deg/V, window ~213..480 at 1.5x).
 SLOPE_SANITY_FACTOR = 1.5
 
 
@@ -175,6 +206,40 @@ def read_motor_az_deg(transport, start_id="$"):
     """Current motor az in degrees (steps converted via MOTOR_GEOMETRY)."""
     steps = read_motor_az_steps(transport, start_id=start_id)
     return steps_to_deg(steps, **MOTOR_GEOMETRY)
+
+
+def _latest_pot_voltage(transport):
+    """Most recent pot_az voltage on ``stream:potmon``, or None if empty.
+
+    Non-blocking (unlike :func:`collect_samples`): used by the mid-move
+    rail monitor in :func:`_wait_for_settle`, where a momentarily quiet
+    pot stream must not stall settle detection — pot liveness is already
+    enforced at every stop by :func:`collect_samples`.
+    """
+    entries = transport.r.xrevrange(POTMON_STREAM, count=1)
+    if not entries:
+        return None
+    _msg_id, fields = entries[0]
+    return json.loads(fields[b"value"]).get("pot_az_voltage")
+
+
+def _check_off_rails(v, where):
+    """Raise if ``v`` is within RAIL_GUARD_V of an ADC rail.
+
+    Near a rail the wiper is clipping (or about to): the voltage still
+    looks plausible but no longer tracks azimuth, so a calibration fit
+    that ingests it is silently biased. Shared by the in-box sampling
+    helpers, :func:`rezero`, and the mid-move monitor in
+    :func:`_wait_for_settle`.
+    """
+    if v <= RAIL_GUARD_V or v >= ADC_VREF - RAIL_GUARD_V:
+        raise RuntimeError(
+            f"pot_az voltage {v:.3f} V is within {RAIL_GUARD_V:.2f} V of "
+            f"an ADC rail (0..{ADC_VREF:.1f} V) {where}. The pot is at "
+            "(or past) an electrical end; aborting so clipped readings "
+            "cannot corrupt the calibration. Re-home the drive nearer "
+            "the pot's mid-travel and retry."
+        )
 
 
 def compute_linear_fit(voltages, angles):
@@ -291,13 +356,15 @@ def expected_slope_mag(turns, vref=ADC_VREF):
     return turns * 360.0 / vref
 
 
-def slope_out_of_range(m, turns, vref=ADC_VREF, factor=SLOPE_SANITY_FACTOR):
-    """True when ``|m|`` diverges from the expected slope by more than ``factor``.
+def slope_out_of_range(m, expected, factor=SLOPE_SANITY_FACTOR):
+    """True when ``|m|`` diverges from ``expected`` by more than ``factor``.
 
+    ``expected`` is the anticipated slope magnitude in deg/V — the
+    physical :func:`expected_slope_mag` for bench modes, the
+    field-measured :data:`EMPIRICAL_SLOPE_DEG_PER_V` for in-box modes.
     Magnitude-only (slope sign is a wiring-direction convention). A zero
-    slope, or a non-positive expected slope, is always out of range.
+    slope, or a non-positive expectation, is always out of range.
     """
-    expected = expected_slope_mag(turns, vref)
     if expected <= 0 or m == 0:
         return True
     ratio = max(abs(m) / expected, expected / abs(m))
@@ -388,6 +455,7 @@ def _sample_home(transport, n_samples):
     _warn_if_not_homed(az_home)
     print("  averaging samples...")
     v0 = collect_samples(transport, n_samples)
+    _check_off_rails(v0, where="at motor-home")
     print(
         f"  home: az=0.00 deg (motor reads {az_home:.2f}), pot_az={v0:.4f} V"
     )
@@ -395,9 +463,15 @@ def _sample_home(transport, n_samples):
 
 
 def _sample_stop(transport, n_samples, az, label=""):
-    """Average the pot voltage at one sweep stop and print the result."""
+    """Average the pot voltage at one sweep stop and print the result.
+
+    Raises RuntimeError (via :func:`_check_off_rails`) when the sampled
+    voltage sits within the rail guard margin — a clipped sample would
+    otherwise bias the fit with no error.
+    """
     print("  averaging samples...")
     v = collect_samples(transport, n_samples)
+    _check_off_rails(v, where=f"at az {az:.1f} deg")
     print(f"  az={az:8.2f} deg{label}: pot_az={v:.4f} V")
     return v
 
@@ -453,11 +527,21 @@ def _wait_for_settle(
     in :func:`main`): closer than that, the stationary pre-move position
     already satisfies both conditions. Returns the settled az. Raises
     ``TimeoutError`` if the motor hasn't settled within ``timeout_s``.
+
+    Each poll also checks the latest pot voltage against the rail guard
+    (checked before the settle test, so a railed pot can never be
+    reported as a clean arrival): a rail crossing *during* a move means
+    the sweep has left the pot's trustworthy range, and the resulting
+    RuntimeError makes :func:`collect_auto` halt the motor rather than
+    let it keep driving toward the electrical end.
     """
     deadline = time.monotonic() + timeout_s
     prev_az = None
     while time.monotonic() < deadline:
         az = read_motor_az_deg(transport, start_id="$")
+        v = _latest_pot_voltage(transport)
+        if v is not None:
+            _check_off_rails(v, where=f"mid-move (motor at {az:.1f} deg)")
         if (
             prev_az is not None
             and abs(az - target_deg) <= tol_deg
@@ -487,6 +571,47 @@ def _motor_command(motor_proxy, action, **kwargs):
     return motor_proxy.send_command(action, **kwargs)
 
 
+def _preflight_sweep_headroom(transport, v0):
+    """Abort before the first move if the ±180 deg sweep would rail.
+
+    Predicts the voltage at the sweep endpoints from the stored
+    calibration slope (magnitude only — the sweep is symmetric about
+    home, so the wiring-direction sign is irrelevant), falling back to
+    the field-measured :data:`EMPIRICAL_SLOPE_DEG_PER_V` when no stored
+    slope is usable. Requires :data:`RAIL_GUARD_V` of margin to both
+    rails at the predicted extremes, raising RuntimeError before any
+    move is commanded otherwise — the post-sweep headroom report only
+    tells the operator *after* the motor has already been driven
+    through the rail region.
+    """
+    stored = PotCalStore(transport).get()
+    slope = None
+    source = "stored calibration"
+    if stored and "pot_az" in stored:
+        try:
+            slope = abs(float(stored["pot_az"][0]))
+        except (TypeError, ValueError, IndexError):
+            slope = None
+    if not slope:
+        slope = EMPIRICAL_SLOPE_DEG_PER_V
+        source = "field-measured default"
+    swing_v = SWEEP_HALF_RANGE_DEG / slope
+    v_lo, v_hi = v0 - swing_v, v0 + swing_v
+    print(
+        f"  preflight: predicted sweep window {v_lo:.3f}..{v_hi:.3f} V "
+        f"(slope ~{slope:.0f} deg/V from {source})"
+    )
+    if v_lo < RAIL_GUARD_V or v_hi > ADC_VREF - RAIL_GUARD_V:
+        raise RuntimeError(
+            f"insufficient headroom for a ±{SWEEP_HALF_RANGE_DEG:.0f} deg "
+            f"sweep: home at {v0:.3f} V predicts a "
+            f"{v_lo:.3f}..{v_hi:.3f} V window, leaving less than "
+            f"{RAIL_GUARD_V:.2f} V to an ADC rail (0..{ADC_VREF:.1f} V). "
+            "Re-position the drive so home sits nearer the pot's "
+            "mid-travel, re-home, and retry."
+        )
+
+
 def collect_auto(
     transport,
     motor_proxy,
@@ -498,11 +623,18 @@ def collect_auto(
 
     Same sweep as :func:`collect_azimuth`, but instead of an operator
     driving the motor and pressing Enter at each stop, this commands the
-    motor through ``n_stops`` stops evenly spaced over one 360 deg
-    operating turn (default 8 -> 45 deg spacing). The operator is
-    assumed to have homed the motor beforehand (az~=0 at the start of
-    this call); the first sample (at the assumed-home position) defines
-    az=0 and v0, exactly as in :func:`collect_azimuth`.
+    motor through ``n_stops + 1`` stops evenly spaced over the ±180 deg
+    production operating window (default 8 -> 45 deg spacing, stops at
+    -180, -135, ..., +180), so the swept window — and therefore the
+    post-fit headroom report — covers exactly the range a production
+    scan will visit. The operator is assumed to have homed the motor
+    beforehand (az~=0 at the start of this call); the first sample (at
+    the assumed-home position) defines az=0 and v0, exactly as in
+    :func:`collect_azimuth`. Before the first move,
+    :func:`_preflight_sweep_headroom` aborts the sweep if the predicted
+    window would come within :data:`RAIL_GUARD_V` of an ADC rail, and
+    every sampled stop plus every mid-move poll is rail-checked
+    (:func:`_check_off_rails`).
 
     Moves are sent non-blocking (``wait_for_stop=False``) because the
     manager runs routed commands synchronously on its command thread and
@@ -527,15 +659,20 @@ def collect_auto(
         propagates before ``return``, so the caller cannot mistakenly
         save a fit from an interrupted sweep.
     """
-    claim_ttl = int(settle_timeout_s * (n_stops + 2))
+    # n_stops + 2 moves (n_stops + 1 sweep stops plus the return home),
+    # with one settle-budget of slack.
+    claim_ttl = int(settle_timeout_s * (n_stops + 3))
     _motor_command(motor_proxy, "claim", ttl=claim_ttl)
     try:
         v0 = _sample_home(transport, n_samples)
+        _preflight_sweep_headroom(transport, v0)
         voltages = [v0]
         angles = [0.0]
 
-        for i in range(1, n_stops + 1):
-            target = i * (360.0 / n_stops)
+        for i in range(n_stops + 1):
+            target = -SWEEP_HALF_RANGE_DEG + i * (
+                2.0 * SWEEP_HALF_RANGE_DEG / n_stops
+            )
             print(f"\nMoving to az {target:.1f} deg...")
             _motor_command(
                 motor_proxy,
@@ -593,6 +730,7 @@ def rezero(transport, n_samples):
     input("\nDrive the motor to HOME (az 0), stop there, then press Enter.")
     print("  averaging samples...")
     v0 = collect_samples(transport, n_samples)
+    _check_off_rails(v0, where="at motor-home (rezero)")
     b = -m * v0
     print(
         f"  reused slope m={m:.4f}; V0={v0:.4f} V -> new intercept b={b:.4f}"
@@ -650,11 +788,11 @@ def build_parser():
             "(per-turn least-squares). In-box (motor-driven): 'azimuth' "
             "(operator drives the motor; sweep + zero pinned to "
             "motor-home), 'auto' (calibrate-pot drives the motor itself "
-            "through the same sweep -- non-blocking moves, settle "
-            "detected by polling stream:motor), 'rezero' (re-pin zero "
-            "with the stored slope). Recovery: 'manual' (write a "
-            "hand-supplied --slope/--intercept directly, no sweep). "
-            "Default: azimuth."
+            "through a -180..+180 deg sweep -- non-blocking moves, "
+            "settle detected by polling stream:motor, rail-guarded), "
+            "'rezero' (re-pin zero with the stored slope). Recovery: "
+            "'manual' (write a hand-supplied --slope/--intercept "
+            "directly, no sweep). Default: azimuth."
         ),
     )
     parser.add_argument(
@@ -662,9 +800,10 @@ def build_parser():
         type=int,
         default=8,
         help=(
-            "Number of stops after home for --mode auto, evenly spaced "
-            "over one 360 deg turn (default: 8, i.e. 45 deg spacing). "
-            "Spacing must exceed twice the settle tolerance "
+            "Stop count parameter for --mode auto: after sampling home, "
+            "the sweep visits n-stops + 1 stops evenly spaced from -180 "
+            "to +180 deg (default: 8, i.e. 45 deg spacing). Spacing must "
+            "exceed twice the settle tolerance "
             f"({2 * SETTLE_TOL_DEG:.0f} deg), or settle detection could "
             "not tell the next stop from the previous one."
         ),
@@ -921,15 +1060,25 @@ def main():
         print(f"  stored: angle = {m_old:.4f} * V + {b_old:.4f}")
         print(f"  new:    angle = {cal[0]:.4f} * V + {cal[1]:.4f}")
 
-    # Physical sanity bound on the slope (all modes), independent of any
-    # stored cal — the main guard against a fat-fingered manual --slope.
-    slope_bad = slope_out_of_range(cal[0], args.turns)
+    # Sanity bound on the slope (all modes), independent of any stored
+    # cal — the main guard against a fat-fingered manual --slope. Bench
+    # modes sweep the pot's full travel, so the physical turns*360/Vref
+    # derivation applies; in-box modes compare against the
+    # field-measured slope of the installed drive instead (its wiper
+    # covers less than the full ADC span per az degree, so the physical
+    # value systematically overshoots).
+    if args.mode in ("minmax", "turns"):
+        expected_slope = expected_slope_mag(args.turns)
+        expected_src = f"a {args.turns:g}-turn pot over {ADC_VREF:.1f} V"
+    else:
+        expected_slope = EMPIRICAL_SLOPE_DEG_PER_V
+        expected_src = "the installed az drive (field-measured)"
+    slope_bad = slope_out_of_range(cal[0], expected_slope)
     if slope_bad:
-        expected = expected_slope_mag(args.turns)
         print(
             f"\nWARNING: slope |{cal[0]:.1f}| deg/V is more than "
-            f"{SLOPE_SANITY_FACTOR:g}x off the expected ~{expected:.0f} deg/V "
-            f"for a {args.turns:g}-turn pot over {ADC_VREF:.1f} V. "
+            f"{SLOPE_SANITY_FACTOR:g}x off the expected "
+            f"~{expected_slope:.0f} deg/V for {expected_src}. "
             "Check the wiring, --turns, or a typo in the slope."
         )
 

--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -757,9 +757,9 @@ def main():
         sys.exit(1)
 
     # Auto mode additionally commands the motor itself, so it hard-requires
-    # the motor's heartbeat too (azimuth mode only reads the motor stream,
-    # which the pot-availability check above doesn't cover either, but that
-    # mode is operator-driven so a stalled read just blocks on input()).
+    # the motor's heartbeat too. (Azimuth mode also reads the motor stream,
+    # and will raise within SAMPLE_TIMEOUT_S if the motor isn't publishing
+    # once the operator presses Enter.)
     motor_proxy = None
     if args.mode == "auto":
         motor_proxy = PicoProxy(MOTOR_NAME, transport, source="calibrate-pot")

--- a/picohost/src/picohost/calibrate_pot.py
+++ b/picohost/src/picohost/calibrate_pot.py
@@ -60,7 +60,7 @@ import numpy as np
 from eigsep_redis import Transport
 
 from .buses import PotCalStore
-from .motor import steps_to_deg
+from .motor import GEAR_TEETH, MICROSTEP, STEP_ANGLE_DEG, steps_to_deg
 from .proxy import PicoProxy
 
 logger = logging.getLogger(__name__)
@@ -82,6 +82,16 @@ HEADROOM_WARN_DEG = 72.0
 # Motor az should read ~0 at home; warn beyond this if the operator
 # forgot to home before pressing Enter.
 HOME_AZ_TOL_DEG = 5.0
+# Geometry of the installed az drive, from picohost.motor — the same
+# constants PicoMotor uses for deg->steps on the manager side. Fixed
+# hardware properties, deliberately not CLI-tunable: a client-side
+# override here would desync the two conversions and make --mode auto's
+# settle detection unreachable. Recorded in the cal metadata.
+MOTOR_GEOMETRY = {
+    "step_angle_deg": STEP_ANGLE_DEG,
+    "gear_teeth": GEAR_TEETH,
+    "microstep": MICROSTEP,
+}
 # --mode auto: a commanded move is considered settled once two
 # consecutive stream:motor reads agree with each other and with the
 # target within this many degrees.
@@ -161,17 +171,10 @@ def read_motor_az_steps(transport, start_id="$"):
     return float(value["az_pos"])
 
 
-def read_motor_az_deg(
-    transport, *, step_angle_deg, gear_teeth, microstep, start_id="$"
-):
-    """Current motor az in degrees (steps converted via motor geometry)."""
+def read_motor_az_deg(transport, start_id="$"):
+    """Current motor az in degrees (steps converted via MOTOR_GEOMETRY)."""
     steps = read_motor_az_steps(transport, start_id=start_id)
-    return steps_to_deg(
-        steps,
-        step_angle_deg=step_angle_deg,
-        gear_teeth=gear_teeth,
-        microstep=microstep,
-    )
+    return steps_to_deg(steps, **MOTOR_GEOMETRY)
 
 
 def compute_linear_fit(voltages, angles):
@@ -374,7 +377,32 @@ def _warn_if_not_homed(az_home):
         )
 
 
-def collect_azimuth(transport, n_samples, motor_cfg):
+def _sample_home(transport, n_samples):
+    """Sample the home stop shared by both in-box sweep modes.
+
+    Reads the motor az (warning if it isn't ~0), averages the pot voltage
+    there, and prints the home line. Home *defines* az=0 regardless of
+    the actual read. Returns ``v0``.
+    """
+    az_home = read_motor_az_deg(transport)
+    _warn_if_not_homed(az_home)
+    print("  averaging samples...")
+    v0 = collect_samples(transport, n_samples)
+    print(
+        f"  home: az=0.00 deg (motor reads {az_home:.2f}), pot_az={v0:.4f} V"
+    )
+    return v0
+
+
+def _sample_stop(transport, n_samples, az, label=""):
+    """Average the pot voltage at one sweep stop and print the result."""
+    print("  averaging samples...")
+    v = collect_samples(transport, n_samples)
+    print(f"  az={az:8.2f} deg{label}: pot_az={v:.4f} V")
+    return v
+
+
+def collect_azimuth(transport, n_samples):
     """In-box sweep: operator drives the motor; we record (az, voltage).
 
     The operator moves the motor with ``motor_manual`` and presses Enter
@@ -383,13 +411,7 @@ def collect_azimuth(transport, n_samples, motor_cfg):
     and *defines* az=0. Returns ``(voltages, angles, v0)``.
     """
     input("\nDrive the motor to HOME (az 0), stop there, then press Enter.")
-    az_home = read_motor_az_deg(transport, **motor_cfg)
-    _warn_if_not_homed(az_home)
-    print("  averaging samples...")
-    v0 = collect_samples(transport, n_samples)
-    print(
-        f"  home: az=0.00 deg (motor reads {az_home:.2f}), pot_az={v0:.4f} V"
-    )
+    v0 = _sample_home(transport, n_samples)
     voltages = [v0]
     angles = [0.0]
 
@@ -404,10 +426,8 @@ def collect_azimuth(transport, n_samples, motor_cfg):
         )
         if resp == "q":
             break
-        az = read_motor_az_deg(transport, **motor_cfg)
-        print("  averaging samples...")
-        v = collect_samples(transport, n_samples)
-        print(f"  az={az:8.2f} deg: pot_az={v:.4f} V")
+        az = read_motor_az_deg(transport)
+        v = _sample_stop(transport, n_samples, az)
         voltages.append(v)
         angles.append(az)
 
@@ -416,7 +436,6 @@ def collect_azimuth(transport, n_samples, motor_cfg):
 
 def _wait_for_settle(
     transport,
-    motor_cfg,
     target_deg,
     *,
     tol_deg=SETTLE_TOL_DEG,
@@ -428,14 +447,17 @@ def _wait_for_settle(
     caller must poll for settle itself rather than waiting on the proxy.
     "Settled" requires two consecutive reads that agree with each other
     and with the target within ``tol_deg`` -- a single sample could catch
-    the motor mid-move if it happens to cross the tolerance band. Returns
-    the settled az. Raises ``TimeoutError`` if the motor hasn't settled
-    within ``timeout_s``.
+    the motor mid-move if it happens to cross the tolerance band. This
+    only discriminates "arrived" from "still at the previous stop" when
+    the stops are more than ``2 * tol_deg`` apart (enforced on --n-stops
+    in :func:`main`): closer than that, the stationary pre-move position
+    already satisfies both conditions. Returns the settled az. Raises
+    ``TimeoutError`` if the motor hasn't settled within ``timeout_s``.
     """
     deadline = time.monotonic() + timeout_s
     prev_az = None
     while time.monotonic() < deadline:
-        az = read_motor_az_deg(transport, start_id="$", **motor_cfg)
+        az = read_motor_az_deg(transport, start_id="$")
         if (
             prev_az is not None
             and abs(az - target_deg) <= tol_deg
@@ -449,13 +471,27 @@ def _wait_for_settle(
     )
 
 
+def _motor_command(motor_proxy, action, **kwargs):
+    """Send a motor command, failing fast if the motor went away.
+
+    ``PicoProxy.send_command`` silently no-ops (returns ``None``) when
+    the device heartbeat is down. For a sweep that would otherwise wait
+    out a ~3 min settle timeout on a move that was never dispatched,
+    that must be an immediate, clearly-attributed error instead.
+    """
+    if not motor_proxy.is_available:
+        raise RuntimeError(
+            f"{MOTOR_NAME} became unreachable (heartbeat down); "
+            f"'{action}' not sent."
+        )
+    return motor_proxy.send_command(action, **kwargs)
+
+
 def collect_auto(
     transport,
     motor_proxy,
     n_samples,
-    motor_cfg,
     n_stops=8,
-    settle_tol_deg=SETTLE_TOL_DEG,
     settle_timeout_s=SETTLE_TIMEOUT_S,
 ):
     """In-box sweep: calibrate-pot drives the motor itself.
@@ -482,63 +518,58 @@ def collect_auto(
     Raises
     ------
     RuntimeError, TimeoutError
-        On any command or settle failure mid-sweep. This function never
-        returns a partial result on failure -- the exception propagates
-        before ``return``, so the caller cannot mistakenly save a fit
-        from an interrupted sweep.
+        On any command or settle failure mid-sweep (including the motor
+        heartbeat dropping). Because moves are non-blocking, the firmware
+        would otherwise keep driving toward the last commanded target
+        with nobody watching, so on any failure (or Ctrl-C) a best-effort
+        ``halt`` is sent before the claim is released. This function
+        never returns a partial result on failure -- the exception
+        propagates before ``return``, so the caller cannot mistakenly
+        save a fit from an interrupted sweep.
     """
     claim_ttl = int(settle_timeout_s * (n_stops + 2))
-    motor_proxy.send_command("claim", ttl=claim_ttl)
+    _motor_command(motor_proxy, "claim", ttl=claim_ttl)
     try:
-        az_home = read_motor_az_deg(transport, **motor_cfg)
-        _warn_if_not_homed(az_home)
-        print("  averaging samples...")
-        v0 = collect_samples(transport, n_samples)
-        print(
-            f"  home: az=0.00 deg (motor reads {az_home:.2f}), "
-            f"pot_az={v0:.4f} V"
-        )
+        v0 = _sample_home(transport, n_samples)
         voltages = [v0]
         angles = [0.0]
 
         for i in range(1, n_stops + 1):
             target = i * (360.0 / n_stops)
             print(f"\nMoving to az {target:.1f} deg...")
-            motor_proxy.send_command(
+            _motor_command(
+                motor_proxy,
                 "az_target_deg",
                 target_deg=target,
                 wait_for_start=False,
                 wait_for_stop=False,
             )
             az = _wait_for_settle(
-                transport,
-                motor_cfg,
-                target,
-                tol_deg=settle_tol_deg,
-                timeout_s=settle_timeout_s,
+                transport, target, timeout_s=settle_timeout_s
             )
-            print("  averaging samples...")
-            v = collect_samples(transport, n_samples)
-            print(
-                f"  az={az:8.2f} deg (target {target:.1f}): pot_az={v:.4f} V"
+            v = _sample_stop(
+                transport, n_samples, az, label=f" (target {target:.1f})"
             )
             voltages.append(v)
             angles.append(az)
 
         print("\nReturning motor to home (az 0)...")
-        motor_proxy.send_command(
+        _motor_command(
+            motor_proxy,
             "az_target_deg",
             target_deg=0.0,
             wait_for_start=False,
             wait_for_stop=False,
         )
-        _wait_for_settle(
-            transport,
-            motor_cfg,
-            0.0,
-            tol_deg=settle_tol_deg,
-            timeout_s=settle_timeout_s,
-        )
+        _wait_for_settle(transport, 0.0, timeout_s=settle_timeout_s)
+    except BaseException:
+        # Includes KeyboardInterrupt: an operator's Ctrl-C mid-sweep must
+        # also stop the motor, not just this process.
+        try:
+            motor_proxy.send_command("halt")
+        except (TimeoutError, RuntimeError):
+            pass  # best-effort; the original failure is what matters
+        raise
     finally:
         motor_proxy.send_command("release")
 
@@ -632,7 +663,10 @@ def build_parser():
         default=8,
         help=(
             "Number of stops after home for --mode auto, evenly spaced "
-            "over one 360 deg turn (default: 8, i.e. 45 deg spacing)."
+            "over one 360 deg turn (default: 8, i.e. 45 deg spacing). "
+            "Spacing must exceed twice the settle tolerance "
+            f"({2 * SETTLE_TOL_DEG:.0f} deg), or settle detection could "
+            "not tell the next stop from the previous one."
         ),
     )
     parser.add_argument(
@@ -655,25 +689,6 @@ def build_parser():
             "Free-text provenance recorded in the calibration metadata, "
             "e.g. 'restored from corr_20260615.h5'. Useful with --mode manual."
         ),
-    )
-    parser.add_argument(
-        "--step-angle-deg",
-        type=float,
-        default=1.8,
-        help="Motor step angle in degrees (mirrors PicoMotor; default 1.8).",
-    )
-    parser.add_argument(
-        "--gear-teeth",
-        type=int,
-        default=113,
-        help="Motor gear teeth (mirrors PicoMotor; default 113).",
-    )
-    parser.add_argument(
-        "--microstep",
-        type=int,
-        default=1,
-        help="Motor microstep divisor (mirrors PicoMotor; default 1). "
-        "MUST match the deployed motor or the slope scales wrong.",
     )
     parser.add_argument(
         "--redis-host",
@@ -702,9 +717,20 @@ def main():
         print("turns must be positive.", file=sys.stderr)
         sys.exit(1)
 
-    if args.mode == "auto" and args.n_stops <= 0:
-        print("n-stops must be positive.", file=sys.stderr)
-        sys.exit(1)
+    if args.mode == "auto":
+        if args.n_stops <= 0:
+            print("n-stops must be positive.", file=sys.stderr)
+            sys.exit(1)
+        spacing = 360.0 / args.n_stops
+        if spacing <= 2 * SETTLE_TOL_DEG:
+            print(
+                f"n-stops {args.n_stops} gives {spacing:.1f} deg spacing; "
+                f"settle detection needs more than {2 * SETTLE_TOL_DEG:.0f} "
+                "deg between stops to tell arrival at the next stop from "
+                "rest at the previous one.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     if args.mode == "manual" and (
         args.slope is None or args.intercept is None
@@ -756,11 +782,6 @@ def main():
         print(f"Mode: {args.mode} ({args.n_samples} samples/position)")
     print(f"Reading voltages from {POTMON_STREAM}.")
 
-    motor_cfg = {
-        "step_angle_deg": args.step_angle_deg,
-        "gear_teeth": args.gear_teeth,
-        "microstep": args.microstep,
-    }
     headroom = None
     free = None
     resid = None
@@ -776,18 +797,16 @@ def main():
             )
             cal = compute_linear_fit(voltages, angles)
         elif args.mode in ("azimuth", "auto"):
-            if args.mode == "azimuth":
-                voltages, angles, v0 = collect_azimuth(
-                    transport, args.n_samples, motor_cfg
-                )
-            else:
-                voltages, angles, v0 = collect_auto(
+            voltages, angles, v0 = (
+                collect_azimuth(transport, args.n_samples)
+                if args.mode == "azimuth"
+                else collect_auto(
                     transport,
                     motor_proxy,
                     args.n_samples,
-                    motor_cfg,
                     n_stops=args.n_stops,
                 )
+            )
             if len(voltages) < 2:
                 print(
                     "\nNeed at least one stop beyond home to fit a slope.",
@@ -864,7 +883,7 @@ def main():
         metadata["turns"] = float(args.turns)
         metadata["total_degrees"] = total_degrees
     if args.mode in ("azimuth", "auto"):
-        metadata["motor_cfg"] = motor_cfg
+        metadata["motor_cfg"] = dict(MOTOR_GEOMETRY)
         metadata["free_fit_intercept"] = float(free[1])
         metadata["residual_max_deg"] = resid["max_abs_deg"]
         metadata["residual_rms_deg"] = resid["rms_deg"]

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -10,6 +10,16 @@ from .base import PicoDevice
 
 logger = logging.getLogger(__name__)
 
+# Geometry of the installed az drive. Step angle and gear teeth are fixed
+# properties of the hardware; microstep is a physical driver switch that
+# is very unlikely to change. Single source for both PicoMotor (deg->steps
+# on the manager side) and calibrate-pot (steps->deg on the client side) —
+# the two conversions must always use the same numbers or --mode auto's
+# settle detection can never match the commanded target.
+STEP_ANGLE_DEG = 1.8
+GEAR_TEETH = 113
+MICROSTEP = 1
+
 
 def steps_to_deg(steps, *, step_angle_deg, gear_teeth, microstep):
     """Convert motor pulses to degrees (pure; no device state).
@@ -32,9 +42,9 @@ class PicoMotor(PicoDevice):
     def __init__(
         self,
         port,
-        step_angle_deg=1.8,
-        gear_teeth=113,
-        microstep=1,
+        step_angle_deg=STEP_ANGLE_DEG,
+        gear_teeth=GEAR_TEETH,
+        microstep=MICROSTEP,
         verbose=False,
         timeout=5.0,
         name=None,

--- a/picohost/tests/test_calibrate_pot.py
+++ b/picohost/tests/test_calibrate_pot.py
@@ -122,6 +122,133 @@ def test_collect_azimuth_warns_when_not_homed(monkeypatch, capsys):
     assert "WARNING" in capsys.readouterr().out
 
 
+# ---------------------------------------------------------------------------
+# collect_auto (--mode auto): motor-driven sweep
+# ---------------------------------------------------------------------------
+
+
+class _FakeMotorProxy:
+    """Records send_command calls; can be told to fail on a given action."""
+
+    def __init__(self, fail_on=None, fail_exc=RuntimeError("boom")):
+        self.is_available = True
+        self.calls = []
+        self._fail_on = fail_on
+        self._fail_exc = fail_exc
+
+    def send_command(self, action, **kwargs):
+        self.calls.append((action, kwargs))
+        if action == self._fail_on:
+            raise self._fail_exc
+
+
+def test_collect_auto_commands_expected_targets_and_reads_actual_az(
+    monkeypatch,
+):
+    # n_stops=2 -> 180 deg spacing: commanded targets 180, 360, then home (0).
+    # Actual settled reads are offset from the commanded target (within the
+    # settle tolerance) to prove angles come from the stream, not the target.
+    monkeypatch.setattr(
+        calibrate_pot,
+        "read_motor_az_deg",
+        _seq(
+            [
+                1.0,  # home read
+                181.0,
+                181.0,  # settle at stop 1 (target 180)
+                361.0,
+                361.0,  # settle at stop 2 (target 360)
+                0.5,
+                0.5,  # settle back at home (target 0)
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        calibrate_pot, "collect_samples", _seq([1.0, 1.5, 2.0])
+    )
+
+    proxy = _FakeMotorProxy()
+    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    voltages, angles, v0 = calibrate_pot.collect_auto(
+        DummyTransport(), proxy, n_samples=10, motor_cfg=cfg, n_stops=2
+    )
+
+    assert v0 == pytest.approx(1.0)
+    assert voltages == [1.0, 1.5, 2.0]
+    # Recorded angles are the actual stream reads (181, 361), not the
+    # commanded targets (180, 360).
+    assert angles == [0.0, 181.0, 361.0]
+
+    move_calls = [c for c in proxy.calls if c[0] == "az_target_deg"]
+    assert [c[1]["target_deg"] for c in move_calls] == [180.0, 360.0, 0.0]
+    # Moves must be non-blocking -- the manager's command thread cannot
+    # afford to wait on a multi-minute move.
+    for _action, kwargs in move_calls:
+        assert kwargs["wait_for_start"] is False
+        assert kwargs["wait_for_stop"] is False
+
+    # Claimed at the start, released at the end.
+    assert proxy.calls[0][0] == "claim"
+    assert proxy.calls[-1][0] == "release"
+
+
+def test_collect_auto_warns_when_not_homed(monkeypatch, capsys):
+    monkeypatch.setattr(
+        calibrate_pot,
+        "read_motor_az_deg",
+        _seq([10.0, 360.5, 360.5, 0.2, 0.2]),
+    )
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0, 2.0]))
+
+    proxy = _FakeMotorProxy()
+    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    calibrate_pot.collect_auto(
+        DummyTransport(), proxy, n_samples=10, motor_cfg=cfg, n_stops=1
+    )
+
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_collect_auto_releases_claim_on_command_failure(monkeypatch):
+    monkeypatch.setattr(calibrate_pot, "read_motor_az_deg", _seq([0.0]))
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0]))
+
+    proxy = _FakeMotorProxy(fail_on="az_target_deg")
+    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    with pytest.raises(RuntimeError, match="boom"):
+        calibrate_pot.collect_auto(
+            DummyTransport(), proxy, n_samples=10, motor_cfg=cfg, n_stops=1
+        )
+
+    assert proxy.calls[0][0] == "claim"
+    assert proxy.calls[-1][0] == "release"
+
+
+def test_collect_auto_raises_on_settle_timeout(monkeypatch):
+    # The motor never reaches the commanded target -- read_motor_az_deg
+    # always reports the same stale value.
+    monkeypatch.setattr(
+        calibrate_pot, "read_motor_az_deg", lambda *a, **k: 0.0
+    )
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0]))
+
+    proxy = _FakeMotorProxy()
+    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    with pytest.raises(TimeoutError, match="did not settle"):
+        calibrate_pot.collect_auto(
+            DummyTransport(),
+            proxy,
+            n_samples=10,
+            motor_cfg=cfg,
+            n_stops=1,
+            settle_timeout_s=0.05,
+        )
+
+    # Claim still released after the settle timeout propagates.
+    assert proxy.calls[0][0] == "claim"
+    assert proxy.calls[-1][0] == "release"
+
+
 def test_rezero_reuses_stored_slope(monkeypatch):
     t = DummyTransport()
     PotCalStore(t).upload({"pot_az": [100.0, -50.0]})
@@ -189,6 +316,17 @@ def test_build_parser_accepts_new_modes_and_motor_cfg():
     assert d.step_angle_deg == pytest.approx(1.8)
     assert d.gear_teeth == 113
     assert d.microstep == 1
+
+
+def test_build_parser_accepts_auto_mode():
+    p = calibrate_pot.build_parser()
+
+    a = p.parse_args(["--mode", "auto"])
+    assert a.mode == "auto"
+    assert a.n_stops == 8  # ~45 deg spacing over one 360 deg turn
+
+    a = p.parse_args(["--mode", "auto", "--n-stops", "4"])
+    assert a.n_stops == 4
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +418,105 @@ def test_main_rezero_mode(monkeypatch):
     action, kwargs = fake_proxy.calls[0]
     assert action == "set_calibration"
     assert kwargs["pot_az_params"] == pytest.approx([100.0, -100.0])
+
+
+def _make_named_fake_proxy_factory(unavailable=frozenset()):
+    """Fake PicoProxy factory keyed by device name.
+
+    Unlike ``_make_fake_proxy`` (a single shared instance), --mode auto
+    constructs two proxies (pot and motor) that must be independently
+    controllable and independently record their calls.
+    """
+
+    class FakePicoProxy:
+        def __init__(self, name, *args, **kwargs):
+            self.name = name
+            self.is_available = name not in unavailable
+            self.calls = []
+
+        def send_command(self, action, **kwargs):
+            self.calls.append((action, kwargs))
+
+    proxies = {}
+
+    def factory(name, *args, **kwargs):
+        proxy = FakePicoProxy(name, *args, **kwargs)
+        proxies[name] = proxy
+        return proxy
+
+    return proxies, factory
+
+
+def test_main_auto_mode(monkeypatch):
+    """main() --mode auto: collects via collect_auto, fits, stores, pushes."""
+    dummy_transport = DummyTransport()
+    proxies, proxy_factory = _make_named_fake_proxy_factory()
+
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr(
+        calibrate_pot,
+        "collect_auto",
+        lambda *a, **k: ([1.0, 1.9], [0.0, 360.0], 1.0),
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", ["calibrate-pot", "--mode", "auto"])
+
+    calibrate_pot.main()
+
+    stored = PotCalStore(dummy_transport).get()
+    expected_m, expected_b = calibrate_pot.fit_slope_pin_zero(
+        [1.0, 1.9], [0.0, 360.0], 1.0
+    )
+    assert stored["pot_az"][0] == pytest.approx(expected_m)
+    assert stored["pot_az"][1] == pytest.approx(expected_b)
+    assert stored["metadata"]["mode"] == "auto"
+    assert "motor_cfg" in stored["metadata"]
+    assert stored["metadata"]["n_stops"] == 8
+
+    # Only the pot proxy gets the live push; the motor proxy is used only
+    # inside collect_auto (which is monkeypatched away here).
+    pot_calls = proxies[calibrate_pot.POTMON_NAME].calls
+    assert len(pot_calls) == 1
+    action, kwargs = pot_calls[0]
+    assert action == "set_calibration"
+    assert kwargs["pot_az_params"] == pytest.approx([expected_m, expected_b])
+
+
+def test_main_auto_mode_requires_motor_available(monkeypatch):
+    """--mode auto exits(1) up front if the motor isn't reachable."""
+    dummy_transport = DummyTransport()
+    _proxies, proxy_factory = _make_named_fake_proxy_factory(
+        unavailable={calibrate_pot.MOTOR_NAME}
+    )
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr(sys, "argv", ["calibrate-pot", "--mode", "auto"])
+
+    with pytest.raises(SystemExit) as exc:
+        calibrate_pot.main()
+    assert exc.value.code == 1
+    assert PotCalStore(dummy_transport).get() is None
+
+
+def test_main_auto_mode_rejects_nonpositive_n_stops(monkeypatch):
+    dummy_transport = DummyTransport()
+    _proxies, proxy_factory = _make_named_fake_proxy_factory()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr(
+        sys, "argv", ["calibrate-pot", "--mode", "auto", "--n-stops", "0"]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        calibrate_pot.main()
+    assert exc.value.code == 1
 
 
 # ---------------------------------------------------------------------------

--- a/picohost/tests/test_calibrate_pot.py
+++ b/picohost/tests/test_calibrate_pot.py
@@ -70,11 +70,10 @@ def test_read_motor_az_steps_reads_latest():
 
 
 def test_read_motor_az_deg_converts_with_geometry():
+    # 22600 steps = one full turn for the installed drive (MOTOR_GEOMETRY).
     t = DummyTransport()
     _xadd_motor(t, 22600)
-    deg = calibrate_pot.read_motor_az_deg(
-        t, step_angle_deg=1.8, gear_teeth=113, microstep=1, start_id="0-0"
-    )
+    deg = calibrate_pot.read_motor_az_deg(t, start_id="0-0")
     assert deg == pytest.approx(360.0)
 
 
@@ -90,6 +89,26 @@ def _seq(values):
     return lambda *a, **k: next(it)
 
 
+class FakePicoProxy:
+    """Records send_command calls; the one fake proxy for every test here.
+
+    ``fail_on`` raises ``fail_exc`` when that action is sent; flip
+    ``is_available`` to simulate a heartbeat drop.
+    """
+
+    def __init__(self, name="", available=True, fail_on=None, fail_exc=None):
+        self.name = name
+        self.is_available = available
+        self.calls = []
+        self._fail_on = fail_on
+        self._fail_exc = fail_exc or RuntimeError("boom")
+
+    def send_command(self, action, **kwargs):
+        self.calls.append((action, kwargs))
+        if action == self._fail_on:
+            raise self._fail_exc
+
+
 def test_collect_azimuth_pairs_voltage_with_motor_az(monkeypatch):
     monkeypatch.setattr(
         calibrate_pot, "collect_samples", _seq([1.0, 1.5, 2.0])
@@ -100,9 +119,8 @@ def test_collect_azimuth_pairs_voltage_with_motor_az(monkeypatch):
     # home prompt, two stop prompts, then 'q' to finish
     monkeypatch.setattr("builtins.input", _seq(["", "", "", "q"]))
 
-    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
     voltages, angles, v0 = calibrate_pot.collect_azimuth(
-        DummyTransport(), n_samples=10, motor_cfg=cfg
+        DummyTransport(), n_samples=10
     )
 
     assert v0 == pytest.approx(1.0)
@@ -117,29 +135,13 @@ def test_collect_azimuth_warns_when_not_homed(monkeypatch, capsys):
         calibrate_pot, "read_motor_az_deg", _seq([45.0, 360.0])
     )
     monkeypatch.setattr("builtins.input", _seq(["", "", "q"]))
-    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
-    calibrate_pot.collect_azimuth(DummyTransport(), 10, cfg)
+    calibrate_pot.collect_azimuth(DummyTransport(), 10)
     assert "WARNING" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------
 # collect_auto (--mode auto): motor-driven sweep
 # ---------------------------------------------------------------------------
-
-
-class _FakeMotorProxy:
-    """Records send_command calls; can be told to fail on a given action."""
-
-    def __init__(self, fail_on=None, fail_exc=RuntimeError("boom")):
-        self.is_available = True
-        self.calls = []
-        self._fail_on = fail_on
-        self._fail_exc = fail_exc
-
-    def send_command(self, action, **kwargs):
-        self.calls.append((action, kwargs))
-        if action == self._fail_on:
-            raise self._fail_exc
 
 
 def test_collect_auto_commands_expected_targets_and_reads_actual_az(
@@ -167,10 +169,9 @@ def test_collect_auto_commands_expected_targets_and_reads_actual_az(
         calibrate_pot, "collect_samples", _seq([1.0, 1.5, 2.0])
     )
 
-    proxy = _FakeMotorProxy()
-    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    proxy = FakePicoProxy()
     voltages, angles, v0 = calibrate_pot.collect_auto(
-        DummyTransport(), proxy, n_samples=10, motor_cfg=cfg, n_stops=2
+        DummyTransport(), proxy, n_samples=10, n_stops=2
     )
 
     assert v0 == pytest.approx(1.0)
@@ -187,9 +188,10 @@ def test_collect_auto_commands_expected_targets_and_reads_actual_az(
         assert kwargs["wait_for_start"] is False
         assert kwargs["wait_for_stop"] is False
 
-    # Claimed at the start, released at the end.
+    # Claimed at the start, released at the end; no halt on success.
     assert proxy.calls[0][0] == "claim"
     assert proxy.calls[-1][0] == "release"
+    assert "halt" not in [c[0] for c in proxy.calls]
 
 
 def test_collect_auto_warns_when_not_homed(monkeypatch, capsys):
@@ -200,31 +202,31 @@ def test_collect_auto_warns_when_not_homed(monkeypatch, capsys):
     )
     monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0, 2.0]))
 
-    proxy = _FakeMotorProxy()
-    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    proxy = FakePicoProxy()
     calibrate_pot.collect_auto(
-        DummyTransport(), proxy, n_samples=10, motor_cfg=cfg, n_stops=1
+        DummyTransport(), proxy, n_samples=10, n_stops=1
     )
 
     assert "WARNING" in capsys.readouterr().out
 
 
-def test_collect_auto_releases_claim_on_command_failure(monkeypatch):
+def test_collect_auto_halts_and_releases_on_command_failure(monkeypatch):
     monkeypatch.setattr(calibrate_pot, "read_motor_az_deg", _seq([0.0]))
     monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0]))
 
-    proxy = _FakeMotorProxy(fail_on="az_target_deg")
-    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    proxy = FakePicoProxy(fail_on="az_target_deg")
     with pytest.raises(RuntimeError, match="boom"):
         calibrate_pot.collect_auto(
-            DummyTransport(), proxy, n_samples=10, motor_cfg=cfg, n_stops=1
+            DummyTransport(), proxy, n_samples=10, n_stops=1
         )
 
+    # Moves are non-blocking, so the failure path must stop the motor
+    # before giving up the claim.
     assert proxy.calls[0][0] == "claim"
-    assert proxy.calls[-1][0] == "release"
+    assert [c[0] for c in proxy.calls[-2:]] == ["halt", "release"]
 
 
-def test_collect_auto_raises_on_settle_timeout(monkeypatch):
+def test_collect_auto_halts_and_releases_on_settle_timeout(monkeypatch):
     # The motor never reaches the commanded target -- read_motor_az_deg
     # always reports the same stale value.
     monkeypatch.setattr(
@@ -232,20 +234,44 @@ def test_collect_auto_raises_on_settle_timeout(monkeypatch):
     )
     monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0]))
 
-    proxy = _FakeMotorProxy()
-    cfg = {"step_angle_deg": 1.8, "gear_teeth": 113, "microstep": 1}
+    proxy = FakePicoProxy()
     with pytest.raises(TimeoutError, match="did not settle"):
         calibrate_pot.collect_auto(
             DummyTransport(),
             proxy,
             n_samples=10,
-            motor_cfg=cfg,
             n_stops=1,
             settle_timeout_s=0.05,
         )
 
-    # Claim still released after the settle timeout propagates.
+    # The motor may still be en route after a settle timeout: halt it,
+    # then release the claim.
     assert proxy.calls[0][0] == "claim"
+    assert [c[0] for c in proxy.calls[-2:]] == ["halt", "release"]
+
+
+def test_collect_auto_fails_fast_when_motor_drops_mid_sweep(monkeypatch):
+    proxy = FakePicoProxy()
+
+    def _sample_and_drop_heartbeat(*a, **k):
+        # Heartbeat lapses while the home stop is being sampled — the
+        # next move must raise immediately, not silently no-op and then
+        # burn the full settle timeout.
+        proxy.is_available = False
+        return 1.0
+
+    monkeypatch.setattr(calibrate_pot, "read_motor_az_deg", _seq([0.0]))
+    monkeypatch.setattr(
+        calibrate_pot, "collect_samples", _sample_and_drop_heartbeat
+    )
+
+    with pytest.raises(RuntimeError, match="unreachable"):
+        calibrate_pot.collect_auto(
+            DummyTransport(), proxy, n_samples=10, n_stops=1
+        )
+
+    # No move was dispatched; cleanup still ran.
+    assert "az_target_deg" not in [c[0] for c in proxy.calls]
     assert proxy.calls[-1][0] == "release"
 
 
@@ -302,20 +328,23 @@ def test_build_parser_accepts_manual_mode_and_args():
     assert d.note is None
 
 
-def test_build_parser_accepts_new_modes_and_motor_cfg():
+def test_build_parser_accepts_new_modes():
     p = calibrate_pot.build_parser()
 
-    a = p.parse_args(["--mode", "azimuth", "--gear-teeth", "200"])
-    assert a.mode == "azimuth"
-    assert a.gear_teeth == 200
-
+    assert p.parse_args(["--mode", "azimuth"]).mode == "azimuth"
     assert p.parse_args(["--mode", "rezero"]).mode == "rezero"
+    assert p.parse_args([]).mode == "azimuth"  # in-box is the common case
 
-    d = p.parse_args([])
-    assert d.mode == "azimuth"  # in-box calibration is the common case
-    assert d.step_angle_deg == pytest.approx(1.8)
-    assert d.gear_teeth == 113
-    assert d.microstep == 1
+
+def test_build_parser_rejects_motor_geometry_flags():
+    # Geometry is a fixed hardware property (picohost.motor constants),
+    # deliberately not CLI-tunable: a client-side override would desync
+    # deg->steps (manager) from steps->deg (calibrate-pot) and make
+    # --mode auto's settle detection unreachable.
+    p = calibrate_pot.build_parser()
+    for flag in ("--step-angle-deg", "--gear-teeth", "--microstep"):
+        with pytest.raises(SystemExit):
+            p.parse_args([flag, "2"])
 
 
 def test_build_parser_accepts_auto_mode():
@@ -335,16 +364,7 @@ def test_build_parser_accepts_auto_mode():
 
 
 def _make_fake_proxy():
-    """Return a fake PicoProxy class whose instances record send_command calls."""
-
-    class FakePicoProxy:
-        def __init__(self, *args, **kwargs):
-            self.is_available = True
-            self.calls = []
-
-        def send_command(self, action, **kwargs):
-            self.calls.append((action, kwargs))
-
+    """Return a shared FakePicoProxy instance and a factory that yields it."""
     instance = FakePicoProxy()
     return instance, lambda *a, **k: instance
 
@@ -421,26 +441,16 @@ def test_main_rezero_mode(monkeypatch):
 
 
 def _make_named_fake_proxy_factory(unavailable=frozenset()):
-    """Fake PicoProxy factory keyed by device name.
+    """FakePicoProxy factory keyed by device name.
 
     Unlike ``_make_fake_proxy`` (a single shared instance), --mode auto
     constructs two proxies (pot and motor) that must be independently
     controllable and independently record their calls.
     """
-
-    class FakePicoProxy:
-        def __init__(self, name, *args, **kwargs):
-            self.name = name
-            self.is_available = name not in unavailable
-            self.calls = []
-
-        def send_command(self, action, **kwargs):
-            self.calls.append((action, kwargs))
-
     proxies = {}
 
     def factory(name, *args, **kwargs):
-        proxy = FakePicoProxy(name, *args, **kwargs)
+        proxy = FakePicoProxy(name, available=name not in unavailable)
         proxies[name] = proxy
         return proxy
 
@@ -517,6 +527,28 @@ def test_main_auto_mode_rejects_nonpositive_n_stops(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         calibrate_pot.main()
     assert exc.value.code == 1
+
+
+def test_main_auto_mode_rejects_spacing_within_settle_tolerance(monkeypatch):
+    """Stops closer than 2x the settle tolerance would false-settle at the
+    previous stop (the stationary pre-move position already matches the
+    target within tolerance), silently corrupting the calibration."""
+    dummy_transport = DummyTransport()
+    _proxies, proxy_factory = _make_named_fake_proxy_factory()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    # 90 stops -> 4.0 deg spacing == 2 * SETTLE_TOL_DEG: not strictly
+    # greater, so it must be rejected (89 -> ~4.04 deg is the max).
+    monkeypatch.setattr(
+        sys, "argv", ["calibrate-pot", "--mode", "auto", "--n-stops", "90"]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        calibrate_pot.main()
+    assert exc.value.code == 1
+    assert PotCalStore(dummy_transport).get() is None
 
 
 # ---------------------------------------------------------------------------

--- a/picohost/tests/test_calibrate_pot.py
+++ b/picohost/tests/test_calibrate_pot.py
@@ -147,26 +147,30 @@ def test_collect_azimuth_warns_when_not_homed(monkeypatch, capsys):
 def test_collect_auto_commands_expected_targets_and_reads_actual_az(
     monkeypatch,
 ):
-    # n_stops=2 -> 180 deg spacing: commanded targets 180, 360, then home (0).
-    # Actual settled reads are offset from the commanded target (within the
-    # settle tolerance) to prove angles come from the stream, not the target.
+    # The sweep must cover the production operating window (-180..+180
+    # deg around home), not 0..360: n_stops=2 -> 180 deg spacing gives
+    # commanded targets -180, 0, +180, then home (0). Actual settled
+    # reads are offset from the commanded target (within the settle
+    # tolerance) to prove angles come from the stream, not the target.
     monkeypatch.setattr(
         calibrate_pot,
         "read_motor_az_deg",
         _seq(
             [
                 1.0,  # home read
-                181.0,
-                181.0,  # settle at stop 1 (target 180)
-                361.0,
-                361.0,  # settle at stop 2 (target 360)
+                -179.0,
+                -179.0,  # settle at stop 1 (target -180)
                 0.5,
-                0.5,  # settle back at home (target 0)
+                0.5,  # settle at stop 2 (target 0)
+                179.5,
+                179.5,  # settle at stop 3 (target +180)
+                0.2,
+                0.2,  # settle back at home (target 0)
             ]
         ),
     )
     monkeypatch.setattr(
-        calibrate_pot, "collect_samples", _seq([1.0, 1.5, 2.0])
+        calibrate_pot, "collect_samples", _seq([1.0, 1.4, 1.5, 1.6])
     )
 
     proxy = FakePicoProxy()
@@ -175,13 +179,18 @@ def test_collect_auto_commands_expected_targets_and_reads_actual_az(
     )
 
     assert v0 == pytest.approx(1.0)
-    assert voltages == [1.0, 1.5, 2.0]
-    # Recorded angles are the actual stream reads (181, 361), not the
-    # commanded targets (180, 360).
-    assert angles == [0.0, 181.0, 361.0]
+    assert voltages == [1.0, 1.4, 1.5, 1.6]
+    # Recorded angles are the actual stream reads (-179, 0.5, 179.5),
+    # not the commanded targets (-180, 0, 180).
+    assert angles == [0.0, -179.0, 0.5, 179.5]
 
     move_calls = [c for c in proxy.calls if c[0] == "az_target_deg"]
-    assert [c[1]["target_deg"] for c in move_calls] == [180.0, 360.0, 0.0]
+    assert [c[1]["target_deg"] for c in move_calls] == [
+        -180.0,
+        0.0,
+        180.0,
+        0.0,
+    ]
     # Moves must be non-blocking -- the manager's command thread cannot
     # afford to wait on a multi-minute move.
     for _action, kwargs in move_calls:
@@ -195,12 +204,15 @@ def test_collect_auto_commands_expected_targets_and_reads_actual_az(
 
 
 def test_collect_auto_warns_when_not_homed(monkeypatch, capsys):
+    # n_stops=1 -> targets -180, +180, then home (0).
     monkeypatch.setattr(
         calibrate_pot,
         "read_motor_az_deg",
-        _seq([10.0, 360.5, 360.5, 0.2, 0.2]),
+        _seq([10.0, -180.2, -180.2, 179.8, 179.8, 0.2, 0.2]),
     )
-    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0, 2.0]))
+    monkeypatch.setattr(
+        calibrate_pot, "collect_samples", _seq([1.5, 1.0, 2.0])
+    )
 
     proxy = FakePicoProxy()
     calibrate_pot.collect_auto(
@@ -273,6 +285,133 @@ def test_collect_auto_fails_fast_when_motor_drops_mid_sweep(monkeypatch):
     # No move was dispatched; cleanup still ran.
     assert "az_target_deg" not in [c[0] for c in proxy.calls]
     assert proxy.calls[-1][0] == "release"
+
+
+# ---------------------------------------------------------------------------
+# rail guards: near the ADC rails the wiper clips and the pot silently
+# stops being an absolute azimuth reference, so in-box sampling and the
+# auto sweep must abort rather than record clipped voltages.
+# ---------------------------------------------------------------------------
+
+
+def test_check_off_rails_bounds():
+    # Mid-range passes silently.
+    calibrate_pot._check_off_rails(1.65, where="test")
+    # Within the guard margin of either rail raises.
+    with pytest.raises(RuntimeError, match="rail"):
+        calibrate_pot._check_off_rails(0.05, where="test")
+    with pytest.raises(RuntimeError, match="rail"):
+        calibrate_pot._check_off_rails(3.25, where="test")
+
+
+def test_sample_stop_aborts_on_railed_voltage(monkeypatch):
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([0.05]))
+    with pytest.raises(RuntimeError, match="rail"):
+        calibrate_pot._sample_stop(DummyTransport(), 10, 45.0)
+
+
+def test_collect_auto_halts_on_railed_sample(monkeypatch):
+    # Home samples fine; the first sweep stop reads a clipped voltage.
+    # The sweep must halt the motor and release the claim, not keep
+    # collecting a fit from clipped data.
+    monkeypatch.setattr(
+        calibrate_pot,
+        "read_motor_az_deg",
+        _seq([0.0, -179.5, -179.5]),
+    )
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([1.0, 3.28]))
+
+    proxy = FakePicoProxy()
+    with pytest.raises(RuntimeError, match="rail"):
+        calibrate_pot.collect_auto(
+            DummyTransport(), proxy, n_samples=10, n_stops=2
+        )
+
+    assert [c[0] for c in proxy.calls[-2:]] == ["halt", "release"]
+
+
+def test_collect_auto_preflight_aborts_before_moving_when_home_near_rail(
+    monkeypatch,
+):
+    # v0=0.4 V: at the field-measured slope (~320 deg/V) the -180 deg
+    # half of the sweep needs ~0.56 V of travel, which would cross the
+    # 0 V rail. The preflight must abort before any move is commanded.
+    monkeypatch.setattr(calibrate_pot, "read_motor_az_deg", _seq([0.0]))
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([0.4]))
+
+    proxy = FakePicoProxy()
+    with pytest.raises(RuntimeError, match="headroom"):
+        calibrate_pot.collect_auto(
+            DummyTransport(), proxy, n_samples=10, n_stops=8
+        )
+
+    assert "az_target_deg" not in [c[0] for c in proxy.calls]
+    assert proxy.calls[-1][0] == "release"
+
+
+def test_collect_auto_preflight_uses_stored_slope(monkeypatch):
+    # A stored steep slope (1000 deg/V -> 0.18 V per 180 deg) makes the
+    # same 0.4 V home viable; the empirical fallback alone would abort.
+    t = DummyTransport()
+    PotCalStore(t).upload({"pot_az": [1000.0, -400.0]})
+    monkeypatch.setattr(
+        calibrate_pot,
+        "read_motor_az_deg",
+        _seq([0.0, -179.8, -179.8, 179.9, 179.9, 0.1, 0.1]),
+    )
+    monkeypatch.setattr(
+        calibrate_pot, "collect_samples", _seq([0.4, 0.3, 0.55])
+    )
+
+    proxy = FakePicoProxy()
+    voltages, angles, v0 = calibrate_pot.collect_auto(
+        t, proxy, n_samples=10, n_stops=1
+    )
+
+    assert v0 == pytest.approx(0.4)
+    move_calls = [c for c in proxy.calls if c[0] == "az_target_deg"]
+    assert [c[1]["target_deg"] for c in move_calls] == [-180.0, 180.0, 0.0]
+
+
+def test_wait_for_settle_aborts_when_pot_rails_mid_move(monkeypatch):
+    # The motor is settling happily on target, but the pot hit a rail
+    # mid-move: the settle poll must abort (upstream halts the motor)
+    # rather than report a clean arrival.
+    t = DummyTransport()
+    t.r.xadd(
+        calibrate_pot.POTMON_STREAM,
+        {"value": json.dumps({"pot_az_voltage": 0.05})},
+    )
+    monkeypatch.setattr(
+        calibrate_pot, "read_motor_az_deg", lambda *a, **k: 180.0
+    )
+
+    with pytest.raises(RuntimeError, match="rail"):
+        calibrate_pot._wait_for_settle(t, 180.0, timeout_s=1.0)
+
+
+def test_wait_for_settle_passes_with_healthy_pot(monkeypatch):
+    t = DummyTransport()
+    t.r.xadd(
+        calibrate_pot.POTMON_STREAM,
+        {"value": json.dumps({"pot_az_voltage": 1.5})},
+    )
+    monkeypatch.setattr(
+        calibrate_pot, "read_motor_az_deg", lambda *a, **k: 180.0
+    )
+
+    az = calibrate_pot._wait_for_settle(t, 180.0, timeout_s=1.0)
+    assert az == pytest.approx(180.0)
+
+
+def test_rezero_aborts_on_railed_home(monkeypatch):
+    # Re-pinning zero to a clipped voltage would poison the intercept.
+    t = DummyTransport()
+    PotCalStore(t).upload({"pot_az": [320.0, -50.0]})
+    monkeypatch.setattr(calibrate_pot, "collect_samples", _seq([3.25]))
+    monkeypatch.setattr("builtins.input", _seq([""]))
+    with pytest.raises(RuntimeError, match="rail"):
+        calibrate_pot.rezero(t, n_samples=10)
 
 
 def test_rezero_reuses_stored_slope(monkeypatch):
@@ -844,23 +983,73 @@ def test_expected_slope_mag_installed_pot():
 
 
 def test_slope_out_of_range_in_window():
-    # Expected ~409 deg/V; factor 1.5 -> in-range ~273..614 deg/V.
-    assert calibrate_pot.slope_out_of_range(409.0, 3.75) is False
-    assert calibrate_pot.slope_out_of_range(300.0, 3.75) is False
-    assert calibrate_pot.slope_out_of_range(600.0, 3.75) is False
+    # Expected 320 deg/V (field-measured); factor 1.5 -> ~213..480 deg/V.
+    assert calibrate_pot.slope_out_of_range(320.0, 320.0) is False
+    assert calibrate_pot.slope_out_of_range(409.0, 320.0) is False
+    assert calibrate_pot.slope_out_of_range(250.0, 320.0) is False
     # Sign is irrelevant — magnitude only.
-    assert calibrate_pot.slope_out_of_range(-409.0, 3.75) is False
+    assert calibrate_pot.slope_out_of_range(-320.0, 320.0) is False
 
 
 def test_slope_out_of_range_flags_gross_errors():
     # An order-of-magnitude typo in either direction is flagged.
-    assert calibrate_pot.slope_out_of_range(40.9, 3.75) is True
-    assert calibrate_pot.slope_out_of_range(4090.0, 3.75) is True
+    assert calibrate_pot.slope_out_of_range(32.0, 320.0) is True
+    assert calibrate_pot.slope_out_of_range(3200.0, 320.0) is True
     # Just outside the 1.5x window on each side.
-    assert calibrate_pot.slope_out_of_range(200.0, 3.75) is True
-    assert calibrate_pot.slope_out_of_range(700.0, 3.75) is True
-    # A zero slope is never sane.
-    assert calibrate_pot.slope_out_of_range(0.0, 3.75) is True
+    assert calibrate_pot.slope_out_of_range(200.0, 320.0) is True
+    assert calibrate_pot.slope_out_of_range(500.0, 320.0) is True
+    # A zero slope is never sane, nor is a non-positive expectation.
+    assert calibrate_pot.slope_out_of_range(0.0, 320.0) is True
+    assert calibrate_pot.slope_out_of_range(320.0, 0.0) is True
+
+
+def test_main_manual_sanity_centered_on_empirical_slope(monkeypatch):
+    """In-box modes check the slope against the field-measured ~320 deg/V.
+
+    500 deg/V sat comfortably inside the old physically-derived window
+    (409 * 1.5 = 614) but is >1.5x off the measured slope, so it must
+    escalate the save — a bare 'y' discards."""
+    dummy_transport = DummyTransport()
+    fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", _manual_argv(500.0, -400.0))
+
+    calibrate_pot.main()
+
+    assert PotCalStore(dummy_transport).get() is None
+    assert fake_proxy.calls == []
+
+
+def test_main_bench_mode_keeps_physical_expectation(monkeypatch, capsys):
+    """Bench modes keep the physical turns*360/vref expectation.
+
+    A 500 deg/V fit is in range for a 3.75-turn pot on the bench (where
+    the wiper genuinely spans the full range) even though it would fail
+    the in-box empirical window."""
+    dummy_transport = DummyTransport()
+    _fake_proxy, proxy_factory = _make_fake_proxy()
+    monkeypatch.setattr(
+        calibrate_pot, "Transport", lambda *a, **k: dummy_transport
+    )
+    monkeypatch.setattr(calibrate_pot, "PicoProxy", proxy_factory)
+    # minmax fit: 0..1350 deg over 0.3..3.0 V -> slope = 1350/2.7 = 500
+    monkeypatch.setattr(
+        calibrate_pot,
+        "collect_minmax",
+        lambda *a, **k: ([0.3, 3.0], [0.0, 1350.0]),
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    monkeypatch.setattr(sys, "argv", ["calibrate-pot", "--mode", "minmax"])
+
+    calibrate_pot.main()
+
+    out = capsys.readouterr().out
+    assert "off the expected" not in out.lower()
+    assert PotCalStore(dummy_transport).get() is not None
 
 
 # ---------------------------------------------------------------------------

--- a/picohost/tests/test_potentiometer.py
+++ b/picohost/tests/test_potentiometer.py
@@ -167,8 +167,37 @@ class TestPotRedisHandler:
             "pot_az_cal_slope",
             "pot_az_cal_intercept",
             "pot_az_angle",
+            "pot_az_near_rail",
         }
         assert expected_added.issubset(before)
+        pot.disconnect()
+
+    def test_near_rail_flag_false_mid_range(self):
+        """The emulator's ~1.5 V baseline is far from both rails."""
+        pot = _make_pot()
+        published = self._capture(pot)
+        assert published["pot_az_near_rail"] is False
+        pot.disconnect()
+
+    def test_near_rail_flag_true_near_either_rail(self):
+        """A wiper within the margin of 0 V or vref publishes True.
+
+        A railed pot reports a steady, plausible voltage, so this flag
+        is the only stream-level tell that the absolute azimuth
+        reference is compromised (e.g. accumulated motor slip during a
+        multi-day scan)."""
+        pot = _make_pot()
+        captured = {}
+        pot._base_redis_handler = lambda d: captured.update(d)
+        for v in (0.05, 3.25):
+            captured.clear()
+            pot._pot_redis_handler({"pot_az_voltage": v})
+            assert captured["pot_az_near_rail"] is True, f"{v} V"
+        # Missing voltage keeps the stable-shape contract: field present,
+        # value None.
+        captured.clear()
+        pot._pot_redis_handler({})
+        assert captured["pot_az_near_rail"] is None
         pot.disconnect()
 
 


### PR DESCRIPTION
## Summary

Adds `--mode auto` to `calibrate-pot`: a motor-driven variant of the existing `--mode azimuth` in-box sweep. Instead of an operator driving the motor and pressing Enter at each stop, `auto` commands the motor itself and samples automatically.

**Design** (agreed with repo owner ahead of implementation):

- **Non-blocking moves + stream settle polling.** The manager (`PicoManager._route_command`) runs routed commands synchronously on its command thread, and a full-turn move takes ~2 minutes — so `calibrate_pot.collect_auto` commands each stop via `motor_proxy.send_command("az_target_deg", target_deg=..., wait_for_start=False, wait_for_stop=False)` (never `wait_for_stop=True`, which is in the manager's `_BLOCKED_ACTIONS` deny-list territory of "would stall the cmd thread"). Settle is then detected client-side by polling `stream:motor` (new `_wait_for_settle`, built on the existing `read_motor_az_deg`): two consecutive reads must agree with each other and with the commanded target within `SETTLE_TOL_DEG` (2.0 deg), bounded by `SETTLE_TIMEOUT_S` (180 s — comfortably more than a ~2 min full turn). The recorded angle at each stop is the *actual* settled stream read, not the commanded target.
- **Home assumption.** `auto` does not implement a homing routine — the operator homes the motor beforehand, same as `azimuth`. At the start of the sweep it reads motor az and reuses `azimuth` mode's exact "did you home the motor first?" warning (factored out into a shared `_warn_if_not_homed` helper so the message can't drift between the two modes) if it's more than `HOME_AZ_TOL_DEG` off zero.
- **Claim/release.** The motor is soft-claimed via the proxy `claim` action for the duration of the sweep and released in a `finally` block, so the claim is released even if a move command or settle poll fails mid-sweep (claims are advisory, not enforced, per `manager.py`).
- **No partial saves.** Any failure mid-sweep (settle timeout, command error) raises before the function's `return`, so `main()` never has a fit to persist from an interrupted sweep.
- **Sweep shape.** `n_stops` (default 8, CLI `--n-stops`) evenly spaced stops over one 360 deg operating turn (default → 45 deg spacing), plus a return-to-home move at the end.
- Everything downstream of collection (least-squares fit pinned to motor-home, linearity/headroom report, divergence-vs-stored warning, slope sanity check, `prompt_save`, `PotCalStore` persistence, live push) is unchanged and shared with `azimuth` — audited every `args.mode == "azimuth"` / `in (...)` branch in `main()` and added `auto` wherever azimuth semantics apply (collection dispatch, metadata block, linearity report label).
- Default mode remains `azimuth` in this PR (a separate PR changes the default; `auto` is additive either way).

**CLAUDE.md amendment:** the "Scripts and ownership" section previously implied `calibrate_pot` only reads the motor stream. This PR amends it to state that calibration utilities in the picohost category (`calibrate_pot`, `calibrate_imu`) may command the motor via `PicoProxy` for calibration purposes — the coordination exists to calibrate the Pico stack, not to do science, so the "Pico stack vs. doing science" ownership test still applies even though these scripts now touch two Picos. Also updated the now-stale `read_motor_az_steps` docstring claim that "calibrate-pot never commands the motor."

## Changes

- `picohost/src/picohost/calibrate_pot.py`: `collect_auto()`, `_wait_for_settle()`, shared `_warn_if_not_homed()` helper (also used by `collect_azimuth`), `auto` wired into `build_parser()` (`--mode auto`, `--n-stops`) and `main()`, module docstring updated to "Six modes".
- `picohost/tests/test_calibrate_pot.py`: parser test for `--mode auto`; `collect_auto` unit tests (expected commanded target sequence, recorded angles come from stream reads not commanded targets, off-home warning, claim released on command failure, raises `TimeoutError` on settle timeout); `main()` integration tests for `auto` mode (fit/metadata/live-push wiring, motor-unavailable early exit, `--n-stops` validation).
- `CLAUDE.md`: ownership section amendment described above.

No firmware (`src/*.c`) changes — host-side Python only, so no emulator-parity concerns.

## Test plan

- [x] `cd picohost && python -m pytest tests/test_calibrate_pot.py -q` → **51 passed**
- [x] `python -m pytest -q` (full suite) → **667 passed** in 181.58s (the known `TestCmdLoopEndToEnd` flake did not trip this run; nothing was deselected)
- [x] `ruff check` / `ruff format --check` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQKTsyC9gR9zF2QqL5jUxo


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQKTsyC9gR9zF2QqL5jUxo)_