### PR TITLE
feat(potmon): SP1 failsafe termination switch on GPIO 27

### DIFF
--- a/picohost/src/picohost/base.py
+++ b/picohost/src/picohost/base.py
@@ -1271,6 +1271,11 @@ class PicoPotentiometer(PicoDevice):
     # cal/angle fields are explicitly float()-cast in the handler.
     _REDIS_FLOAT_FIELDS = ("pot_az_voltage",)
 
+    # Pin levels driven on the potmon pico's SP1 failsafe-termination
+    # GPIO (POTMON_GPIO_SP1_TERM in src/potmon.h). LOW/0 = SHORT is the
+    # failsafe: a rebooted or dead pico leaves the long cable shorted.
+    SP1_TERMINATIONS = {"SHORT": 0, "OPEN": 1}
+
     def __init__(
         self,
         port,
@@ -1328,17 +1333,18 @@ class PicoPotentiometer(PicoDevice):
             self.redis_handler = self._pot_redis_handler
 
     def _pot_redis_handler(self, data):
-        """Add per-component cal scalars, angle, and rail flag before upload.
+        """Add per-component cal scalars, angle, rail flag, and SP1 name.
 
         Augments the raw voltage payload with the calibration slope and
         intercept (flattened into scalar fields per the
         :func:`redis_handler` scalar-only contract), the derived angle,
-        and a ``<key>_near_rail`` bool (voltage within
-        :data:`POT_NEAR_RAIL_V` of an ADC rail — wiper at risk of
-        clipping, absolute reference no longer trustworthy). All added
-        fields are ``None`` when their input is missing (no calibration,
-        or no voltage for the rail flag), so the published shape is
-        stable regardless of state.
+        a ``<key>_near_rail`` bool (voltage within :data:`POT_NEAR_RAIL_V`
+        of an ADC rail — wiper at risk of clipping, absolute reference no
+        longer trustworthy), and ``sp1_term_name`` (the string name of the
+        SP1 failsafe termination state, ``"SHORT"``/``"OPEN"`` or ``None``
+        when missing/unmapped). All added fields are ``None`` when their
+        input is missing, so the published shape is stable regardless of
+        state.
         """
         data = data.copy()
         for key in ("pot_az",):
@@ -1362,6 +1368,11 @@ class PicoPotentiometer(PicoDevice):
                 data[f"{key}_cal_slope"] = None
                 data[f"{key}_cal_intercept"] = None
                 data[f"{key}_angle"] = None
+        # SP1 failsafe termination: map the raw pin level to its name
+        # ("SHORT"/"OPEN"); None when the firmware didn't report it or
+        # the level is unmapped. Raw sp1_term is kept alongside.
+        name_by_level = {v: k for k, v in self.SP1_TERMINATIONS.items()}
+        data["sp1_term_name"] = name_by_level.get(data.get("sp1_term"))
         self._base_redis_handler(data)
 
     def set_calibration(self, pot_az_params=None):
@@ -1374,6 +1385,37 @@ class PicoPotentiometer(PicoDevice):
         """
         if pot_az_params is not None:
             self._cal["pot_az"] = tuple(pot_az_params)
+
+    def set_sp1_termination(self, state):
+        """Drive the SP1 failsafe termination switch.
+
+        The call returns as soon as the command has been delivered to
+        the firmware; the firmware echoes the actual pin level as
+        ``sp1_term`` in its status stream, so callers that need
+        closed-loop confirmation poll Redis for ``sp1_term_name``.
+
+        Parameters
+        ----------
+        state : str
+            ``"SHORT"`` (pin LOW — the failsafe) or ``"OPEN"``
+            (pin HI). See :attr:`SP1_TERMINATIONS`.
+
+        Raises
+        ------
+        ValueError
+            If ``state`` is not a valid termination name.
+        ConnectionError
+            If the device is not connected or the write failed.
+        """
+        try:
+            level = self.SP1_TERMINATIONS[state]
+        except (KeyError, TypeError) as e:
+            raise ValueError(
+                f"Invalid SP1 termination '{state}'. Valid: "
+                f"{list(self.SP1_TERMINATIONS)}"
+            ) from e
+        self.send_command({"sp1_term": level})
+        self.logger.info(f"SP1 termination set to {state}.")
 
     def load_calibration(self, path):
         """Load calibration from a JSON file.

--- a/picohost/src/picohost/emulators/potmon.py
+++ b/picohost/src/picohost/emulators/potmon.py
@@ -9,16 +9,35 @@ VREF = 3.3
 class PotMonEmulator(PicoEmulator):
     """Emulates src/potmon.c firmware."""
 
+    # Mirrors POTMON_SP1_TERM_SHORT / POTMON_SP1_TERM_OPEN in
+    # src/potmon.h: the level driven on the SP1 failsafe termination
+    # GPIO. LOW/0 = SHORT is the failsafe (unpowered/reboot state).
+    SP1_TERM_SHORT = 0
+    SP1_TERM_OPEN = 1
+
     def __init__(self, app_id=2, **kwargs):
         self._base_voltage_az = 1.5
         self.voltage_az = self._base_voltage_az
+        self.sp1_term = self.SP1_TERM_SHORT
         super().__init__(app_id=app_id, **kwargs)
 
     def init(self):
         self.voltage_az = self._base_voltage_az
+        # Mirrors potmon_init: gpio_put(POTMON_GPIO_SP1_TERM, SHORT).
+        self.sp1_term = self.SP1_TERM_SHORT
 
     def server(self, cmd):
-        pass  # potmon does not handle commands
+        # Mirrors potmon_server: accept {"sp1_term": 0|1} only.
+        # cJSON_IsNumber matches only real JSON numbers; bools parse as
+        # cJSON_True/cJSON_False and must be rejected here too (same
+        # guard as RFSwitchEmulator.server).
+        if "sp1_term" not in cmd:
+            return
+        raw = cmd["sp1_term"]
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return
+        if raw == 0 or raw == 1:
+            self.sp1_term = int(raw)
 
     def op(self):
         self.voltage_az = float(
@@ -35,4 +54,5 @@ class PotMonEmulator(PicoEmulator):
             "app_id": self.app_id,
             "status": "update",
             "pot_az_voltage": self.voltage_az,
+            "sp1_term": self.sp1_term,
         }

--- a/picohost/tests/test_emulators.py
+++ b/picohost/tests/test_emulators.py
@@ -1620,6 +1620,43 @@ ALL_EMULATORS = [
 ]
 
 
+class TestPotMonEmulatorSp1Term:
+    """SP1 failsafe termination control — mirrors src/potmon.c.
+
+    GPIO 27 LOW/0 = SHORT cap (failsafe: the unpowered/reboot state),
+    HI/1 = OPEN. potmon_server accepts {"sp1_term": 0|1} and ignores
+    anything else, mirroring rfswitch_server's cJSON validation.
+    """
+
+    def test_boots_short(self):
+        emu = PotMonEmulator()
+        assert emu.sp1_term == PotMonEmulator.SP1_TERM_SHORT
+        assert emu.get_status()["sp1_term"] == 0
+
+    def test_command_sets_open_and_back(self):
+        emu = PotMonEmulator()
+        emu.server({"sp1_term": 1})
+        assert emu.get_status()["sp1_term"] == 1
+        emu.server({"sp1_term": 0})
+        assert emu.get_status()["sp1_term"] == 0
+
+    def test_invalid_commands_ignored(self):
+        emu = PotMonEmulator()
+        emu.server({"sp1_term": 1})
+        # cJSON_IsNumber rejects bools/strings; exact 0/1 only.
+        for bad in (2, -1, 0.5, "OPEN", True, None):
+            emu.server({"sp1_term": bad})
+            assert emu.get_status()["sp1_term"] == 1
+        emu.server({"unrelated": 0})
+        assert emu.get_status()["sp1_term"] == 1
+
+    def test_init_resets_to_short(self):
+        emu = PotMonEmulator()
+        emu.server({"sp1_term": 1})
+        emu.init()
+        assert emu.sp1_term == PotMonEmulator.SP1_TERM_SHORT
+
+
 class TestSensorName:
     """Ensure every emulator status contains 'sensor_name' for redis_handler."""
 

--- a/picohost/tests/test_potentiometer.py
+++ b/picohost/tests/test_potentiometer.py
@@ -316,3 +316,47 @@ class TestPicoPotentiometerCalSource:
             assert pot._cal["pot_az"] == (3.0, 4.0)
         finally:
             pot.disconnect()
+
+
+class TestSp1Termination:
+    """SP1 failsafe termination: command method + handler name field."""
+
+    def test_set_sp1_termination_drives_emulator(self):
+        pot = _make_pot()
+        pot.set_sp1_termination("OPEN")
+        wait_for_condition(lambda: pot.last_status.get("sp1_term") == 1)
+        pot.set_sp1_termination("SHORT")
+        wait_for_condition(lambda: pot.last_status.get("sp1_term") == 0)
+        pot.disconnect()
+
+    def test_set_sp1_termination_invalid_raises(self):
+        pot = _make_pot()
+        with pytest.raises(ValueError, match="Invalid SP1 termination"):
+            pot.set_sp1_termination("open")  # case-sensitive
+        with pytest.raises(ValueError, match="Invalid SP1 termination"):
+            pot.set_sp1_termination(1)
+        pot.disconnect()
+
+    def test_handler_adds_sp1_term_name(self):
+        from picohost.base import PicoPotentiometer
+
+        pot = PicoPotentiometer.__new__(PicoPotentiometer)
+        pot._cal = {"pot_az": None}
+        captured = {}
+        pot._base_redis_handler = lambda d: captured.update(d)
+        pot._pot_redis_handler(
+            {"sensor_name": "potmon", "status": "update", "sp1_term": 1}
+        )
+        # Additive: raw int kept, name added.
+        assert captured["sp1_term"] == 1
+        assert captured["sp1_term_name"] == "OPEN"
+
+    def test_handler_sp1_term_name_none_when_missing(self):
+        from picohost.base import PicoPotentiometer
+
+        pot = PicoPotentiometer.__new__(PicoPotentiometer)
+        pot._cal = {"pot_az": None}
+        captured = {}
+        pot._base_redis_handler = lambda d: captured.update(d)
+        pot._pot_redis_handler({"sensor_name": "potmon", "status": "update"})
+        assert captured["sp1_term_name"] is None

--- a/src/potmon.c
+++ b/src/potmon.c
@@ -29,11 +29,28 @@ void potmon_init(uint8_t app_id)
 {
     adc_init();
     pot_sensor_init(&pot_az, POTMON_GPIO_AZ, POTMON_ADC_CH_AZ);
+    /* SP1 failsafe termination: boot in SHORT (the failsafe level). */
+    gpio_init(POTMON_GPIO_SP1_TERM);
+    gpio_set_dir(POTMON_GPIO_SP1_TERM, GPIO_OUT);
+    gpio_put(POTMON_GPIO_SP1_TERM, POTMON_SP1_TERM_SHORT);
 }
 
 void potmon_server(uint8_t app_id, const char *json_str)
 {
-    //potmon does not handle json commands
+    cJSON *root = cJSON_Parse(json_str);
+    if (!root || !cJSON_IsObject(root)) {
+        cJSON_Delete(root);
+        return;
+    }
+    cJSON *term_json = cJSON_GetObjectItem(root, "sp1_term");
+    if (term_json && cJSON_IsNumber(term_json)) {
+        double v = cJSON_GetNumberValue(term_json);
+        /* Exact 0 or 1 only; anything else is ignored. */
+        if (v == 0.0 || v == 1.0) {
+            gpio_put(POTMON_GPIO_SP1_TERM, v == 1.0);
+        }
+    }
+    cJSON_Delete(root);
 }
 void potmon_op(uint8_t app_id)
 {
@@ -42,11 +59,12 @@ void potmon_op(uint8_t app_id)
 
 void potmon_status(uint8_t app_id)
 {
-    send_json(4,
+    send_json(5,
         KV_STR,   "sensor_name",    "potmon",
         KV_INT,   "app_id",         (int)app_id,
         KV_STR,   "status",         "update",
-        KV_FLOAT, "pot_az_voltage", pot_az.voltage
+        KV_FLOAT, "pot_az_voltage", pot_az.voltage,
+        KV_INT,   "sp1_term",       (int)gpio_get(POTMON_GPIO_SP1_TERM)
     );
 }
 

--- a/src/potmon.h
+++ b/src/potmon.h
@@ -10,6 +10,14 @@
 
 #define POTMON_GPIO_AZ          26
 
+/* SP1 failsafe termination control. The pin was freed when the el pot
+ * was removed. LOW = SHORT cap (failsafe: matches the unpowered state
+ * of the termination switch, so a rebooted or dead pico leaves the
+ * long cable shorted), HI = OPEN. */
+#define POTMON_GPIO_SP1_TERM    27
+#define POTMON_SP1_TERM_SHORT   0
+#define POTMON_SP1_TERM_OPEN    1
+
 #define POTMON_ADC_BITS         12
 #define POTMON_ADC_MAX          ((1 << POTMON_ADC_BITS) - 1)
 #define POTMON_VREF             3.3f


### PR DESCRIPTION
## Summary
- potmon firmware: GPIO 27 (freed el-pot pin) becomes a digital output driving the SP1 long-cable failsafe termination switch. LOW = SHORT cap (failsafe / boot state), HI = OPEN. First command this app handles: `{"sp1_term": 0|1}` (cJSON validation mirrors `rfswitch_server`); status gains `sp1_term` (pin readback via `gpio_get`, never a cached shadow).
- `PotMonEmulator` mirrors the firmware exactly (boot SHORT, command validation incl. bool rejection, status field).
- picohost: `PicoPotentiometer.set_sp1_termination("SHORT"|"OPEN")` (raise-on-delivery-failure contract, `SP1_TERMINATIONS` class constant) + additive `sp1_term_name` in the redis handler (raw `sp1_term` int kept).

Consumer side (observing modes `RFSP1_SHORT`/`RFSP1_OPEN`, VNA sp1 short/open sweeps, live-status pane) lands in an eigsep_observing PR (draft until this releases as the next picohost minor).

## Test plan
- `picohost/tests/test_emulators.py -k Sp1Term` (4 tests: boot state, round-trip, invalid-command rejection incl. bools, init reset)
- `picohost/tests/test_potentiometer.py -k Sp1` (emulator round-trip via DummyPicoPotentiometer, ValueError cases, additive handler fields)
- Neighboring suites green: 192 passed (test_potentiometer, test_emulators, test_manager, test_proxy)
- Firmware `./build.sh` clean (pico_multi.uf2 produced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)