### PR TITLE
fix(picohost): publish whole-valued firmware floats as floats

### DIFF
--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -23,7 +23,7 @@ PICO_PID_CDC = 0x0009  # CDC mode (serial)
 PICO_PID_BOOTSEL = 0x000F  # RP2350 BOOTSEL mode (RP2040 was 0x0003)
 
 
-def redis_handler(writer):
+def redis_handler(writer, float_fields=()):
     """
     Create a handler function that publishes a status dict via a
     :class:`eigsep_redis.MetadataWriter`.
@@ -35,6 +35,15 @@ def redis_handler(writer):
         field on each data dict is used as the metadata key (so
         ``stream:{sensor_name}`` carries the per-sensor history and
         ``metadata[sensor_name]`` holds the live snapshot).
+    float_fields : tuple of str, optional
+        Published field names that are float-typed in the consumer
+        metadata schema. Values arriving as ``int`` are cast to
+        ``float`` before publication: firmware cJSON prints a
+        whole-valued double with no decimal point ("30" not "30.0"),
+        so ``json.loads`` yields ``int`` for KV_FLOAT fields whenever
+        the reading lands on a whole value (issue #148). ``bool`` and
+        ``None`` values are never touched, and the caller's dict is
+        not mutated (it doubles as ``last_status``).
 
     Returns
     -------
@@ -68,7 +77,12 @@ def redis_handler(writer):
         except KeyError:
             logger.error("Data does not contain 'sensor_name' key")
             return
-        writer.add(name, data)
+        out = dict(data)
+        for key in float_fields:
+            value = out.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                out[key] = float(value)
+        writer.add(name, out)
 
     return handler
 
@@ -77,6 +91,14 @@ class PicoDevice:
     """
     Base class for communicating with Pico devices running custom firmware.
     """
+
+    #: Published field names that are float-typed in the consumer
+    #: metadata schema (see :func:`redis_handler`). Subclasses list
+    #: every field their firmware app emits as ``KV_FLOAT``, under the
+    #: field's PUBLISHED name (after any fan-out renaming), so that a
+    #: whole-valued reading — which cJSON serializes as a JSON int —
+    #: is cast back to float at the publish boundary.
+    _REDIS_FLOAT_FIELDS = ()
 
     def __init__(
         self,
@@ -122,7 +144,9 @@ class PicoDevice:
             self.name = name
 
         if metadata_writer is not None:
-            self.redis_handler = redis_handler(metadata_writer)
+            self.redis_handler = redis_handler(
+                metadata_writer, self._REDIS_FLOAT_FIELDS
+            )
         else:
             self.redis_handler = None
         self.connect()
@@ -456,6 +480,10 @@ class PicoRFSwitch(PicoDevice):
     SW_STATE_UNKNOWN = -1
     SW_STATE_UNKNOWN_NAME = "UNKNOWN"
 
+    # Firmware KV_FLOAT fields (src/rfswitch.c status tick); the
+    # host-derived temp_therm* are float-or-None already.
+    _REDIS_FLOAT_FIELDS = ("volt_therm0", "volt_therm1", "volt_therm2")
+
     # --- PCB thermistor conversion (host-side) --------------------------
     # Three 10k NTC thermistors on the RF switch PCB (ADC0-2). Wiring:
     #   5.0V --[10k pullup]-- ADC pin --[NTC]-- GND
@@ -693,6 +721,24 @@ class PicoPeltier(PicoDevice):
         "integral",
     )
     _PELTIER_STREAMS = (("LNA", "tempctrl_lna"), ("LOAD", "tempctrl_load"))
+
+    # The subset of _PELTIER_CHANNEL_FIELDS the firmware emits as
+    # KV_FLOAT (src/tempctrl.c status tick) — keep the two in sync when
+    # adding channel fields. Coerced under their published (unprefixed)
+    # names, i.e. after the LNA_/LOAD_ fan-out.
+    _REDIS_FLOAT_FIELDS = (
+        "T_now",
+        "voltage",
+        "resistance",
+        "timestamp",
+        "T_target",
+        "drive_level",
+        "hysteresis",
+        "clamp",
+        "Kp",
+        "Ki",
+        "integral",
+    )
 
     def _peltier_redis_handler(self, data):
         """Fan out the combined tempctrl status dict into two Redis streams.
@@ -964,6 +1010,17 @@ class PicoIMU(PicoDevice):
     difference.
     """
 
+    # Firmware KV_FLOAT fields (src/imu.c status tick); the derived
+    # angle fields are host-computed floats or None already.
+    _REDIS_FLOAT_FIELDS = (
+        "yaw",
+        "pitch",
+        "roll",
+        "accel_x",
+        "accel_y",
+        "accel_z",
+    )
+
     def __init__(self, *args, imu_cal_store=None, **kwargs):
         # {"imu_el": {...}, "imu_az": {...}} — only loaded sections present.
         self._imu_cal = {}
@@ -1087,6 +1144,11 @@ class PicoLidar(PicoDevice):
     when uncalibrated (no nominal fallback).
     """
 
+    # Firmware KV_FLOAT fields (src/lidar.c status tick).
+    # ``current_voltage`` is coerced in the system_current fan-out; the
+    # derived current fields are host-computed floats or None already.
+    _REDIS_FLOAT_FIELDS = ("distance_m", "current_voltage")
+
     def __init__(self, *args, current_cal_store=None, **kwargs):
         """
         Parameters
@@ -1203,6 +1265,10 @@ POT_NEAR_RAIL_V = 0.2
 
 class PicoPotentiometer(PicoDevice):
     """Potentiometer monitoring device with voltage-to-angle calibration."""
+
+    # Firmware KV_FLOAT fields (src/potmon.c status tick); the derived
+    # cal/angle fields are explicitly float()-cast in the handler.
+    _REDIS_FLOAT_FIELDS = ("pot_az_voltage",)
 
     def __init__(
         self,

--- a/picohost/src/picohost/emulators/base.py
+++ b/picohost/src/picohost/emulators/base.py
@@ -1,4 +1,5 @@
 import json
+import math
 import threading
 import time
 import logging
@@ -18,6 +19,26 @@ def _safe_int(val, default=0):
         return int(val)
     except (ValueError, TypeError):
         return default
+
+
+def _cjson_number(value):
+    """Reshape one JSON value the way firmware cJSON prints it.
+
+    cJSON's print_number emits a whole-valued double with no decimal
+    point ("30" not "30.0") — via %d when the value fits in a C int and
+    via %1.15g (which also drops the point for whole values) above that
+    — so the host's json.loads yields int for KV_FLOAT fields whenever
+    the reading lands on a whole value (issue #148). %1.15g switches to
+    exponent notation at 1e15, where the text parses back as float.
+    NaN/inf print as JSON null in cJSON; Python's json.dumps would emit
+    the non-JSON tokens 'NaN'/'Infinity' instead, so map those to None.
+    """
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        if value.is_integer() and abs(value) < 1e15:
+            return int(value)
+    return value
 
 
 def _safe_float(val, default=0.0):
@@ -156,7 +177,16 @@ class PicoEmulator:
         if not data or self._peer is None:
             return
         try:
-            line = json.dumps(data, separators=(",", ":")) + "\n"
+            # Serialize numbers the way firmware cJSON does, so tests
+            # driving devices through emulators see the same shapes as
+            # real hardware (whole-valued floats arrive as JSON ints).
+            line = (
+                json.dumps(
+                    {k: _cjson_number(v) for k, v in data.items()},
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
             self._peer.write(line.encode("utf-8"))
         except Exception as e:
             logger.debug(f"Emulator write error: {e}")

--- a/picohost/src/picohost/motor.py
+++ b/picohost/src/picohost/motor.py
@@ -87,10 +87,10 @@ class PicoMotor(PicoDevice):
             usb_serial=usb_serial,
             verbose=verbose,
         )
-        # Wrap the base redis handler to publish position fields as
-        # floats. See _motor_redis_handler. Install this immediately
-        # after super().__init__ because the base class may already
-        # have started the reader thread.
+        # Wrap the base redis handler to checkpoint positions and
+        # detect reboots. See _motor_redis_handler. Install this
+        # immediately after super().__init__ because the base class may
+        # already have started the reader thread.
         if self.redis_handler is not None:
             self._base_redis_handler = self.redis_handler
             self.redis_handler = self._motor_redis_handler
@@ -103,34 +103,25 @@ class PicoMotor(PicoDevice):
         "el_target_pos",
     )
 
+    # The C firmware emits position fields with ``KV_INT`` (raw step
+    # counts), which the JSON parser surfaces as Python ``int``.
+    # Position values legitimately change within a single consumer
+    # integration window during a scan, so the consumer-side
+    # per-integration reduction needs the float→mean policy rather
+    # than the int→min "invariant" policy. Listing them here casts
+    # them at the publish boundary (see PicoDevice._REDIS_FLOAT_FIELDS)
+    # without requiring a firmware reflash.
+    _REDIS_FLOAT_FIELDS = _POSITION_FIELDS
+
     def _motor_redis_handler(self, data):
-        """Cast position fields to float before uploading to Redis.
+        """Checkpoint the raw integer positions, then publish.
 
-        The C firmware emits position fields with ``KV_INT`` (raw step
-        counts), which the JSON parser surfaces as Python ``int``.
-        Position values legitimately change within a single consumer
-        integration window during a scan, so the consumer-side
-        per-integration reduction needs the float→mean policy rather
-        than the int→min "invariant" policy. Coercing here at the
-        publish boundary keeps the consumer schema clean (positions
-        declared as ``float``, mean reduction) without requiring a
-        firmware reflash.
-
-        Mirrors :meth:`PicoPotentiometer._pot_redis_handler` and
-        :meth:`PicoRFSwitch._rfswitch_redis_handler`: both adapt the
-        raw firmware payload to the published Redis shape at the same
-        boundary.
-
-        Also drives the position checkpoint / boot-detection logic
-        (:meth:`_checkpoint_and_seed`) off the raw integer payload,
-        before the float cast.
+        The position checkpoint / boot-detection logic
+        (:meth:`_checkpoint_and_seed`) runs off the raw integer
+        payload; the float cast for the published position fields
+        happens downstream in the base handler (``_REDIS_FLOAT_FIELDS``).
         """
         self._checkpoint_and_seed(data)
-        data = data.copy()
-        for key in self._POSITION_FIELDS:
-            v = data.get(key)
-            if v is not None:
-                data[key] = float(v)
         self._base_redis_handler(data)
 
     def _checkpoint_and_seed(self, data):

--- a/picohost/tests/test_base.py
+++ b/picohost/tests/test_base.py
@@ -477,22 +477,35 @@ class TestRFSwitchThermistorFanout:
 
 
 class TestMotorRedisHandler:
-    """Verify _motor_redis_handler coerces position fields to float.
+    """Verify the motor publish path coerces position fields to float.
 
     The C firmware emits ``az_pos``/``el_pos``/``az_target_pos``/
     ``el_target_pos`` with ``KV_INT``, which the JSON parser surfaces
     as Python ``int``. The downstream consumer schema declares these
     as ``float`` so the per-integration reduction picks the
     float→mean policy (positions legitimately change within an
-    integration during a scan). Coercing here at the publish boundary
-    is what makes the producer satisfy that contract.
+    integration during a scan). The cast happens in the base redis
+    handler via ``PicoMotor._REDIS_FLOAT_FIELDS``; these tests drive
+    the full wrapper chain down to the writer boundary.
     """
 
     _POSITION_KEYS = ("az_pos", "az_target_pos", "el_pos", "el_target_pos")
 
     def _capture(self, motor, data):
+        from picohost.base import redis_handler
+
         captured = {}
-        motor._base_redis_handler = lambda d: captured.update(d)
+
+        class _Writer:
+            def add(self, name, payload):
+                captured.update(payload)
+
+        # Same wiring as PicoDevice.__init__ with a metadata_writer,
+        # minus the emulator: factory handler (float coercion) fed by
+        # the motor wrapper (checkpointing).
+        motor._base_redis_handler = redis_handler(
+            _Writer(), motor._REDIS_FLOAT_FIELDS
+        )
         motor._motor_redis_handler(data)
         return captured
 

--- a/picohost/tests/test_emulator_integration.py
+++ b/picohost/tests/test_emulator_integration.py
@@ -279,11 +279,15 @@ class TestIMUIntegration:
         s = imu.last_status
         # Integers
         assert isinstance(s["app_id"], int)
-        # Floats
+        # KV_FLOAT fields: numeric on the wire, but cJSON prints a
+        # whole-valued double with no decimal point, so json.loads may
+        # yield int (issue #148). Float typing is restored at the Redis
+        # publish boundary (see test_redis_float_coercion.py).
         for key in ("yaw", "pitch", "roll", "accel_x", "accel_y", "accel_z"):
-            assert isinstance(s[key], float), (
-                f"{key} should be float, got {type(s[key])}"
+            assert isinstance(s[key], (int, float)), (
+                f"{key} should be numeric, got {type(s[key])}"
             )
+            assert not isinstance(s[key], bool), key
         # Strings
         assert isinstance(s["sensor_name"], str)
         assert isinstance(s["status"], str)

--- a/picohost/tests/test_redis_float_coercion.py
+++ b/picohost/tests/test_redis_float_coercion.py
@@ -15,7 +15,6 @@ the fix are pinned here:
 """
 
 import json
-import math
 
 from conftest import wait_for_condition
 
@@ -131,7 +130,7 @@ class TestRedisHandlerFloatFields:
         writer = FakeMetadataWriter()
         handler = redis_handler(writer, float_fields=("a", "b"))
         handler({"sensor_name": "s", "a": 30, "b": 2.5, "c": 7})
-        (name, data), = writer.received
+        ((name, data),) = writer.received
         assert name == "s"
         assert data["a"] == 30.0 and isinstance(data["a"], float)
         assert data["b"] == 2.5 and isinstance(data["b"], float)
@@ -142,7 +141,7 @@ class TestRedisHandlerFloatFields:
         writer = FakeMetadataWriter()
         handler = redis_handler(writer, float_fields=("a", "b"))
         handler({"sensor_name": "s", "a": None})
-        (_, data), = writer.received
+        ((_, data),) = writer.received
         assert data["a"] is None
         assert "b" not in data
 
@@ -152,7 +151,7 @@ class TestRedisHandlerFloatFields:
         writer = FakeMetadataWriter()
         handler = redis_handler(writer, float_fields=("a",))
         handler({"sensor_name": "s", "a": True})
-        (_, data), = writer.received
+        ((_, data),) = writer.received
         assert data["a"] is True
 
     def test_caller_dict_not_mutated(self):
@@ -259,7 +258,7 @@ class TestDeviceHandlersCoerce:
             )
         finally:
             dev.disconnect()
-        (name, data), = writer.received
+        ((name, data),) = writer.received
         assert name == "imu_el"
         for key in ("yaw", "pitch", "roll", "accel_x", "accel_y", "accel_z"):
             assert isinstance(data[key], float), key
@@ -326,7 +325,7 @@ class TestDeviceHandlersCoerce:
             )
         finally:
             dev.disconnect()
-        (name, data), = writer.received
+        ((name, data),) = writer.received
         assert name == "potmon"
         assert isinstance(data["pot_az_voltage"], float)
         assert data["pot_az_near_rail"] is False

--- a/picohost/tests/test_redis_float_coercion.py
+++ b/picohost/tests/test_redis_float_coercion.py
@@ -1,0 +1,357 @@
+"""Regression tests for issue #148: whole-valued floats must not reach
+Redis as ints.
+
+Firmware cJSON prints a whole-valued double with no decimal point
+(``30.0`` -> ``30``), so ``json.loads`` on the host yields Python
+``int`` for fields the firmware emitted as ``KV_FLOAT``. Two halves of
+the fix are pinned here:
+
+1. Emulators serialize numbers the way cJSON does, so the dummy-device
+   pipeline exercises the same int-collapsed shapes as real firmware
+   (previously ``json.dumps`` preserved ``30.0`` and masked the bug).
+2. The redis publish path coerces the firmware's float-typed fields
+   back to ``float`` before ``MetadataWriter.add``, so the published
+   types satisfy the consumer metadata schemas regardless of value.
+"""
+
+import json
+import math
+
+from conftest import wait_for_condition
+
+from picohost.base import redis_handler
+from picohost.emulators.base import PicoEmulator
+from picohost.testing import (
+    DummyPicoIMU,
+    DummyPicoLidar,
+    DummyPicoPeltier,
+    DummyPicoPotentiometer,
+    DummyPicoRFSwitch,
+)
+
+
+class FakeMetadataWriter:
+    def __init__(self):
+        self.received = []
+
+    def add(self, name, data):
+        self.received.append((name, dict(data)))
+
+
+# Emulator-less dummies: the handler-chain tests below drive
+# dev.redis_handler() directly with firmware-shaped payloads, so a live
+# emulator would only interleave unrelated entries into the writer.
+class _QuietPeltier(DummyPicoPeltier):
+    def _make_emulator(self):
+        return None
+
+
+class _QuietIMU(DummyPicoIMU):
+    def _make_emulator(self):
+        return None
+
+
+class _QuietLidar(DummyPicoLidar):
+    def _make_emulator(self):
+        return None
+
+
+class _QuietRFSwitch(DummyPicoRFSwitch):
+    def _make_emulator(self):
+        return None
+
+
+class _QuietPotentiometer(DummyPicoPotentiometer):
+    def _make_emulator(self):
+        return None
+
+
+# --- 1. Emulator serialization matches cJSON print_number ---
+
+
+class _FakePeer:
+    def __init__(self):
+        self.chunks = []
+
+    def write(self, data):
+        self.chunks.append(data)
+
+
+def _emit(payload):
+    emu = PicoEmulator()
+    peer = _FakePeer()
+    emu.attach(peer)
+    emu._write_json(payload)
+    return json.loads(b"".join(peer.chunks).decode())
+
+
+class TestEmulatorCJSONNumbers:
+    def test_whole_float_collapses_to_int(self):
+        parsed = _emit({"a": 30.0})
+        assert parsed["a"] == 30
+        assert isinstance(parsed["a"], int)
+
+    def test_fractional_float_survives(self):
+        parsed = _emit({"a": 30.5})
+        assert parsed["a"] == 30.5
+        assert isinstance(parsed["a"], float)
+
+    def test_nan_and_inf_become_null(self):
+        parsed = _emit({"a": float("nan"), "b": float("inf")})
+        assert parsed["a"] is None
+        assert parsed["b"] is None
+
+    def test_bool_int_str_none_untouched(self):
+        parsed = _emit({"a": True, "b": 7, "c": "x", "d": None})
+        assert parsed["a"] is True
+        assert parsed["b"] == 7 and isinstance(parsed["b"], int)
+        assert parsed["c"] == "x"
+        assert parsed["d"] is None
+
+    def test_whole_float_beyond_int32_still_collapses(self):
+        # cJSON prints these via %1.15g, which also drops the decimal
+        # point for whole values ("4000000000"), so json.loads -> int.
+        parsed = _emit({"a": 4000000000.0})
+        assert parsed["a"] == 4000000000
+        assert isinstance(parsed["a"], int)
+
+    def test_exponent_notation_range_stays_float(self):
+        # At 1e15 %1.15g switches to exponent notation ("1e+15"),
+        # which parses back as float — mirror that boundary.
+        parsed = _emit({"a": 1e15})
+        assert parsed["a"] == 1e15
+        assert isinstance(parsed["a"], float)
+
+
+# --- 2. redis_handler factory coercion ---
+
+
+class TestRedisHandlerFloatFields:
+    def test_listed_int_fields_publish_as_float(self):
+        writer = FakeMetadataWriter()
+        handler = redis_handler(writer, float_fields=("a", "b"))
+        handler({"sensor_name": "s", "a": 30, "b": 2.5, "c": 7})
+        (name, data), = writer.received
+        assert name == "s"
+        assert data["a"] == 30.0 and isinstance(data["a"], float)
+        assert data["b"] == 2.5 and isinstance(data["b"], float)
+        # Unlisted fields keep their parsed type.
+        assert data["c"] == 7 and isinstance(data["c"], int)
+
+    def test_none_and_missing_fields_untouched(self):
+        writer = FakeMetadataWriter()
+        handler = redis_handler(writer, float_fields=("a", "b"))
+        handler({"sensor_name": "s", "a": None})
+        (_, data), = writer.received
+        assert data["a"] is None
+        assert "b" not in data
+
+    def test_bool_never_coerced(self):
+        # bool is a subclass of int; a listed field that arrives as a
+        # bool (KV_BOOL mixup upstream) must not silently become 0.0/1.0.
+        writer = FakeMetadataWriter()
+        handler = redis_handler(writer, float_fields=("a",))
+        handler({"sensor_name": "s", "a": True})
+        (_, data), = writer.received
+        assert data["a"] is True
+
+    def test_caller_dict_not_mutated(self):
+        # The same dict is stored as device.last_status; coercion must
+        # not alias into it.
+        writer = FakeMetadataWriter()
+        handler = redis_handler(writer, float_fields=("a",))
+        payload = {"sensor_name": "s", "a": 30}
+        handler(payload)
+        assert payload["a"] == 30 and isinstance(payload["a"], int)
+
+
+# --- 3. Device handler chains publish float-typed firmware fields ---
+
+
+def _tempctrl_payload():
+    """Firmware-shaped tempctrl status (src/tempctrl.c) with every
+    routinely whole-valued KV_FLOAT collapsed to int, as cJSON emits."""
+    payload = {
+        "sensor_name": "tempctrl",
+        "app_id": 1,
+        "watchdog_tripped": False,
+        "watchdog_timeout_ms": 30000,
+    }
+    for ch in ("LNA", "LOAD"):
+        payload.update(
+            {
+                f"{ch}_status": "update",
+                f"{ch}_T_now": 29.87,
+                f"{ch}_voltage": 1.234,
+                f"{ch}_resistance": 10234.5,
+                f"{ch}_timestamp": 1234,  # uint32 cast: whole on every tick
+                f"{ch}_T_target": 30,
+                f"{ch}_drive_level": 0,
+                f"{ch}_installed": True,
+                f"{ch}_enabled": True,
+                f"{ch}_active": False,
+                f"{ch}_sensor_tripped": False,
+                f"{ch}_stall_tripped": False,
+                f"{ch}_runaway_tripped": False,
+                f"{ch}_cooling_enabled": False,
+                f"{ch}_hysteresis": 1,
+                f"{ch}_clamp": 1,
+                f"{ch}_Kp": 2,
+                f"{ch}_Ki": 0,
+                f"{ch}_integral": 0,
+            }
+        )
+    return payload
+
+
+TEMPCTRL_FLOAT_FIELDS = (
+    "T_now",
+    "voltage",
+    "resistance",
+    "timestamp",
+    "T_target",
+    "drive_level",
+    "hysteresis",
+    "clamp",
+    "Kp",
+    "Ki",
+    "integral",
+)
+
+
+class TestDeviceHandlersCoerce:
+    def test_peltier_streams_publish_floats(self):
+        writer = FakeMetadataWriter()
+        dev = _QuietPeltier(
+            "/dev/dummy", metadata_writer=writer, keepalive_interval=0
+        )
+        try:
+            dev.redis_handler(_tempctrl_payload())
+        finally:
+            dev.disconnect()
+        published = dict(writer.received)
+        assert set(published) == {"tempctrl_lna", "tempctrl_load"}
+        for stream, data in published.items():
+            for key in TEMPCTRL_FLOAT_FIELDS:
+                assert isinstance(data[key], float), f"{stream}:{key}"
+            # Non-float fields keep their firmware types.
+            assert data["watchdog_tripped"] is False
+            assert isinstance(data["watchdog_timeout_ms"], int)
+            assert data["enabled"] is True
+            assert data["status"] == "update"
+
+    def test_imu_publishes_floats(self):
+        writer = FakeMetadataWriter()
+        dev = _QuietIMU("/dev/dummy", metadata_writer=writer)
+        try:
+            dev.redis_handler(
+                {
+                    "sensor_name": "imu_el",
+                    "status": "update",
+                    "app_id": 3,
+                    "yaw": 0,
+                    "pitch": 0,
+                    "roll": 0,
+                    "accel_x": 0,
+                    "accel_y": 0,
+                    "accel_z": 1,
+                }
+            )
+        finally:
+            dev.disconnect()
+        (name, data), = writer.received
+        assert name == "imu_el"
+        for key in ("yaw", "pitch", "roll", "accel_x", "accel_y", "accel_z"):
+            assert isinstance(data[key], float), key
+        assert isinstance(data["app_id"], int)
+
+    def test_lidar_and_system_current_publish_floats(self):
+        writer = FakeMetadataWriter()
+        dev = _QuietLidar("/dev/dummy", metadata_writer=writer)
+        try:
+            dev.redis_handler(
+                {
+                    "sensor_name": "lidar",
+                    "status": "update",
+                    "app_id": 4,
+                    "distance_m": 5,
+                    "current_voltage": 1,
+                }
+            )
+        finally:
+            dev.disconnect()
+        published = dict(writer.received)
+        assert set(published) == {"lidar", "system_current"}
+        assert isinstance(published["lidar"]["distance_m"], float)
+        assert isinstance(
+            published["system_current"]["current_voltage"], float
+        )
+
+    def test_rfswitch_therm_stream_publishes_floats(self):
+        writer = FakeMetadataWriter()
+        dev = _QuietRFSwitch("/dev/dummy", metadata_writer=writer)
+        try:
+            dev.redis_handler(
+                {
+                    "sensor_name": "rfswitch",
+                    "status": "update",
+                    "app_id": 5,
+                    "sw_state": 0,
+                    "volt_therm0": 1,
+                    "volt_therm1": 2,
+                    "volt_therm2": 3,
+                }
+            )
+        finally:
+            dev.disconnect()
+        published = dict(writer.received)
+        assert set(published) == {"rfswitch", "rfswitch_therm"}
+        therm = published["rfswitch_therm"]
+        for i in range(3):
+            assert isinstance(therm[f"volt_therm{i}"], float), i
+        # Switch state is categorical and must stay an int.
+        assert isinstance(published["rfswitch"]["sw_state"], int)
+
+    def test_potmon_publishes_float_voltage(self):
+        writer = FakeMetadataWriter()
+        dev = _QuietPotentiometer("/dev/dummy", metadata_writer=writer)
+        try:
+            dev.redis_handler(
+                {
+                    "sensor_name": "potmon",
+                    "app_id": 2,
+                    "status": "update",
+                    "pot_az_voltage": 2,
+                }
+            )
+        finally:
+            dev.disconnect()
+        (name, data), = writer.received
+        assert name == "potmon"
+        assert isinstance(data["pot_az_voltage"], float)
+        assert data["pot_az_near_rail"] is False
+
+
+# --- 4. End-to-end: emulator collapse -> parse -> coerce -> publish ---
+
+
+def test_dummy_peltier_round_trip_publishes_floats():
+    """Full-pipeline #148 regression. The tempctrl emulator's defaults
+    (T_target=30.0, Ki=0.0, integral=0.0) are exactly the whole values
+    that cJSON collapses; after the round trip they must still publish
+    as floats."""
+    writer = FakeMetadataWriter()
+    dev = DummyPicoPeltier(
+        "/dev/dummy", metadata_writer=writer, keepalive_interval=0
+    )
+    try:
+        wait_for_condition(
+            lambda: any(n == "tempctrl_lna" for n, _ in writer.received),
+            cadence_ms=dev.EMULATOR_CADENCE_MS,
+        )
+    finally:
+        dev.disconnect()
+    data = next(d for n, d in writer.received if n == "tempctrl_lna")
+    assert data["T_target"] == 30.0
+    for key in ("T_target", "Ki", "integral", "drive_level"):
+        assert isinstance(data[key], float), key

--- a/picohost/uv.lock
+++ b/picohost/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "picohost"
-version = "3.11.0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "eigsep-redis" },


### PR DESCRIPTION
## Summary

Fixes #148 — whole-valued floats were reaching Redis as JSON ints, violating the consumer metadata schemas for `tempctrl_*`, `lidar`, `imu_*`, `potmon`, and `rfswitch_therm` (~51k WARNING lines in 3.5 h of logs).

**Root cause (confirmed in code):** firmware emits these fields as `KV_FLOAT`, but cJSON's `print_number` (`lib/cJSON/cJSON.c:616-619`) prints a whole-valued double with no decimal point (`30.0` → `30`), so `json.loads` in picohost yields Python `int`, which the redis handlers published verbatim.

## Changes

- **`redis_handler(writer, float_fields=())`**: the factory now casts listed fields from `int` back to `float` at the single publish choke point (`writer.add`). `bool`/`None` are never touched; the caller's dict (also `last_status`) is not mutated.
- **`PicoDevice._REDIS_FLOAT_FIELDS`**: each device class declares its firmware `KV_FLOAT` fields under their published names (after fan-out renaming) — tempctrl's 11 per-channel fields, IMU's 6 orientation/accel fields, lidar's `distance_m`/`current_voltage`, rfswitch's 3 thermistor volts, potmon's `pot_az_voltage`.
- **`PicoMotor`** migrates its existing hand-rolled position float cast (same idea, predating this fix) onto the shared mechanism; `_motor_redis_handler` keeps checkpoint/boot-detection on the raw integer payload.
- **Emulator parity**: `PicoEmulator._write_json` now serializes numbers the way cJSON does (whole floats collapse to ints, NaN/inf to null). The old `json.dumps` behavior preserved `30.0` and is why tests never caught this divergence.

## Tests

- New `test_redis_float_coercion.py` (16 tests): emulator serialization matches cJSON `print_number` (including the `%1.15g` / exponent-notation boundaries), factory coercion semantics, per-device handler chains driven with firmware-shaped payloads, and a full dummy-peltier round trip.
- `test_emulator_integration.py::TestIMUIntegration::test_status_types` updated: parsed wire values are numeric (int-or-float), matching real firmware; float typing is asserted at the publish boundary instead.
- `TestMotorRedisHandler._capture` now captures at the writer boundary through the real factory handler.

Full suite: 720 passed.

## Notes for reviewers

- Consumer-side (`eigsep_observing`) is untouched per the issue: the producer fix is the real one; a warning throttle there is a possible follow-up.
- The coercion is type-only (`30` → `30.0`); values are unchanged, and non-listed fields keep their parsed types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)